### PR TITLE
print help output when running tool with no args

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -553,7 +553,8 @@ def parse_filter(filters: List[str]) -> Dict[str, Any]:
 
 def run() -> None:
     parser = setup_parser()
-    args = parser.parse_args()
+    # if no args are passed, print the help output
+    args = parser.parse_args(args=None if sys.argv[1:] else ['--help'])
 
     logging.basicConfig(format='[%(levelname)s]: %(message)s',
                         level=logging.DEBUG if args.debug else logging.INFO)


### PR DESCRIPTION
### Background

Running `panther_analysis_tool` without arguments would throw an error. This change causes it to print the help output rather than an exception.  Closes #47 

### Changes

* update to the args passed to parse_args so that if no args are passed in it will print help output. 

### Testing

* `make ci`
* manual testing

Sample Output:
```
# bin/panther_analysis_tool
usage: panther_analysis_tool [-h] [--version] {test,zip,upload} ...

Panther Analysis Tool: A command line tool for managing Panther policies and
rules.

positional arguments:
  {test,zip,upload}
    test             Validate analysis specifications and run policy and rule
                     tests.
    zip              Create an archive of local policies and rules for
                     uploading to Panther.
    upload           Upload specified policies and rules to a Panther
                     deployment.

optional arguments:
  -h, --help         show this help message and exit
  --version          show program's version number and exit
```

```
# bin/panther_analysis_tool test --path ./tests/fixtures/valid_analysis
[INFO]: Testing analysis packs in ./tests/fixtures/valid_analysis

AWS.IAM.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance

AWS.IAM.BetaTest
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance

AWS.IAM.MFAEnabled Extra Fields
	[PASS] Root MFA not enabled triggers a violation.

AWS.CloudTrail.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance
	[PASS] User MFA enabled passes compliance.
		[PASS] [dedup] test
		[PASS] [title] test does not have MFA enabled

AWS.CloudTrail.MFAEnabled Extra Fields
	[PASS] Root MFA not enabled fails compliance
	[PASS] User MFA not enabled fails compliance

--------------------------
Panther CLI Test Summary
	Path: ./tests/fixtures/valid_analysis
	Passed: 5
	Failed: 0
	Invalid: 0
```