### PR TITLE
Support Rule Fields

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.1.8',
+    version='0.1.9',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.1.8.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.1.9.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[

--- a/tests/fixtures/valid_policies/example_rule.yml
+++ b/tests/fixtures/valid_policies/example_rule.yml
@@ -3,9 +3,9 @@ Filename: example_rule.py
 DisplayName: MFA Rule
 Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
 Severity: High
-PolicyID: AWS.CloudTrail.MFAEnabled
+RuleID: AWS.CloudTrail.MFAEnabled
 Enabled: true
-ResourceTypes:
+LogTypes:
   - AWS.CloudTrail
 Tags:
   - AWS Managed Rules - Security, Identity & Compliance
@@ -18,9 +18,9 @@ Reference: https://www.link-to-info.io
 Tests:
   -
     Name: Root MFA not enabled fails compliance
-    ResourceType: AWS.CloudTrail
+    LogType: AWS.CloudTrail
     ExpectedResult: false
-    Resource:
+    Log:
       Arn: arn:aws:iam::123456789012:user/root
       CreateDate: 2019-01-01T00:00:00Z
       CredentialReport:
@@ -29,9 +29,9 @@ Tests:
       UserName: root
   -
     Name: User MFA not enabled fails compliance
-    ResourceType: AWS.CloudTrail
+    LogType: AWS.CloudTrail
     ExpectedResult: false
-    Resource:
+    Log:
       {
         "Arn": "arn:aws:iam::123456789012:user/test",
         "CreateDate": "2019-01-01T00:00:00",


### PR DESCRIPTION
### Background

Add support for `RuleID`, `LogType` fields in rule specifications, and `Log` and `LogType` fields in test specifications.

Closes #3.

### Changes

* Added some optional fields
* Used secondary fields when primary fields where not present

### Testing

* Unit testing
* Used the `upload` command to upload some rules with the new fields to my test account
