### PR TITLE
Add support for destination overrides

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -47,7 +47,8 @@ class TestCase():
     def __init__(self, data: Dict[str, Any]) -> None:
         """
         Args:
-            data (Dict[str, Any]): An AWS Resource representation or Log event to test the policy or rule against respectively.
+            data (Dict[str, Any]): An AWS Resource representation or Log event to test the policy
+            or rule against respectively.
         """
         self._data = data
 
@@ -307,7 +308,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     return int(bool(failed_tests or invalid_specs)), invalid_specs
 
 
-def print_summary(test_path: str, num_tests: int, failed_tests: List[Any],
+def print_summary(test_path: str, num_tests: int, failed_tests: Dict[str, list],
                   invalid_specs: List[Any]) -> None:
     '''Print a summary of passed, failed, and invalid specs'''
     print('--------------------------')

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -54,6 +54,7 @@ POLICY_SCHEMA = Schema(
             str,
         Optional('DisplayName'):
             str,
+        Optional('OutputIds'): [str],
         Optional('Reference'):
             str,
         Optional('Runbook'):
@@ -92,6 +93,7 @@ RULE_SCHEMA = Schema(
             int,
         Optional('DisplayName'):
             str,
+        Optional('OutputIds'): [str],
         Optional('Reference'):
             str,
         Optional('Runbook'):

--- a/tests/fixtures/valid_analysis/policies/example_policy.yml
+++ b/tests/fixtures/valid_analysis/policies/example_policy.yml
@@ -4,6 +4,8 @@ DisplayName: MFA Is Enabled For User
 Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
 Severity: Critical
 PolicyID: AWS.IAM.MFAEnabled
+OutputIds:
+  - 00000-01-00000
 Enabled: true
 ResourceTypes:
   - AWS.IAM.RootUser.Snapshot


### PR DESCRIPTION
### Background

@s0l0ist added support for destination overrides in Panther including in the BulkUpload API, so we should allow users to define this field when managing policies or rules from the commandline.

### Changes

* Add `OutputIds` as an optional field to policies and rules. This field is a list of strings, where each string is the ID of a destination. In a future iteration, we might allow users to specify a destination name that is then mapped to the corresponding destination ID by either the CLI tool or the backend
* Fixed some linting/typing issues `make ci` found 

### Testing

* Unit tests
