### PR TITLE
spec loading multiple times

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -272,7 +272,7 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
                     'statusCode') != 200:
                 logging.warning(
                     'Failed to upload to Panther\n\tstatus code: %s\n\terror message: %s',
-                    response_payload['statusCode'], response_payload['body'])
+                    response_payload.get('statusCode', 0), response_payload.get('errorMessage', response_payload.get('body')))
                 return 1, ''
 
         body = json.loads(response_payload['body'])

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -272,7 +272,9 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
                     'statusCode') != 200:
                 logging.warning(
                     'Failed to upload to Panther\n\tstatus code: %s\n\terror message: %s',
-                    response_payload.get('statusCode', 0), response_payload.get('errorMessage', response_payload.get('body')))
+                    response_payload.get('statusCode', 0),
+                    response_payload.get('errorMessage',
+                                         response_payload.get('body')))
                 return 1, ''
 
         body = json.loads(response_payload['body'])

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -87,7 +87,8 @@ def load_module(filename: str) -> Tuple[Any, Any]:
     return module, None
 
 
-def load_analysis_specs(directory: str) -> Iterator[Tuple[str, str, Any, Any]]:
+def load_analysis_specs(
+        directories: List[str]) -> Iterator[Tuple[str, str, Any, Any]]:
     """Loads the analysis specifications from a file.
 
     Args:
@@ -96,40 +97,49 @@ def load_analysis_specs(directory: str) -> Iterator[Tuple[str, str, Any, Any]]:
     Yields:
         A tuple of the relative filepath, directory name, and loaded analysis specification dict.
     """
-    for relative_path, _, file_list in os.walk(directory):
-        # setup yaml object
-        yaml = YAML(typ='safe')
-        # If the user runs with no path args, filter to make sure
-        # we only run folders with valid analysis files. Ensure we test
-        # files in the current directory by not skipping this iteration
-        # when relative_path is the current dir
-        if directory in ['.', './'] and relative_path not in ['.', './']:
-            if not any([
-                    fnmatch(relative_path, path_pattern) for path_pattern in (
-                        DATA_MODEL_PATH_PATTERN, HELPERS_PATH_PATTERN,
-                        RULES_PATH_PATTERN, POLICIES_PATH_PATTERN)
-            ]):
-                logging.debug('Skipping path %s', relative_path)
-                continue
-        for filename in sorted(file_list):
-            spec_filename = os.path.join(relative_path, filename)
-            if fnmatch(filename, '*.y*ml'):
-                with open(spec_filename, 'r') as spec_file_obj:
-                    try:
-                        yield spec_filename, relative_path, yaml.load(
-                            spec_file_obj), None
-                    except (YAMLParser.ParserError,
-                            YAMLScanner.ScannerError) as err:
-                        # recreate the yaml object and yeild the error
-                        yaml = YAML(typ='safe')
-                        yield spec_filename, relative_path, None, err
-            if fnmatch(filename, '*.json'):
-                with open(spec_filename, 'r') as spec_file_obj:
-                    try:
-                        yield spec_filename, relative_path, json.load(
-                            spec_file_obj), None
-                    except ValueError as err:
-                        yield spec_filename, relative_path, None, err
+    # setup a list of paths to ensure we do not import the same files
+    # multiple times, which can happen when testing from root directory without filters
+    loaded_specs = []
+    for directory in directories:
+        for relative_path, _, file_list in os.walk(directory):
+            # setup yaml object
+            yaml = YAML(typ='safe')
+            # If the user runs with no path args, filter to make sure
+            # we only run folders with valid analysis files. Ensure we test
+            # files in the current directory by not skipping this iteration
+            # when relative_path is the current dir
+            if directory in ['.', './'] and relative_path not in ['.', './']:
+                if not any([
+                        fnmatch(relative_path, path_pattern)
+                        for path_pattern in (
+                            DATA_MODEL_PATH_PATTERN, HELPERS_PATH_PATTERN,
+                            RULES_PATH_PATTERN, POLICIES_PATH_PATTERN)
+                ]):
+                    logging.debug('Skipping path %s', relative_path)
+                    continue
+            for filename in sorted(file_list):
+                spec_filename = os.path.join(relative_path, filename)
+                # skip loading files that have already been imported
+                if spec_filename in loaded_specs:
+                    continue
+                loaded_specs.append(spec_filename)
+                if fnmatch(filename, '*.y*ml'):
+                    with open(spec_filename, 'r') as spec_file_obj:
+                        try:
+                            yield spec_filename, relative_path, yaml.load(
+                                spec_file_obj), None
+                        except (YAMLParser.ParserError,
+                                YAMLScanner.ScannerError) as err:
+                            # recreate the yaml object and yeild the error
+                            yaml = YAML(typ='safe')
+                            yield spec_filename, relative_path, None, err
+                if fnmatch(filename, '*.json'):
+                    with open(spec_filename, 'r') as spec_file_obj:
+                        try:
+                            yield spec_filename, relative_path, json.load(
+                                spec_file_obj), None
+                        except ValueError as err:
+                            yield spec_filename, relative_path, None, err
 
 
 def datetime_converted(obj: Any) -> Any:
@@ -172,10 +182,9 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
         # Always zip the helpers and data models
         analysis = []
         files: Set[str] = set()
-        for (file_name, f_path, spec,
-             _) in list(load_analysis_specs(args.path)) + list(
-                 load_analysis_specs(HELPERS_LOCATION)) + list(
-                     load_analysis_specs(DATA_MODEL_LOCATION)):
+        for (file_name, f_path, spec, _) in list(
+                load_analysis_specs(
+                    [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION])):
             if file_name not in files:
                 analysis.append((file_name, f_path, spec))
                 files.add(file_name)
@@ -267,9 +276,9 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
 
     # First classify each file, always include globals and data models location
     data_models, global_analysis, analysis, invalid_specs = classify_analysis(
-        list(load_analysis_specs(args.path)) +
-        list(load_analysis_specs(HELPERS_LOCATION)) +
-        list(load_analysis_specs(DATA_MODEL_LOCATION)))
+        list(
+            load_analysis_specs(
+                [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION])))
 
     if all(len(x) == 0 for x in [data_models, global_analysis, analysis]):
         if len(invalid_specs) > 0:

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.4.0',
+    version='0.4.1',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.4.0.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.4.1.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[


### PR DESCRIPTION
### Background

The tool tries to be helpful by always including globals/data models, but this can cause them to be imported multiple times when running in current directory(imports both ./global_helpers and *global_helpers*) Because it imports multiple times and the latest release does more strict checking of analysis IDs - this will cause running `test` against the panther-analysis repo to fail.  

Update to upload payload format to take into account the new analysis-api

### Changes

* Check that each file imported is unique
* upload payload update, try old format if new format fails

### Testing

* `make ci` 
* run test in the panther-analysis repo: `python ../panther_analysis_tool/panther_analysis_tool/main.py test`
* confirmed upload to both panther v1.13.0 and v1.14.0 analysis-api works