### PR TITLE
Add support for generic filtering

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -23,9 +23,9 @@ from collections import defaultdict
 import json
 import logging
 import os
-import shutil
 import sys
 from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Tuple
+import zipfile
 from schema import (Optional, Or, Schema, SchemaError, SchemaMissingKeyError,
                     SchemaForbiddenKeyError, SchemaUnexpectedTypeError)
 import yaml
@@ -223,9 +223,17 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     current_time = datetime.now().isoformat(timespec='seconds').replace(
         ':', '-')
     filename = 'panther-analysis'
-    return 0, shutil.make_archive(
-        os.path.join(args.out, '{}-{}'.format(filename, current_time)), 'zip',
-        args.path)
+    zip_out = zipfile.ZipFile('{}-{}.zip'.format(filename, current_time), 'w',
+                              zipfile.ZIP_DEFLATED)
+
+    analysis = filter_analysis(list(load_analysis_specs(args.path)),
+                               args.filter)
+    for analysis_spec_filename, dir_name, analysis_spec in analysis:
+        zip_out.write(analysis_spec_filename)
+        zip_out.write(os.path.join(dir_name, analysis_spec['Filename']))
+
+    zip_out.close()
+    return 0, str(zip_out.filename)
 
 
 def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
@@ -302,6 +310,10 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     specs = list(load_analysis_specs(args.path))
     global_analysis, analysis, invalid_specs = classify_analysis(specs)
 
+    # Apply the filters as needed
+    global_analysis = filter_analysis(global_analysis, args.filter)
+    analysis = filter_analysis(analysis, args.filter)
+
     # First import the globals
     for analysis_spec_filename, dir_name, analysis_spec in global_analysis:
         module, load_err = load_module(
@@ -347,6 +359,20 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
         print("Invalid: {}\n\t{}\n".format(spec_filename, spec_error))
 
     return int(bool(failed_tests or invalid_specs)), invalid_specs
+
+
+def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
+    if filters is None:
+        return analysis
+
+    filtered_analysis = []
+    for file_name, dir_name, analysis_spec in analysis:
+        if all(
+                analysis_spec.get(key, "") in values
+                for key, values in filters.items()):
+            filtered_analysis.append((file_name, dir_name, analysis_spec))
+
+    return filtered_analysis
 
 
 def classify_analysis(
@@ -415,7 +441,7 @@ def setup_parser() -> argparse.ArgumentParser:
         prog='panther_analysis_tool')
     parser.add_argument('--version',
                         action='version',
-                        version='panther_analysis_tool 0.2.1')
+                        version='panther_analysis_tool 0.2.2')
     subparsers = parser.add_subparsers()
 
     test_parser = subparsers.add_parser(
@@ -426,6 +452,10 @@ def setup_parser() -> argparse.ArgumentParser:
         type=str,
         help='The relative path to Panther policies and rules.',
         required=True)
+    test_parser.add_argument('--filter',
+                             required=False,
+                             metavar="KEY=VALUE",
+                             nargs='+')
     test_parser.set_defaults(func=test_analysis)
 
     zip_parser = subparsers.add_parser(
@@ -443,6 +473,10 @@ def setup_parser() -> argparse.ArgumentParser:
         type=str,
         help='The path to write zipped policies and rules to.',
         required=True)
+    zip_parser.add_argument('--filter',
+                            required=False,
+                            metavar="KEY=VALUE",
+                            nargs='+')
     zip_parser.set_defaults(func=zip_analysis)
 
     upload_parser = subparsers.add_parser(
@@ -460,9 +494,33 @@ def setup_parser() -> argparse.ArgumentParser:
         help=
         'The location to store a local copy of the packaged policies and rules.',
         required=False)
+    upload_parser.add_argument('--filter',
+                               required=False,
+                               metavar="KEY=VALUE",
+                               nargs='+')
     upload_parser.set_defaults(func=upload_analysis)
 
     return parser
+
+
+# Parses the filters, expects a list of strings
+def parse_filter(filters: List[str]) -> Dict[str, Any]:
+    logging.info('Parsing filter in %s', str(filters))
+    parsed_filters = {}
+    for filt in filters:
+        split = filt.split('=')
+        if len(split) != 2 or split[0] == '' or split[1] == '':
+            logging.warning('Filter %s is not in format KEY=VALUE, skipping',
+                            filt)
+            continue
+        key = split[0]
+        if key not in list(GLOBAL_SCHEMA.schema.keys()) + list(
+                POLICY_SCHEMA.schema.keys()) + list(RULE_SCHEMA.schema.keys()):
+            logging.warning(
+                'Filter key %s is not a valid filter field, skipping', key)
+            continue
+        parsed_filters[key] = split[1].split(',')
+    return parsed_filters
 
 
 def run() -> None:
@@ -472,6 +530,8 @@ def run() -> None:
     parser = setup_parser()
     args = parser.parse_args()
     try:
+        if args.filter is not None:
+            args.filter = parse_filter(args.filter)
         return_code, out = args.func(args)
     except AttributeError:
         parser.print_help()

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.2.1',
+    version='0.2.2',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.2.1.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.2.2.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[

--- a/tests/fixtures/valid_policies/example_policy.yml
+++ b/tests/fixtures/valid_policies/example_policy.yml
@@ -2,7 +2,7 @@ AnalysisType: policy
 Filename: example_policy.py
 DisplayName: MFA Is Enabled For User
 Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
-Severity: High
+Severity: Critical
 PolicyID: AWS.IAM.MFAEnabled
 Enabled: true
 ResourceTypes:

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -40,6 +40,22 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(invalid_specs[0][0],
                      'tests/fixtures/example_malformed_policy.yml')
 
+    def test_parse_filters(self):
+        args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_policies --filter AnalysisType=policy,global Severity=Critical'.split())
+        args.filter = pat.parse_filter(args.filter)
+        assert_true('AnalysisType' in args.filter.keys())
+        assert_true('policy' in args.filter['AnalysisType'])
+        assert_true('global' in args.filter['AnalysisType'])
+        assert_true('Severity' in args.filter.keys())
+        assert_true('Critical' in args.filter['Severity'])
+
+    def test_with_filters(self):
+        args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_policies --filter AnalysisType=policy,global'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 0)
+        assert_equal(len(invalid_specs), 0)
+
     def test_zip_analysis(self):
         # Note: This is a workaround for CI
         try:


### PR DESCRIPTION
### Background

Adds the `--filter` flag to all commands, allowing users to filter to just specific analysis objects by specifying any valid field in an analysis specification file.

Closes #5 .

Example usage:

`panther_analysis_tool test --path tests/fixtures/valid_policies --filter AnalysisType=policy,global`
  - will only apply to `policy` and `global` analysis types, excluding rules

`panther_analysis_tool test --path tests/fixtures/valid_policies --filter AnalysisType=policy Severity=Critical`
  - will only apply to `policy` analysis types that have the severity `Critical`

`panther_analysis_tool test --path tests/fixtures/valid_policies --filter AnalysisType=policy,global Severity=Critical,""`
  - By providing an empty string, you can indicate that the field need not be present. So this will only apply to `policy` and `global` analysis types, and only if they have a severity of `Critical` or no severity specified at all. In this case this is necessary because `global` analysis types don't have a severity. It is also useful for optional fields.

### Changes

* Added generic filtering to all commands

### Testing

* `make ci`
* manually verifying correctness
