### PR TITLE
aws profile as a command line arg

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -202,6 +202,12 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     if return_code == 1:
         return return_code, ''
 
+    # optionally set env variable for profile passed as argument
+    # this must be called prior to setting up the client
+    if args.aws_profile is not None:
+        logging.info('Using AWS profile: %s', args.aws_profile)
+        set_env("AWS_PROFILE", args.aws_profile)
+
     client = boto3.client('lambda')
 
     with open(archive, 'rb') as analysis_zip:
@@ -524,6 +530,12 @@ def setup_parser() -> argparse.ArgumentParser:
         'upload',
         help='Upload specified policies and rules to a Panther deployment.')
     upload_parser.add_argument(
+        '--aws-profile',
+        type=str,
+        help=
+        'The AWS profile to use when uploading to an AWS Panther deployment.',
+        required=False)
+    upload_parser.add_argument(
         '--path',
         default='.',
         type=str,
@@ -567,6 +579,10 @@ def parse_filter(filters: List[str]) -> Dict[str, Any]:
             continue
         parsed_filters[key] = split[1].split(',')
     return parsed_filters
+
+
+def set_env(key: str, value: str) -> None:
+    os.environ[key] = value
 
 
 def run() -> None:

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -90,6 +90,12 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
+    def test_aws_profiles(self):
+        aws_profile = "AWS_PROFILE"
+        args = pat.setup_parser().parse_args('upload --path tests/fixtures/valid_analysis --aws-profile myprofile'.split())
+        pat.set_env(aws_profile, args.aws_profile)
+        assert_equal(args.aws_profile, os.environ.get(aws_profile))
+
     def test_invalid_rule_definition(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=Critical RuleID=AWS.CloudTrail.MFAEnabled'.split())
         args.filter = pat.parse_filter(args.filter)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -91,9 +91,10 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(len(invalid_specs), 0)
 
     def test_aws_profiles(self):
-        aws_profile = "AWS_PROFILE"
+        aws_profile = 'AWS_PROFILE'
         args = pat.setup_parser().parse_args('upload --path tests/fixtures/valid_analysis --aws-profile myprofile'.split())
         pat.set_env(aws_profile, args.aws_profile)
+        assert_equal('myprofile', args.aws_profile)
         assert_equal(args.aws_profile, os.environ.get(aws_profile))
 
     def test_invalid_rule_definition(self):


### PR DESCRIPTION
### Background

Add ability to set aws profile as a command line arg to the `upload` command.

### Changes

* new optional arg added to the upload subparser
* unit test for env variable setting

### Testing

* `make ci` 
* manual testing

Update Help Menu:
```
#  panther_analysis_tool upload --help
usage: panther_analysis_tool upload [-h] [--aws-profile AWS_PROFILE]
                                    [--path PATH] [--out OUT]
                                    [--filter KEY=VALUE [KEY=VALUE ...]]
                                    [--debug]

optional arguments:
  -h, --help            show this help message and exit
  --aws-profile AWS_PROFILE
                        The AWS profile to use when uploading to an AWS
                        Panther deployment.
  --path PATH           The relative path to Panther policies and rules.
  --out OUT             The location to store a local copy of the packaged
                        policies and rules.
  --filter KEY=VALUE [KEY=VALUE ...]
  --debug
```

Updated output:
```
# panther_analysis_tool upload --aws-profile testIdentity
...
[INFO]: Using AWS profile: testIdentity
[INFO]: Found credentials in environment variables.
[INFO]: Uploading pack to Panther
[INFO]: Upload success.
[INFO]: API Response:
{
  "modifiedGlobals": 0,
  "modifiedPolicies": 0,
  "modifiedRules": 0,
  "newGlobals": 0,
  "newPolicies": 0,
  "newRules": 0,
  "totalGlobals": 1,
  "totalPolicies": 3,
  "t
```

Unknown profile output:
```
# panther_analysis_tool upload --aws-profile doesNotExist
...
[INFO]: Using AWS profile: doesNotExist
[WARNING]: Unhandled exception: "The config profile (doesNotExist) could not be found"
```