### PR TITLE
non loading error

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,8 +274,8 @@ def rule(event):
 AnalysisType: rule
 Enabled: true
 Filename: example_rule.py
-PolicyID: Example.Rule.01
-ResourceTypes:
+RuleID: Example.Rule.01
+LogTypes:
   - Log.Type.Here
 Severity: Low
 DisplayName: Example Rule to Check the Format of the Spec
@@ -290,10 +290,10 @@ Tests:
     Name: Name to describe our first test.
     LogType: Log.Type.Here  # Not needed in Panther versions >= 1.6.0
     ExpectedResult: true/false
-    Resource:
-      Key: Values
-      For: Our Log
-      Based: On the Schema
+    Log:
+      {
+        "field1": "value1",
+      }
 ```
 
 The requirements for the Rule body and specification files are listed below.

--- a/tests/fixtures/example_unhandled_exception.py
+++ b/tests/fixtures/example_unhandled_exception.py
@@ -1,0 +1,2 @@
+def rule(event):
+    raise Exception

--- a/tests/fixtures/example_unhandled_exception.yml
+++ b/tests/fixtures/example_unhandled_exception.yml
@@ -1,0 +1,20 @@
+AnalysisType: rule
+Enabled: true
+Filename: example_unhandled_exception.py
+RuleID: Example.Rule.Unknown.Exception
+LogTypes:
+  - Log.Type.Here
+Severity: Low
+DisplayName: Example Rule to Check the Format of the Spec
+Tags:
+  - Tags
+Runbook: Find out who changed the spec format.
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: Name to describe our first test.
+    ExpectedResult: true
+    Log:
+      {
+        "field1": "value1",
+      }

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -116,7 +116,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 2)
+        assert_equal(len(invalid_specs), 4)
 
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -76,6 +76,13 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 1)
         assert_equal(len(invalid_specs), 2)
 
+    def test_unknown_exception(self):
+        args = pat.setup_parser().parse_args('test --path tests/fixtures --filter RuleID=Example.Rule.Unknown.Exception'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 2)
+
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())
         args.filter = pat.parse_filter(args.filter)


### PR DESCRIPTION
### Background

Validate that tests that caused an unknown exception get added to the failed test list.  Closes #29 

### Changes

* Added test case to validate exception throwing test causes `panther_analysis_tool test` to return non-zero exit 

### Testing

* `make ci`
