### PR TITLE
include data model when filtering

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -433,6 +433,11 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
                           os.path.join(file_name))
             filtered_analysis.append((file_name, dir_name, analysis_spec))
             continue
+        elif fnmatch(dir_name, DATA_MODEL_LOCATION):
+            logging.debug('auto-adding data model file %s',
+                          os.path.join(file_name))
+            filtered_analysis.append((file_name, dir_name, analysis_spec))
+            continue
         match = True
         for key, values in filters.items():
             spec_value = analysis_spec.get(key, "")

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -433,7 +433,7 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
                           os.path.join(file_name))
             filtered_analysis.append((file_name, dir_name, analysis_spec))
             continue
-        elif fnmatch(dir_name, DATA_MODEL_LOCATION):
+        if fnmatch(dir_name, DATA_MODEL_LOCATION):
             logging.debug('auto-adding data model file %s',
                           os.path.join(file_name))
             filtered_analysis.append((file_name, dir_name, analysis_spec))


### PR DESCRIPTION
### Background

In creating a zip to upload using a filter, found that data models are not automatically included when a `--filter` is specified.  
### Changes

* automatically include data models in `filter_analsyis`

### Testing

* manual testing:
Before (`panther_analysis_tool test --filter Tags=mytag`):
```
--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 221
        Failed: 2
        Invalid: 0

--------------------------
Failed Tests Summary
        Standard.AdminRoleAssigned
                ['GCP - Admin Assigned', 'GSuite - Privileges Assigned', 'OneLogin - Super user permissions assigned']

        Standard.BruteForceByIP
                ['AWS.CloudTrail - Failed Login', 'Box - Login Failed', 'GSuite - Failed Login Event', 'Okta - Failed Login', 'OneLogin - Failed Login Event']
```

After(`python ../panther_analysis_tool/panther_analysis_tool/main.py test --filter Tags=mytag`):

```
--------------------------
Panther CLI Test Summary
        Path: .
        Passed: 223
        Failed: 0
        Invalid: 0
 ```
