### PR TITLE
Add DedupPeriodMinutes as a supported field

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -72,7 +72,7 @@ SPEC_SCHEMA = Schema(
             object,
         Optional('Description'):
             str,
-        Optional('DedupPeriod'):
+        Optional('DedupPeriodMinutes'):
             int,
         Optional('DisplayName'):
             str,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -332,7 +332,7 @@ def setup_parser() -> argparse.ArgumentParser:
         prog='panther_analysis_tool')
     parser.add_argument('--version',
                         action='version',
-                        version='panther_analysis_tool 0.1.7')
+                        version='panther_analysis_tool 0.1.8')
     subparsers = parser.add_subparsers()
 
     test_parser = subparsers.add_parser(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -72,6 +72,8 @@ SPEC_SCHEMA = Schema(
             object,
         Optional('Description'):
             str,
+        Optional('DedupPeriod'):
+            int,
         Optional('DisplayName'):
             str,
         Optional('Reference'):

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.1.7',
+    version='0.1.8',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.1.7.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.1.8.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[


### PR DESCRIPTION
### Background

Allow users to specify a `DedupPeriodMinutes` field. Currently only supported for rules. If configured for a policy, it will be ignored. 

### Changes

* Adjusted expected schema

### Testing

* `make ci`
