### PR TITLE
#37 - Display Name Validation

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from schema import And, Optional, Or, Regex, Schema
 
-NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9\-\_\.\ \(\)]+$")
+NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9_. ()-]+$")
 
 TYPE_SCHEMA = Schema({
     'AnalysisType': Or("policy", "rule", "global"),

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -94,7 +94,7 @@ RULE_SCHEMA = Schema(
         Optional('DedupPeriodMinutes'):
             int,
         Optional('DisplayName'):
-            And(str, Regex("")),
+            And(str, NAME_ID_VALIDATION_REGEX),
         Optional('OutputIds'): [str],
         Optional('Reference'):
             str,

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -14,7 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-from schema import Optional, Or, Schema
+from schema import And, Optional, Or, Regex, Schema
+
+NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9\-\_\.\ ]+$")
 
 TYPE_SCHEMA = Schema({
     'AnalysisType': Or("policy", "rule", "global"),
@@ -25,7 +27,7 @@ GLOBAL_SCHEMA = Schema(
     {
         'AnalysisType': Or("global"),
         'Filename': str,
-        'GlobalID': str,
+        'GlobalID': And(str, NAME_ID_VALIDATION_REGEX),
         Optional('Description'): str,
         Optional('Tags'): [str],
     },
@@ -40,7 +42,7 @@ POLICY_SCHEMA = Schema(
         'Filename':
             str,
         'PolicyID':
-            str,
+            And(str, NAME_ID_VALIDATION_REGEX),
         'ResourceTypes': [str],
         'Severity':
             Or("Info", "Low", "Medium", "High", "Critical"),
@@ -53,7 +55,7 @@ POLICY_SCHEMA = Schema(
         Optional('Description'):
             str,
         Optional('DisplayName'):
-            str,
+            And(str, NAME_ID_VALIDATION_REGEX),
         Optional('OutputIds'): [str],
         Optional('Reference'):
             str,
@@ -83,7 +85,7 @@ RULE_SCHEMA = Schema(
         'Filename':
             str,
         'RuleID':
-            str,
+            And(str, NAME_ID_VALIDATION_REGEX),
         'LogTypes': [str],
         'Severity':
             Or("Info", "Low", "Medium", "High", "Critical"),
@@ -92,7 +94,7 @@ RULE_SCHEMA = Schema(
         Optional('DedupPeriodMinutes'):
             int,
         Optional('DisplayName'):
-            str,
+            And(str, Regex("")),
         Optional('OutputIds'): [str],
         Optional('Reference'):
             str,

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -16,7 +16,7 @@ limitations under the License.
 
 from schema import And, Optional, Or, Regex, Schema
 
-NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9\-\_\.\ ]+$")
+NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9\-\_\.\ \(\)]+$")
 
 TYPE_SCHEMA = Schema({
     'AnalysisType': Or("policy", "rule", "global"),

--- a/tests/fixtures/example_policy_invalid_characters.py
+++ b/tests/fixtures/example_policy_invalid_characters.py
@@ -1,0 +1,13 @@
+IGNORED_USERS = {}
+
+
+def policy(resource):
+    if resource['UserName'] in IGNORED_USERS:
+        return True
+
+    cred_report = resource.get('CredentialReport', {})
+    if not cred_report:
+        return True
+
+    return cred_report.get('PasswordEnabled', False) and cred_report.get(
+        'MfaActive', False)

--- a/tests/fixtures/example_policy_invalid_characters.yml
+++ b/tests/fixtures/example_policy_invalid_characters.yml
@@ -1,0 +1,58 @@
+AnalysisType: policy
+Filename: example_policy_invalid_characters.py
+DisplayName: MFA Is Enabled For User &
+Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
+Severity: High
+PolicyID: AWS.IAM.MFAEnabled&
+Enabled: true
+ResourceTypes:
+  - AWS.IAM.RootUser.Snapshot
+  - AWS.IAM.User.Snapshot
+Tags:
+  - AWS Managed Rules - Security, Identity & Compliance
+  - AWS
+  - CIS
+  - SOC2
+Runbook: >
+  Find out who disabled MFA on the account.
+Reference: https://www.link-to-info.io
+Suppressions:
+  - aws:resource:1
+  - aws:.*:other-resource
+Tests:
+  -
+    Name: Root MFA not enabled triggers a violation.
+    ExpectedResult: false
+    Resource:
+      Arn: arn:aws:iam::123456789012:user/root
+      CreateDate: 2019-01-01T00:00:00Z
+      CredentialReport:
+        MfaActive: false
+        PasswordEnabled: true
+      UserName: root
+  -
+    Name: User MFA not enabled triggers a violation.
+    ExpectedResult: false
+    Resource:
+      {
+        "Arn": "arn:aws:iam::123456789012:user/test",
+        "CreateDate": "2019-01-01T00:00:00",
+        "CredentialReport": {
+          "MfaActive": false,
+          "PasswordEnabled": true
+        },
+        "UserName": "test"
+      }
+  -
+    Name: User MFA enabled.
+    ExpectedResult: false
+    Resource:
+      {
+        "Arn": "arn:aws:iam::123456789012:user/test",
+        "CreateDate": "2019-01-01T00:00:00",
+        "CredentialReport": {
+          "MfaActive": true,
+          "PasswordEnabled": true
+        },
+        "UserName": "test"
+      }

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -67,7 +67,14 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 1)
+        assert_equal(len(invalid_specs), 2)
+
+    def test_invalid_characters(self):
+        args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled&'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 2)
 
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -70,7 +70,7 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(len(invalid_specs), 2)
 
     def test_invalid_characters(self):
-        args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled&'.split())
+        args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled'.split())
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)


### PR DESCRIPTION
Added imports And, Regex from schemas. Added character validation for DisplayName, GlobalID, PolicyID, and RuleID

### Background

Panther does not accept certain special characters in display names, such as:

'
"
&
,
and perhaps others. The panther_analysis_tool should warn against these characters when they are present in a displayname.

### Changes

All changes, with the exception of related testing, that have been made are specific to the `panther_analysis_tool/schemas.py` file.
Created a new global variable `NAME_ID_VALIDATION_REGEX` which is meant to check against strings to ensure the string only contains alphanumeric characters along with dashes, underscores, periods, and spaces.
For GLOBAL_SCHEMA, POLICY_SCHEMA, and RULE_SCHEMA, the schema definition for the fields DisplayName, GlobalID, PolicyID, and RuleID have been updated to verify that the field value is both: of type str and matching NAME_ID_VALIDATION_REGEX

### Testing

Created a copy of tests/fixtures/valid_analysis/policies/example_policy.yml and the respective .py file
Edited the copy to include invalid characters
![image](https://user-images.githubusercontent.com/71197790/93529304-ac5cb480-f909-11ea-92d0-08b9cd9bd7a8.png)
