### PR TITLE
Allowing packaging of just globals

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,4 +2,4 @@
 # Each line is a file pattern followed by one or more owners.
 
 # These owners will be the default owners for everything in the repo.
-*       @kostaspap @nhakmiller @austinbyers
+*       @kostaspap @nhakmiller @austinbyers @lindsey-w

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -459,7 +459,7 @@ def setup_parser() -> argparse.ArgumentParser:
         prog='panther_analysis_tool')
     parser.add_argument('--version',
                         action='version',
-                        version='panther_analysis_tool 0.3.4')
+                        version='panther_analysis_tool 0.3.5')
     subparsers = parser.add_subparsers()
 
     test_parser = subparsers.add_parser(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -158,11 +158,10 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     with zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED) as zip_out:
         # Always zip the helpers
         analysis = []
-        files: Set[str] = Set()
+        files: Set[str] = set()
         for (file_name, f_path, spec) in list(load_analysis_specs(
                 args.path)) + list(load_analysis_specs(HELPERS_LOCATION)):
             if file_name not in files:
-                print(file_name)
                 analysis.append((file_name, f_path, spec))
                 files.add(file_name)
                 files.add('./' + file_name)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -18,7 +18,7 @@ from collections import defaultdict
 from datetime import datetime
 from fnmatch import fnmatch
 from importlib.abc import Loader
-from typing import Any, DefaultDict, Dict, Iterator, List, Tuple
+from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple
 import argparse
 import base64
 import importlib.util
@@ -158,12 +158,14 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     with zipfile.ZipFile(filename, 'w', zipfile.ZIP_DEFLATED) as zip_out:
         # Always zip the helpers
         analysis = []
-        files: Dict[str, Any] = {}
+        files: Set[str] = Set()
         for (file_name, f_path, spec) in list(load_analysis_specs(
                 args.path)) + list(load_analysis_specs(HELPERS_LOCATION)):
             if file_name not in files:
+                print(file_name)
                 analysis.append((file_name, f_path, spec))
-                files[file_name] = None
+                files.add(file_name)
+                files.add('./' + file_name)
         analysis = filter_analysis(analysis, args.filter)
         for analysis_spec_filename, dir_name, analysis_spec in analysis:
             zip_out.write(analysis_spec_filename)
@@ -247,14 +249,14 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
         list(load_analysis_specs(args.path)) +
         list(load_analysis_specs(HELPERS_LOCATION)))
 
-    if len(analysis) == 0:
+    if len(analysis) == 0 and len(global_analysis) == 0:
         return 1, ["Nothing to test in {}".format(args.path)]
 
     # Apply the filters as needed
     global_analysis = filter_analysis(global_analysis, args.filter)
     analysis = filter_analysis(analysis, args.filter)
 
-    if len(analysis) == 0:
+    if len(analysis) == 0 and len(global_analysis) == 0:
         return 1, [
             "No analyses in {} matched filters {}".format(
                 args.path, args.filter)

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -8,3 +8,4 @@ mypy
 pylint
 pyfakefs
 yapf
+nose

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,16 +1,17 @@
 # functional dependencies
 PyYAML==5.3.1
 schema==0.7.2
-boto3==1.14.47
+boto3==1.14.57
 # ci dependencies
 bandit==1.6.2
 mypy==0.782
 pylint==2.6.0
 pyfakefs==4.1.0
 yapf==0.30.0
+nose==1.3.7
 ## The following requirements were added by pip freeze:
 astroid==2.4.2
-botocore==1.17.47
+botocore==1.17.57
 contextlib2==0.6.0.post1
 docutils==0.15.2
 gitdb==4.0.5

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.3.4',
+    version='0.3.5',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.3.4.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.3.5.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[


### PR DESCRIPTION
### Background

Previously, testing a directory which only contained globals would return an error. This is turn meant that you could not zip or upload just a directory of globals, as Pat first attempts to test any analysis before zipping or uploading.

Since you should still be able to test just globals (simply by validating their specification files), and since you should certainly be able to package and upload just globals, I updated Pat to accept a directory containing only globals for any operation.

### Changes

* Only return a "nothing to test" error if there are no policies, rules, OR globals

### Testing

* None
