### PR TITLE
Support Reports Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ The `panther_analysis_tool` is available on [pip](https://pip.pypa.io/en/stable/
 $ pip3 install panther_analysis_tool
 ```
 
-If you'd prefer instead to locally for development reasons, first setup your environment:
+If you'd prefer instead to run from source for development reasons, first setup your environment:
 
 ```bash
 $ make install

--- a/README.md
+++ b/README.md
@@ -26,7 +26,13 @@ See the [Panther documentation](https://docs.runpanther.io/quick-start) for more
 
 ### Installation
 
-Setup your environment:
+The `panther_analysis_tool` is available on [pip](https://pip.pypa.io/en/stable/)! To get started using the tool, simply install with:
+
+```bash
+$ pip3 install panther_analysis_tool
+```
+
+If you'd prefer instead to locally for development reasons, first setup your environment:
 
 ```bash
 $ make install
@@ -35,7 +41,7 @@ $ source venv/bin/activate
 $ pipenv run -- make deps
 ```
 
-Use the [pip](https://pip.pypa.io/en/stable/) package manager (locally for now) to install `panther_analysis_tool`.
+Use the pip package manager to install the local `panther_analysis_tool`.
 
 ```bash
 $ pipenv run -- pip3 install -e .

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -80,7 +80,9 @@ SPEC_SCHEMA = Schema(
             str,
         Optional('Suppressions'): [str],
         Optional('Tags'): [str],
-        Optional('Reports'): {str: object},
+        Optional('Reports'): {
+            str: object
+        },
         Optional('Tests'): [{
             'Name': str,
             'ResourceType': str,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -80,7 +80,7 @@ SPEC_SCHEMA = Schema(
             str,
         Optional('Suppressions'): [str],
         Optional('Tags'): [str],
-        Optional('Reports'): [object],
+        Optional('Reports'): {str: object},
         Optional('Tests'): [{
             'Name': str,
             'ResourceType': str,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -80,12 +80,13 @@ SPEC_SCHEMA = Schema(
             str,
         Optional('Suppressions'): [str],
         Optional('Tags'): [str],
+        Optional('Reports'): [object],
         Optional('Tests'): [{
             'Name': str,
             'ResourceType': str,
             'ExpectedResult': bool,
             'Resource': object
-        }]
+        }],
     },
     ignore_extra_keys=False)
 
@@ -223,10 +224,6 @@ def upload_policies(args: argparse.Namespace) -> Tuple[int, str]:
         logging.info('Upload success.')
         logging.info('API Response:\n%s',
                      json.dumps(body, indent=2, sort_keys=True))
-        #logging.info(
-        #    '\n\t%d new policies\n\t%d modified policies\n\t%d new rules\n\t%d modified rules',
-        #    body['newPolicies'], body['modifiedPolicies'], body['newRules'],
-        #    body['modifiedRules'])
 
     return 0, ''
 


### PR DESCRIPTION
### Background

We're going to be adding support soon for a reports field, which will help report generation. Since we want to move some information currently encoded in tags to the reports field, this change just allows the field to be present and not throw an error during testing. The Panther backend throws away the Reports field when processing the configuration.

### Changes

* Allow a reports field to exists, which will be a map of strings (report names, which will also later be treated as tags) to objects (typically either a list of strings or a dictionary)

### Testing

* Added some different configurations of report fields to some policies I'm working on locally and tested and uploaded them, no issues