### PR TITLE
schema wrong key error output

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -204,6 +204,12 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     if return_code == 1:
         return return_code, ''
 
+    # optionally set env variable for profile passed as argument
+    # this must be called prior to setting up the client
+    if args.aws_profile is not None:
+        logging.info('Using AWS profile: %s', args.aws_profile)
+        set_env("AWS_PROFILE", args.aws_profile)
+
     client = boto3.client('lambda')
 
     with open(archive, 'rb') as analysis_zip:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -425,7 +425,7 @@ def classify_analysis(
 def handle_wrong_key_error(err: SchemaWrongKeyError, keys: list) -> Exception:
     regex = r"Wrong key(?:s)? (.+?) in (.*)$"
     matches = re.match(regex, str(err))
-    msg = '{} not in list of valid keys: [{}]'
+    msg = '{} not in list of valid keys: {}'
     try:
         if matches:
             raise SchemaWrongKeyError(msg.format(matches.group(1),

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -33,6 +33,20 @@ class TestPantherAnalysisTool(TestCase):
         test_date_string = pat.datetime_converted(test_date)
         assert_is_instance(test_date_string, str)
 
+    def test_handle_wrong_key_error(self):
+        sample_keys = ['DisplayName', 'Enabled', 'Filename']
+        expected_output = '{} not in list of valid keys: {}'
+        # test successful regex match and correct error returned
+        test_str = "Wrong key 'DisplaName' in {'DisplaName':'one','Enabled':true, 'Filename':'sample'}"
+        exc = Exception(test_str)
+        err = pat.handle_wrong_key_error(exc, sample_keys)
+        assert_equal(str(err), expected_output.format("'DisplaName'", sample_keys))
+        # test failing regex match
+        test_str = "Will not match"
+        exc = Exception(test_str)
+        err = pat.handle_wrong_key_error(exc, sample_keys)
+        assert_equal(str(err),  expected_output.format("UNKNOWN_KEY", sample_keys))
+
     def test_load_policy_specs_from_folder(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures'.split())
         return_code, invalid_specs = pat.test_analysis(args)


### PR DESCRIPTION
### Background

`SchemaWrongKeyError` output can be extremely verbose.  Simplify the output by showing exactly what key triggered the error and what keys are expected.  Closes #42 

### Changes

* Catching the particular exception and handling it separately than the other schema-related errors.
* Unit test for new method.

### Testing

* `make ci` 
* manual test

Updated Output:

```
Invalid Tests Summary
        ./tests/fixtures/valid_analysis/rules/example_rule.yml
                'DisplyName', 'Referece' not in list of valid keys: [['AnalysisType', 'Enabled', 'Filename', 'RuleID', 'LogTypes', 
'Severity', Optional('Description'), Optional('DedupPeriodMinutes'), Optional('DisplayName'), Optional('OutputIds'), 
Optional('Reference'), Optional('Runbook'), Optional('SummaryAttributes'), Optional('Suppressions'), Optional('Threshold'), 
Optional('Tags'), Optional('Reports'), Optional('Tests')]]

[ERROR]: [('./tests/fixtures/valid_analysis/rules/example_rule.yml', SchemaWrongKeyError("'DisplyName', 'Referece' not in 
list of valid keys: [['AnalysisType', 'Enabled', 'Filename', 'RuleID', 'LogTypes', 'Severity', Optional('Description'), 
Optional('DedupPeriodMinutes'), Optional('DisplayName'), Optional('OutputIds'), Optional('Reference'), 
Optional('Runbook'), Optional('SummaryAttributes'), Optional('Suppressions'), Optional('Threshold'), Optional('Tags'), 
Optional('Reports'), Optional('Tests')]]"))]
```
