### PR TITLE
hidden error message

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -243,8 +243,7 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
         response_str = response['Payload'].read().decode('utf-8')
         response_payload = json.loads(response_str)
 
-        if response_payload.get(
-                'errorMessage') or response_payload.get('statusCode') != 200:
+        if response_payload.get('errorMessage'):
             # try deprecated version, using analysis-api gateway
             deprecated_payload = {
                 'resource':
@@ -268,14 +267,14 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
             response_str = response['Payload'].read().decode('utf-8')
             response_payload = json.loads(response_str)
 
-            if response_payload.get('errorMessage') or response_payload.get(
-                    'statusCode') != 200:
-                logging.warning(
-                    'Failed to upload to Panther\n\tstatus code: %s\n\terror message: %s',
-                    response_payload.get('statusCode', 0),
-                    response_payload.get('errorMessage',
-                                         response_payload.get('body')))
-                return 1, ''
+        if  response_payload.get('errorMessage') or response_payload.get(
+                'statusCode') != 200:
+            logging.warning(
+                'Failed to upload to Panther\n\tstatus code: %s\n\terror message: %s',
+                response_payload.get('statusCode', 0),
+                response_payload.get('errorMessage',
+                                        response_payload.get('body')))
+            return 1, ''
 
         body = json.loads(response_payload['body'])
         logging.info('Upload success.')

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -267,13 +267,13 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
             response_str = response['Payload'].read().decode('utf-8')
             response_payload = json.loads(response_str)
 
-        if  response_payload.get('errorMessage') or response_payload.get(
-                'statusCode') != 200:
+        if response_payload.get(
+                'errorMessage') or response_payload.get('statusCode') != 200:
             logging.warning(
                 'Failed to upload to Panther\n\tstatus code: %s\n\terror message: %s',
                 response_payload.get('statusCode', 0),
                 response_payload.get('errorMessage',
-                                        response_payload.get('body')))
+                                     response_payload.get('body')))
             return 1, ''
 
         body = json.loads(response_payload['body'])

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -243,32 +243,7 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
         response_str = response['Payload'].read().decode('utf-8')
         response_payload = json.loads(response_str)
 
-        if response_payload.get('errorMessage'):
-            # try deprecated version, using analysis-api gateway
-            deprecated_payload = {
-                'resource':
-                    '/upload',
-                'HTTPMethod':
-                    'POST',
-                'Body':
-                    json.dumps({
-                        'Data': base64.b64encode(zip_bytes).decode('utf-8'),
-                        # The UserID is required by Panther for this API call, but we have
-                        # no way of acquiring it and it isn't used for anything. This is a
-                        # valid UUID used by the Panther deployment tool to indicate this
-                        # action was performed automatically.
-                        'UserID': '00000000-0000-4000-8000-000000000000',
-                    }),
-            }
-            response = client.invoke(FunctionName='panther-analysis-api',
-                                     InvocationType='RequestResponse',
-                                     LogType='None',
-                                     Payload=json.dumps(deprecated_payload))
-            response_str = response['Payload'].read().decode('utf-8')
-            response_payload = json.loads(response_str)
-
-        if response_payload.get(
-                'errorMessage') or response_payload.get('statusCode') != 200:
+        if response_payload.get('statusCode') != 200:
             logging.warning(
                 'Failed to upload to Panther\n\tstatus code: %s\n\terror message: %s',
                 response_payload.get('statusCode', 0),


### PR DESCRIPTION
### Background

In adding support for both the older and newer version of the `analysis-api` - if an error was returned from the new version it was hidden because it automatically re-tried the upload using the old format. This removes support for the old format, as users can choose which version of the `pat` to use based on what version of `panther` they have deployed. 

### Changes

* removed support for the old format

### Testing

* `make ci`
* manual testing
