### PR TITLE
Fix report parsing

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -61,7 +61,7 @@ POLICY_SCHEMA = Schema(
         Optional('Suppressions'): [str],
         Optional('Tags'): [str],
         Optional('Reports'): {
-            str: object
+            str: list
         },
         Optional('Tests'): [{
             'Name': str,
@@ -98,7 +98,7 @@ RULE_SCHEMA = Schema(
         Optional('Suppressions'): [str],
         Optional('Tags'): [str],
         Optional('Reports'): {
-            str: object
+            str: list
         },
         Optional('Tests'): [{
             'Name': str,

--- a/tests/fixtures/valid_analysis/policies/example_policy.yml
+++ b/tests/fixtures/valid_analysis/policies/example_policy.yml
@@ -13,6 +13,11 @@ Tags:
   - AWS
   - CIS
   - SOC2
+Reports:
+  CIS:
+    - 1.1
+  MITRE:
+    - Extraction:Data Parsing
 Runbook: >
   Find out who disabled MFA on the account.
 Reference: https://www.link-to-info.io


### PR DESCRIPTION
### Background

Previously we had envisioned allowing Reports to be defined as either a map of strings to lists of strings OR a map of strings to maps of strings to strings. We have since consolidated on just the first definition on the backend, but the `panther_analysis_tool` needs to be updated to reflect that.

### Changes

* Only allow reports to be maps of strings to lists

### Testing

* Manual testing
