### PR TITLE
Continue if one global fails

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -610,7 +610,7 @@ def setup_parser() -> argparse.ArgumentParser:
         prog='panther_analysis_tool')
     parser.add_argument('--version',
                         action='version',
-                        version='panther_analysis_tool 0.4.3')
+                        version='panther_analysis_tool 0.4.4')
     subparsers = parser.add_subparsers()
 
     test_parser = subparsers.add_parser(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -322,7 +322,7 @@ def setup_global_helpers(global_analysis: List[Any]) -> List[Any]:
         # If the module could not be loaded, continue to the next
         if load_err:
             invalid_specs.append((analysis_spec_filename, load_err))
-            break
+            continue
         sys.modules[analysis_id] = module
     return invalid_specs
 

--- a/setup.py
+++ b/setup.py
@@ -2,14 +2,14 @@ from distutils.core import setup
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.4.3',
+    version='0.4.4',
     license='apache-2.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.4.3.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.4.4.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=[


### PR DESCRIPTION
### Background

Currently, if one global helper fails to load we stop loading any further global helpers. Instead, we should keep loading each global helper that we can load.

### Changes

* Keep loading global helpers even if one fails to load 

### Testing

* Tested in `panther-analysis` with one global that failed to load. Previous to this change multiple other globals were skipped, with this change only the failing global was skipped
