### PR TITLE
test files current dir

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -101,7 +101,7 @@ def load_analysis_specs(directory: str) -> Iterator[Tuple[str, str, Any]]:
         # we only run folders with valid analysis files. Ensure we test
         # files in the current directory by not skipping this iteration
         # when relative_path is the current dir
-        if directory in ['.', './'] and relative_path not in [".", "./"]:
+        if directory in ['.', './'] and relative_path not in ['.', './']:
             if not any([
                     fnmatch(relative_path, path_pattern)
                     for path_pattern in (HELPERS_PATH_PATTERN,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -99,15 +99,10 @@ def load_analysis_specs(directory: str) -> Iterator[Tuple[str, str, Any]]:
     for relative_path, _, file_list in os.walk(directory):
         # If the user runs with no path/out args, filter to make sure
         # we only run folders with valid analysis files.
-        if directory == '.':
-            if not any([
-                    fnmatch(relative_path, path_pattern)
-                    for path_pattern in (HELPERS_PATH_PATTERN,
-                                         RULES_PATH_PATTERN,
-                                         POLICIES_PATH_PATTERN)
-            ]):
-                logging.debug('Skipping path %s', relative_path)
-                continue
+        if relative_path in ['.', "./"] and directory in [".", "./"]:
+            # in order to grab files in the current directory, we need to strip leading
+            # '.' from the relative path
+            relative_path = ""
         for filename in sorted(file_list):
             spec_filename = os.path.join(relative_path, filename)
             if fnmatch(filename, '*.y*ml'):

--- a/tests/fixtures/valid_analysis/rules/example_rule_extraneous_fields.yml
+++ b/tests/fixtures/valid_analysis/rules/example_rule_extraneous_fields.yml
@@ -3,7 +3,7 @@ Filename: example_rule.py
 DisplayName: MFA Rule
 Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
 Severity: High
-RuleID: AWS.CloudTrail.MFAEnabled Extra Fields
+RuleID: AWS.CloudTrail.MFAEnabled.Extra.Fields
 Enabled: true
 LogTypes:
   - AWS.CloudTrail


### PR DESCRIPTION
### Background

This updates the directory walking logic so that running the `panther_analysis_tool` will test any policies/rules in the current dir as well as those within sub directories.  Closes #41 

### Changes

* update to directory walking structure
* new test case for `--path ./` and default (no `--path` option specified)

### Testing

* `make ci` 
