### PR TITLE
Update to yaml verification

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -28,10 +28,10 @@ import os
 import sys
 import zipfile
 
+from ruamel.yaml import YAML, parser as YAMLParser, scanner as YAMLScanner
 from schema import (Optional, SchemaError, SchemaMissingKeyError,
                     SchemaForbiddenKeyError, SchemaUnexpectedTypeError)
 import boto3
-from ruamel.yaml import YAML, parser as YAMLParser, scanner as YAMLScanner
 
 from panther_analysis_tool.schemas import TYPE_SCHEMA, GLOBAL_SCHEMA, POLICY_SCHEMA, RULE_SCHEMA
 
@@ -173,10 +173,9 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
         # Always zip the helpers
         analysis = []
         files: Set[str] = set()
-        for (file_name, f_path, spec,
-             error) in list(load_analysis_specs(args.path)) + list(
-                 load_analysis_specs(HELPERS_LOCATION)):
-            if file_name not in files and not error:
+        for (file_name, f_path, spec, _) in list(load_analysis_specs(
+                args.path)) + list(load_analysis_specs(HELPERS_LOCATION)):
+            if file_name not in files:
                 analysis.append((file_name, f_path, spec))
                 files.add(file_name)
                 files.add('./' + file_name)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -382,21 +382,20 @@ def classify_analysis(
             # check for parsing errors from json.loads (ValueError) / yaml.safe_load (YAMLError)
             if error:
                 raise error
-            else:
-                # validate the schema
-                TYPE_SCHEMA.validate(analysis_spec)
-                if analysis_spec['AnalysisType'] == 'policy':
-                    POLICY_SCHEMA.validate(analysis_spec)
-                    analysis.append(
-                        (analysis_spec_filename, dir_name, analysis_spec))
-                if analysis_spec['AnalysisType'] == 'rule':
-                    RULE_SCHEMA.validate(analysis_spec)
-                    analysis.append(
-                        (analysis_spec_filename, dir_name, analysis_spec))
-                if analysis_spec['AnalysisType'] == 'global':
-                    GLOBAL_SCHEMA.validate(analysis_spec)
-                    global_analysis.append(
-                        (analysis_spec_filename, dir_name, analysis_spec))
+            # validate the schema
+            TYPE_SCHEMA.validate(analysis_spec)
+            if analysis_spec['AnalysisType'] == 'policy':
+                POLICY_SCHEMA.validate(analysis_spec)
+                analysis.append(
+                    (analysis_spec_filename, dir_name, analysis_spec))
+            if analysis_spec['AnalysisType'] == 'rule':
+                RULE_SCHEMA.validate(analysis_spec)
+                analysis.append(
+                    (analysis_spec_filename, dir_name, analysis_spec))
+            if analysis_spec['AnalysisType'] == 'global':
+                GLOBAL_SCHEMA.validate(analysis_spec)
+                global_analysis.append(
+                    (analysis_spec_filename, dir_name, analysis_spec))
         except (SchemaError, SchemaMissingKeyError, SchemaForbiddenKeyError,
                 SchemaUnexpectedTypeError) as err:
             invalid_specs.append((analysis_spec_filename, err))

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -1,5 +1,5 @@
 # functional dependencies
-PyYAML
+ruamel.yaml
 schema
 boto3
 # ci dependencies
@@ -9,3 +9,4 @@ pylint
 pyfakefs
 yapf
 nose
+PyYAML

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # functional dependencies
-PyYAML==5.3.1
+ruamel.yaml==0.16.12
 schema==0.7.2
-boto3==1.14.57
+boto3==1.15.5
 # ci dependencies
 bandit==1.6.2
 mypy==0.782
@@ -9,9 +9,10 @@ pylint==2.6.0
 pyfakefs==4.1.0
 yapf==0.30.0
 nose==1.3.7
+PyYAML==5.3.1
 ## The following requirements were added by pip freeze:
 astroid==2.4.2
-botocore==1.17.57
+botocore==1.18.5
 contextlib2==0.6.0.post1
 docutils==0.15.2
 gitdb==4.0.5
@@ -24,6 +25,7 @@ mccabe==0.6.1
 mypy-extensions==0.4.3
 pbr==5.4.5
 python-dateutil==2.8.1
+ruamel.yaml.clib==0.2.2
 s3transfer==0.3.3
 six==1.15.0
 smmap==3.0.4

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[
-        'PyYAML',
+        'ruamel.yaml',
         'schema',
         'boto3',
     ],

--- a/tests/fixtures/example_malformed_yaml.yml
+++ b/tests/fixtures/example_malformed_yaml.yml
@@ -1,0 +1,32 @@
+AnalysisType: rule 
+Filename: example_rule.py
+DisplayName: MFA Rule
+Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
+Severity: Critical
+Threshold: 5
+RuleID: AWS.CloudTrail.MFAEnabled
+Enabled: true
+SummaryAttributes:
+  - p_log_type
+  - p_any_ip_addresses
+LogTypes:
+  - AWS.CloudTrail
+Tags:
+  - AWS Managed Rules - Security, Identity & Compliance
+  - AWS
+  - CIS
+  - SOC2
+Runbook: >
+  Find out who disabled MFA on the account.
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: User MFA enabled passes compliance but fails dedup check.
+    ExpectedResult: true
+    Log:
+      User:{ "test": "one" }
+      Arn: arn:aws:iam::123456789012:user/test
+      CreateDate: '2019-01-01T00:00:00'
+      CredentialReport:
+        MfaActive: true
+        PasswordEnabled: true

--- a/tests/fixtures/example_strict_invalid_yaml.yml
+++ b/tests/fixtures/example_strict_invalid_yaml.yml
@@ -1,0 +1,25 @@
+AnalysisType: rule 
+Filename: example_strict_invalid_yaml.py
+DisplayName: Sample Rule - Strict Invalid YAML Check
+Severity: Info
+RuleID: Strict.Invalid.YAML.Check
+Enabled: true
+SummaryAttributes:
+  - p_log_type
+  - p_any_ip_addresses
+LogTypes:
+  - Sample.Log.Type
+Tags:
+  - Test
+Runbook: Sample Runbook
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: Testing invalid yaml
+    ExpectedResult: false
+    Log:
+      {
+        UserName:{ 
+          test: test
+        }
+      }

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -17,13 +17,13 @@ class TestPantherAnalysisTool(TestCase):
         self.fs.add_real_directory(self.fixture_path)
 
     def test_valid_json_policy_spec(self):
-        for spec_filename, _, loaded_spec in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
             if spec_filename == 'example_policy.json':
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
 
     def test_valid_yaml_policy_spec(self):
-        for spec_filename, _, loaded_spec in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
             if spec_filename == 'example_policy.yml':
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
@@ -67,14 +67,14 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 2)
+        assert_equal(len(invalid_specs), 3)
 
     def test_invalid_characters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled'.split())
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 2)
+        assert_equal(len(invalid_specs), 3)
 
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -67,14 +67,14 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 3)
+        assert_equal(len(invalid_specs), 4)
 
     def test_invalid_characters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled'.split())
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 3)
+        assert_equal(len(invalid_specs), 4)
 
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())


### PR DESCRIPTION
### Background

The `panther_analsys_tool` isn't validating yaml as vigorously as the panther backed. We should add invalid yaml files to the invalid_specs when running `panther_analysis_tool test` Closes #32 

### Changes

* Added exception handling to the json.loads and yaml.safe_load calls so that any yaml or json file that fails to load will be added to the `invalid_specs` file

### Testing

* Added new invalidly formatted yaml file `example_malformed_yaml.yml` and updated tests to include additional invalid spec  
* `make test`
