### PR TITLE
Fixed up some unexpected behavior

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -409,10 +409,14 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
             result = analysis_funcs['run'](test_case)
         except KeyError as err:
             logging.warning('KeyError: {%s}', err)
+            failed_tests[analysis.get('PolicyID') or
+                         analysis['RuleID']].append(unit_test['Name'])
             continue
         except Exception as err:  # pylint: disable=broad-except
             # Catch arbitrary exceptions raised by user code
             logging.warning('Unexpected exception: {%s}', err)
+            failed_tests[analysis.get('PolicyID') or
+                         analysis['RuleID']].append(unit_test['Name'])
             continue
         test_result = 'PASS'
         if result != unit_test['ExpectedResult']:
@@ -538,9 +542,6 @@ def run() -> None:
         if args.filter is not None:
             args.filter = parse_filter(args.filter)
         return_code, out = args.func(args)
-    except AttributeError:
-        parser.print_help()
-        sys.exit(1)
     except Exception as err:  # pylint: disable=broad-except
         # Catch arbitrary exceptions without printing help message
         logging.warning('Unhandled exception: "%s"', err)

--- a/tests/fixtures/valid_analysis/rules/example_rule.py
+++ b/tests/fixtures/valid_analysis/rules/example_rule.py
@@ -1,5 +1,4 @@
 from panther import test_helper # pylint: disable=import-error
-import world_meme_database
 
 IGNORED_USERS = {}
 

--- a/tests/fixtures/valid_analysis/rules/example_rule.py
+++ b/tests/fixtures/valid_analysis/rules/example_rule.py
@@ -1,4 +1,5 @@
 from panther import test_helper # pylint: disable=import-error
+import world_meme_database
 
 IGNORED_USERS = {}
 

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -62,6 +62,13 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
+    def test_with_tag_filters(self):
+        args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 0)
+        assert_equal(len(invalid_specs), 0)
+
     def test_zip_analysis(self):
         # Note: This is a workaround for CI
         try:


### PR DESCRIPTION
### Background

No longer prints the help message unless the user runs the tool with `--help` or `-h`. 

### Changes

* No longer print the help messages unless specifically requested
* If a rule/policy raises an exception report this as a failed test

### Testing

* Unit testing
