### PR TITLE
Show dedup/title values

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -32,6 +32,7 @@ import yaml
 
 import boto3
 
+HELPERS_LOCATION = 'global_helpers'
 
 class TestCase():
 
@@ -58,6 +59,8 @@ GLOBAL_SCHEMA = Schema(
     {
         'AnalysisType': Or("global"),
         'Filename': str,
+        'GlobalID':
+            str,
         Optional('Description'): str,
         Optional('Tags'): [str],
     },
@@ -305,6 +308,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
 
     # First classify each file
     specs = list(load_analysis_specs(args.path))
+    specs += list(load_analysis_specs(HELPERS_LOCATION))
     global_analysis, analysis, invalid_specs = classify_analysis(specs)
 
     # Apply the filters as needed
@@ -319,7 +323,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
         if load_err:
             invalid_specs.append((analysis_spec_filename, load_err))
             break
-        sys.modules['panther'] = module
+        sys.modules[analysis_spec['GlobalID']] = module
 
     # Next import each policy or rule and run its tests
     for analysis_spec_filename, dir_name, analysis_spec in analysis:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -34,6 +34,7 @@ import boto3
 
 HELPERS_LOCATION = 'global_helpers'
 
+
 class TestCase():
 
     def __init__(self, data: Dict[str, Any], schema: str) -> None:
@@ -59,8 +60,7 @@ GLOBAL_SCHEMA = Schema(
     {
         'AnalysisType': Or("global"),
         'Filename': str,
-        'GlobalID':
-            str,
+        'GlobalID': str,
         Optional('Description'): str,
         Optional('Tags'): [str],
     },
@@ -307,9 +307,9 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     logging.info('Testing analysis packs in %s\n', args.path)
 
     # First classify each file
-    specs = list(load_analysis_specs(args.path))
-    specs += list(load_analysis_specs(HELPERS_LOCATION))
-    global_analysis, analysis, invalid_specs = classify_analysis(specs)
+    global_analysis, analysis, invalid_specs = classify_analysis(
+        list(load_analysis_specs(args.path)) +
+        list(load_analysis_specs(HELPERS_LOCATION)))
 
     # Apply the filters as needed
     global_analysis = filter_analysis(global_analysis, args.filter)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -24,7 +24,7 @@ import json
 import logging
 import os
 import sys
-from typing import Any, Callable, DefaultDict, Dict, Iterator, List, Tuple
+from typing import Any, DefaultDict, Dict, Iterator, List, Tuple
 import zipfile
 from schema import (Optional, Or, Schema, SchemaError, SchemaMissingKeyError,
                     SchemaForbiddenKeyError, SchemaUnexpectedTypeError)
@@ -342,10 +342,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
             continue
 
         tests.append(analysis_id)
-        analysis_funcs = {
-            'dedup': None,
-            'title': None,
-        }
+        analysis_funcs = {}
         if analysis_spec['AnalysisType'] == 'policy':
             analysis_funcs['run'] = module.policy
         elif analysis_spec['AnalysisType'] == 'rule':
@@ -413,7 +410,7 @@ def classify_analysis(
     return (global_analysis, analysis, invalid_specs)
 
 
-def run_tests(analysis: Dict[str, Any], analysis_funcs: DefaultDict[str, Callable[[TestCase], bool]],
+def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
               failed_tests: DefaultDict[str, list]) -> DefaultDict[str, list]:
 
     # First check if any tests exist, so we can print a helpful message if not
@@ -437,9 +434,9 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: DefaultDict[str, Callabl
             failed_tests[analysis.get('PolicyID') or
                          analysis['RuleID']].append(unit_test['Name'])
         print('\t[{}] {}'.format(test_result, unit_test['Name']))
-        if analysis_funcs['title']:
+        if analysis_funcs.get('title'):
             print('\t\t[Title] {}'.format(analysis_funcs['title'](test_case)))
-        if analysis_funcs['dedup']:
+        if analysis_funcs.get('dedup'):
             print('\t\t[Dedup] {}'.format(analysis_funcs['dedup'](test_case)))
 
     return failed_tests

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -453,7 +453,7 @@ def setup_parser() -> argparse.ArgumentParser:
         prog='panther_analysis_tool')
     parser.add_argument('--version',
                         action='version',
-                        version='panther_analysis_tool 0.2.2')
+                        version='panther_analysis_tool 0.3.0')
     subparsers = parser.add_subparsers()
 
     test_parser = subparsers.add_parser(

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.2.2',
+    version='0.3.0',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.2.2.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.3.0.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[

--- a/tests/fixtures/valid_policies/example_rule.py
+++ b/tests/fixtures/valid_policies/example_rule.py
@@ -11,3 +11,9 @@ def rule(event):
 
     return cred_report.get('PasswordEnabled', False) and cred_report.get(
         'MfaActive', False)
+
+def dedup(event):
+    return event['UserName']
+
+def title(event):
+    return '{} does not have MFA enabled'.format(event['UserName'])

--- a/tests/fixtures/valid_policies/helpers.yml
+++ b/tests/fixtures/valid_policies/helpers.yml
@@ -1,4 +1,5 @@
 AnalysisType: global
+GlobalID: panther
 Filename: helpers.py
 Tags:
   - AWS


### PR DESCRIPTION
### Background

When testing rules, show the title and dedup field if one is set. Closes #24 .

Added support for multiple globals, and require the `GlobalID` field in global analysis types now. Also automatically searches for globals in the default location in addition to the path specified.

### Changes

* When testing rules, show the title and dedup values if one is set
* Must specify the `GlobalID` field in global analysis types now, and the `GlobalID` will be used as the module name for importing
* Automatically checks the path `global_helpers` (relative to where the command is being run from) for ANY analysis items. Recommend only putting global analysis types here.

### Testing

* make ci

Example output:

```
$ panther_analysis_tool test --path tests/fixtures/valid_policies
[INFO]: Testing analysis packs in tests/fixtures/valid_policies

AWS.IAM.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance

AWS.IAM.BetaTest
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance

AWS.CloudTrail.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
		[Title] root does not have MFA enabled
		[Dedup] root
	[PASS] User MFA not enabled fails compliance
		[Title] test does not have MFA enabled
		[Dedup] test
```