### PR TITLE
Lindseyw test dedup title

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -429,6 +429,7 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
             test_result['outcome'] = 'FAIL'
 
         # check dedup and title function return non-None
+        # Only applies to rules which match an incoming event
         if unit_test['ExpectedResult']:
             for func in ['dedup', 'title']:
                 if analysis_funcs.get(func):
@@ -436,7 +437,7 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
                         test_result[func] = 'FAIL'
                         test_result['outcome'] = 'FAIL'
 
-        if test_result['expected'] == 'FAIL':
+        if test_result['outcome'] == 'FAIL':
             failed_tests[analysis.get('PolicyID') or
                          analysis['RuleID']].append(unit_test['Name'])
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -420,10 +420,13 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
                          analysis['RuleID']].append(unit_test['Name'])
             continue
 
+        # using a dictionary to map between the tests and their outcomes
+        # assume the test passes (default "PASS") 
+        # until failure condition is found (set to "FAIL")
         test_result = defaultdict(lambda: 'PASS')
         # check expected result
         if result != unit_test['ExpectedResult']:
-            test_result['expected'] = 'FAIL'
+            test_result['outcome'] = 'FAIL'
 
         # check dedup and title function return non-None
         if unit_test['ExpectedResult']:
@@ -431,14 +434,14 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
                 if analysis_funcs.get(func):
                     if not analysis_funcs[func](test_case):
                         test_result[func] = 'FAIL'
-                        test_result['expected'] = 'FAIL'
+                        test_result['outcome'] = 'FAIL'
 
         if test_result['expected'] == 'FAIL':
             failed_tests[analysis.get('PolicyID') or
                          analysis['RuleID']].append(unit_test['Name'])
 
         # print results
-        print('\t[{}] {}'.format(test_result['expected'], unit_test['Name']))
+        print('\t[{}] {}'.format(test_result['outcome'], unit_test['Name']))
         for func in ['dedup', 'title']:
             if analysis_funcs.get(func) and unit_test['ExpectedResult']:
                 print('\t\t[{}] [{}] {}'.format(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -421,7 +421,7 @@ def run_tests(analysis: Dict[str, Any], analysis_funcs: Dict[str, Any],
             continue
 
         # using a dictionary to map between the tests and their outcomes
-        # assume the test passes (default "PASS") 
+        # assume the test passes (default "PASS")
         # until failure condition is found (set to "FAIL")
         test_result = defaultdict(lambda: 'PASS')
         # check expected result

--- a/tests/fixtures/example_rule.py
+++ b/tests/fixtures/example_rule.py
@@ -1,0 +1,22 @@
+from panther import test_helper # pylint: disable=import-error
+
+IGNORED_USERS = {}
+
+
+def rule(event):
+    if event['UserName'] in IGNORED_USERS:
+        return False
+
+    cred_report = event.get('CredentialReport', {})
+    if not cred_report:
+        return True
+
+    return (test_helper() and
+            cred_report.get('PasswordEnabled', False) and
+            cred_report.get('MfaActive', False))
+
+def dedup(event):
+    return None
+
+def title(event):
+    return '{} does not have MFA enabled'.format(event['UserName'])

--- a/tests/fixtures/example_rule_missing_field.yml
+++ b/tests/fixtures/example_rule_missing_field.yml
@@ -2,7 +2,7 @@ AnalysisType: rule
 Filename: example_rule.py
 DisplayName: MFA Rule
 Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
-Severity: High
+Severity: Critical
 Threshold: 5
 RuleID: AWS.CloudTrail.MFAEnabled
 Enabled: true
@@ -21,30 +21,7 @@ Runbook: >
 Reference: https://www.link-to-info.io
 Tests:
   -
-    Name: Root MFA not enabled fails compliance
-    ExpectedResult: false
-    Log:
-      Arn: arn:aws:iam::123456789012:user/root
-      CreateDate: 2019-01-01T00:00:00Z
-      CredentialReport:
-        MfaActive: false
-        PasswordEnabled: true
-      UserName: root
-  -
-    Name: User MFA not enabled fails compliance
-    ExpectedResult: false
-    Log:
-      {
-        "Arn": "arn:aws:iam::123456789012:user/test",
-        "CreateDate": "2019-01-01T00:00:00",
-        "CredentialReport": {
-          "MfaActive": false,
-          "PasswordEnabled": true
-        },
-        "UserName": "test"
-      }
-  -
-    Name: User MFA enabled passes compliance.
+    Name: User MFA enabled passes compliance but fails dedup check.
     ExpectedResult: true
     Log:
       {
@@ -53,6 +30,5 @@ Tests:
         "CredentialReport": {
           "MfaActive": true,
           "PasswordEnabled": true
-        },
-        "UserName": "test"
+        }
       }

--- a/tests/fixtures/valid_analysis/rules/example_rule.yml
+++ b/tests/fixtures/valid_analysis/rules/example_rule.yml
@@ -56,3 +56,4 @@ Tests:
         },
         "UserName": "test"
       }
+      

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -62,6 +62,13 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
+    def test_invalid_rule_definition(self):
+        args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=Critical RuleID=AWS.CloudTrail.MFAEnabled'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 1)
+
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())
         args.filter = pat.parse_filter(args.filter)


### PR DESCRIPTION
### Background

Overall test cases were passing even if the dedup/title functions returned None. Closes #18 

### Changes

* Added ability for overall test to fail if the dedup or title function return None
* Update output of manually running to show dedup/title check status

### Testing

* Added passing and failing unit tests. 

Example Output

Original Format:
```
% panther_analysis_tool test --path ./tests/fixtures/valid_analysis
[INFO]: Testing analysis packs in ./tests/fixtures/valid_analysis

...

AWS.CloudTrail.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance
```

New Format:
```
% panther_analysis_tool test --path ./tests/fixtures/valid_analysis
[INFO]: Testing analysis packs in ./tests/fixtures/valid_analysis

...

AWS.CloudTrail.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance
	[PASS] User MFA enabled passes compliance.
		[PASS] [dedup] test
		[PASS] [title] test does not have MFA enabled
```

