### PR TITLE
Add subcommand to update managed schemas

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -87,8 +87,8 @@ def load_module(filename: str) -> Tuple[Any, Any]:
     return module, None
 
 
-def load_analysis_specs(
-        directories: List[str]) -> Iterator[Tuple[str, str, Any, Any]]:
+def load_analysis_specs(directories: List[str]
+                       ) -> Iterator[Tuple[str, str, Any, Any]]:
     """Loads the analysis specifications from a file.
 
     Args:
@@ -258,6 +258,7 @@ def upload_analysis(args: argparse.Namespace) -> Tuple[int, str]:
 
     return 0, ''
 
+
 def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
     """Updates managed schemas in a Panther deployment.
 
@@ -279,18 +280,16 @@ def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
     client = boto3.client('lambda')
     logging.info('Fetching updates')
     response = client.invoke(FunctionName='panther-logtypes-api',
-            InvocationType='RequestResponse',
-            Payload=json.dumps({
-                'ListManagedSchemaUpdates': {}
-            }))
+                             InvocationType='RequestResponse',
+                             Payload=json.dumps(
+                                 {'ListManagedSchemaUpdates': {}}))
     response_str = response['Payload'].read().decode('utf-8')
     response_payload = json.loads(response_str)
     api_err = response_payload['error']
     if api_err is not None:
         logging.error(
-                'Failed to list managed schema updates\n\tcode: %s\n\terror message: %s',
-                api_err['code'],
-                api_err['message'])
+            'Failed to list managed schema updates\n\tcode: %s\n\terror message: %s',
+            api_err['code'], api_err['message'])
         return 1, ''
     releases = response_payload['releases']
     if releases is None:
@@ -298,30 +297,29 @@ def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
         return 0, ''
     print('Available versions:')
     for (i, release) in enumerate(releases):
-        print('%d: %s'%(i,release.get('tag')))
+        print('%d: %s' % (i, release.get('tag')))
     choice = int(input('choose which version to install: '))
     chosen = releases[choice]
 
     response = client.invoke(FunctionName='panther-logtypes-api',
-            InvocationType='RequestResponse',
-            Payload=json.dumps({
-                'UpdateManagedSchemas': {
-                    'release': chosen.get('tag'),
-                    'manifestURL': chosen.get('manifestURL')
-                }
-            }))
+                             InvocationType='RequestResponse',
+                             Payload=json.dumps({
+                                 'UpdateManagedSchemas': {
+                                     'release': chosen.get('tag'),
+                                     'manifestURL': chosen.get('manifestURL')
+                                 }
+                             }))
     response_str = response['Payload'].read().decode('utf-8')
     response_payload = json.loads(response_str)
     api_err = response_payload['error']
     if api_err is not None:
         logging.error(
-                'Failed to submit managed schema update to %s\n\tcode: %s\n\terror message: %s',
-                chosen.get('tag'),
-                api_err['code'],
-                api_err['message'])
+            'Failed to submit managed schema update to %s\n\tcode: %s\n\terror message: %s',
+            chosen.get('tag'), api_err['code'], api_err['message'])
         return 1, ''
     logging.info('Managed schemas updated successfully')
     return 0, ''
+
 
 def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     """Imports each policy or rule and runs their tests.
@@ -391,8 +389,8 @@ def setup_global_helpers(global_analysis: List[Any]) -> List[Any]:
     return invalid_specs
 
 
-def setup_data_models(
-        data_models: List[Any]) -> Tuple[Dict[str, DataModel], List[Any]]:
+def setup_data_models(data_models: List[Any]
+                     ) -> Tuple[Dict[str, DataModel], List[Any]]:
     invalid_specs = []
     # log_type_to_data_model is a dict used to map LogType to a unique
     # data model, ensuring there is at most one DataModel per LogType
@@ -426,9 +424,9 @@ def setup_data_models(
     return log_type_to_data_model, invalid_specs
 
 
-def setup_run_tests(
-        log_type_to_data_model: Dict[str, DataModel], analysis: List[Any],
-        minimum_tests: int) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
+def setup_run_tests(log_type_to_data_model: Dict[str, DataModel],
+                    analysis: List[Any], minimum_tests: int
+                   ) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
     invalid_specs = []
     failed_tests: DefaultDict[str, list] = defaultdict(list)
     for analysis_spec_filename, dir_name, analysis_spec in analysis:
@@ -517,9 +515,8 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
     return filtered_analysis
 
 
-def classify_analysis(
-    specs: List[Tuple[str, str, Any, Any]]
-) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
+def classify_analysis(specs: List[Tuple[str, str, Any, Any]]
+                     ) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
 
     # First determine the type of each file
     data_models = []
@@ -680,6 +677,7 @@ def setup_parser() -> argparse.ArgumentParser:
     parser.add_argument('--version',
                         action='version',
                         version='panther_analysis_tool 0.4.5')
+    parser.add_argument('--debug', action='store_true', dest='debug')
     subparsers = parser.add_subparsers()
 
     test_parser = subparsers.add_parser(
@@ -704,7 +702,6 @@ def setup_parser() -> argparse.ArgumentParser:
         +
         'greater than 1 is specified, at least one True and one False test is required.',
         required=False)
-    test_parser.add_argument('--debug', action='store_true', dest='debug')
     test_parser.set_defaults(func=test_analysis)
 
     zip_parser = subparsers.add_parser(
@@ -737,7 +734,6 @@ def setup_parser() -> argparse.ArgumentParser:
         +
         'greater than 1 is specified, at least one True and one False test is required.',
         required=False)
-    zip_parser.add_argument('--debug', action='store_true', dest='debug')
     zip_parser.add_argument('--skip-tests',
                             action='store_true',
                             dest='skip_tests')
@@ -778,21 +774,20 @@ def setup_parser() -> argparse.ArgumentParser:
                                required=False,
                                metavar="KEY=VALUE",
                                nargs='+')
-    upload_parser.add_argument('--debug', action='store_true', dest='debug')
     upload_parser.add_argument('--skip-tests',
                                action='store_true',
                                dest='skip_tests')
     upload_parser.set_defaults(func=upload_analysis)
 
     update_schemas_parser = subparsers.add_parser(
-            'update-schemas',
-            help='Update managed schemas on a Panther deployment.')
-    update_schemas.add_argument(
+        'update-schemas',
+        help='Update managed schemas on a Panther deployment.')
+    update_schemas_parser.add_argument(
         '--aws-profile',
         type=str,
         help='The AWS profile to use when updating the AWS Panther deployment.',
         required=False)
-    update_schemas.set_defaults(func=update_schemas)
+    update_schemas_parser.set_defaults(func=update_schemas)
     return parser
 
 
@@ -831,9 +826,10 @@ def run() -> None:
     logging.basicConfig(format='[%(levelname)s]: %(message)s',
                         level=logging.DEBUG if args.debug else logging.INFO)
 
+    if hasattr(args, 'filter') and args.filter is not None:
+        args.filter = parse_filter(args.filter)
+
     try:
-        if args.filter is not None:
-            args.filter = parse_filter(args.filter)
         return_code, out = args.func(args)
     except Exception as err:  # pylint: disable=broad-except
         # Catch arbitrary exceptions without printing help message

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -87,8 +87,8 @@ def load_module(filename: str) -> Tuple[Any, Any]:
     return module, None
 
 
-def load_analysis_specs(directories: List[str]
-                       ) -> Iterator[Tuple[str, str, Any, Any]]:
+def load_analysis_specs(
+        directories: List[str]) -> Iterator[Tuple[str, str, Any, Any]]:
     """Loads the analysis specifications from a file.
 
     Args:
@@ -404,8 +404,8 @@ def setup_global_helpers(global_analysis: List[Any]) -> List[Any]:
     return invalid_specs
 
 
-def setup_data_models(data_models: List[Any]
-                     ) -> Tuple[Dict[str, DataModel], List[Any]]:
+def setup_data_models(
+        data_models: List[Any]) -> Tuple[Dict[str, DataModel], List[Any]]:
     invalid_specs = []
     # log_type_to_data_model is a dict used to map LogType to a unique
     # data model, ensuring there is at most one DataModel per LogType
@@ -439,9 +439,9 @@ def setup_data_models(data_models: List[Any]
     return log_type_to_data_model, invalid_specs
 
 
-def setup_run_tests(log_type_to_data_model: Dict[str, DataModel],
-                    analysis: List[Any], minimum_tests: int
-                   ) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
+def setup_run_tests(
+        log_type_to_data_model: Dict[str, DataModel], analysis: List[Any],
+        minimum_tests: int) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
     invalid_specs = []
     failed_tests: DefaultDict[str, list] = defaultdict(list)
     for analysis_spec_filename, dir_name, analysis_spec in analysis:
@@ -530,8 +530,9 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
     return filtered_analysis
 
 
-def classify_analysis(specs: List[Tuple[str, str, Any, Any]]
-                     ) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
+def classify_analysis(
+    specs: List[Tuple[str, str, Any, Any]]
+) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
 
     # First determine the type of each file
     data_models = []

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -304,9 +304,8 @@ def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
         print('Available versions:')
         for tag in tags:
             print('\t%s' % tag)
-            print(
-                'Panther will update managed schemas to the latest version (%s)'
-                % tag)
+        print('Panther will update managed schemas to the latest version (%s)' %
+              tag)
 
         prompt = 'Choose a different version ({0}): '.format(latest_tag)
         choice = input(prompt).strip() or latest_tag  # nosec

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -87,8 +87,8 @@ def load_module(filename: str) -> Tuple[Any, Any]:
     return module, None
 
 
-def load_analysis_specs(directories: List[str]
-                       ) -> Iterator[Tuple[str, str, Any, Any]]:
+def load_analysis_specs(
+        directories: List[str]) -> Iterator[Tuple[str, str, Any, Any]]:
     """Loads the analysis specifications from a file.
 
     Args:
@@ -405,8 +405,8 @@ def setup_global_helpers(global_analysis: List[Any]) -> List[Any]:
     return invalid_specs
 
 
-def setup_data_models(data_models: List[Any]
-                     ) -> Tuple[Dict[str, DataModel], List[Any]]:
+def setup_data_models(
+        data_models: List[Any]) -> Tuple[Dict[str, DataModel], List[Any]]:
     invalid_specs = []
     # log_type_to_data_model is a dict used to map LogType to a unique
     # data model, ensuring there is at most one DataModel per LogType
@@ -440,9 +440,9 @@ def setup_data_models(data_models: List[Any]
     return log_type_to_data_model, invalid_specs
 
 
-def setup_run_tests(log_type_to_data_model: Dict[str, DataModel],
-                    analysis: List[Any], minimum_tests: int
-                   ) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
+def setup_run_tests(
+        log_type_to_data_model: Dict[str, DataModel], analysis: List[Any],
+        minimum_tests: int) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
     invalid_specs = []
     failed_tests: DefaultDict[str, list] = defaultdict(list)
     for analysis_spec_filename, dir_name, analysis_spec in analysis:
@@ -531,8 +531,9 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
     return filtered_analysis
 
 
-def classify_analysis(specs: List[Tuple[str, str, Any, Any]]
-                     ) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
+def classify_analysis(
+    specs: List[Tuple[str, str, Any, Any]]
+) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
 
     # First determine the type of each file
     data_models = []

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -169,7 +169,7 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     """
     if not args.skip_tests:
         return_code, _ = test_analysis(args)
-        if return_code == 1:
+        if return_code != 0:
             return return_code, ''
 
     logging.info('Zipping analysis packs in %s to %s', args.path, args.out)
@@ -355,7 +355,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
             load_analysis_specs(
                 [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION])))
 
-    if all([data_models, global_analysis, analysis]):
+    if not any([data_models, global_analysis, analysis]):
         if invalid_specs:
             return 1, invalid_specs
         return 1, ["Nothing to test in {}".format(args.path)]
@@ -365,7 +365,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     global_analysis = filter_analysis(global_analysis, args.filter)
     analysis = filter_analysis(analysis, args.filter)
 
-    if all([data_models, global_analysis, analysis]):
+    if not any([data_models, global_analysis, analysis]):
         return 1, [
             "No analyses in {} matched filters {}".format(
                 args.path, args.filter)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -304,10 +304,11 @@ def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
         print('Available versions:')
         for tag in tags:
             print('\t%s' % tag)
-        print('Panther will update managed schemas to the latest version (%s)' %
-              tag)
-        prompt = 'Choose a different version (%s): '.format(tag)
+            print(
+                'Panther will update managed schemas to the latest version (%s)'
+                % tag)
 
+        prompt = 'Choose a different version ({0}): '.format(latest_tag)
         choice = input(prompt).strip() or latest_tag  # nosec
         if choice in tags:
             break
@@ -354,8 +355,8 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
             load_analysis_specs(
                 [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION])))
 
-    if all(len(x) == 0 for x in [data_models, global_analysis, analysis]):
-        if len(invalid_specs) > 0:
+    if all([data_models, global_analysis, analysis]):
+        if invalid_specs:
             return 1, invalid_specs
         return 1, ["Nothing to test in {}".format(args.path)]
 
@@ -364,7 +365,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     global_analysis = filter_analysis(global_analysis, args.filter)
     analysis = filter_analysis(analysis, args.filter)
 
-    if all(len(x) == 0 for x in [data_models, global_analysis, analysis]):
+    if all([data_models, global_analysis, analysis]):
         return 1, [
             "No analyses in {} matched filters {}".format(
                 args.path, args.filter)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -87,8 +87,8 @@ def load_module(filename: str) -> Tuple[Any, Any]:
     return module, None
 
 
-def load_analysis_specs(
-        directories: List[str]) -> Iterator[Tuple[str, str, Any, Any]]:
+def load_analysis_specs(directories: List[str]
+                       ) -> Iterator[Tuple[str, str, Any, Any]]:
     """Loads the analysis specifications from a file.
 
     Args:
@@ -294,12 +294,12 @@ def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
         return 1, ''
 
     releases = response_payload.get('releases')
-    if releases is None or len(releases) is 0:
+    if not releases:
         logging.info('No updates available.')
         return 0, ''
 
     tags = [r.get('tag') for r in releases]
-    tagLatest = tags[-1]
+    latest_tag = tags[-1]
     while True:
         print('Available versions:')
         for tag in tags:
@@ -308,20 +308,20 @@ def update_schemas(args: argparse.Namespace) -> Tuple[int, str]:
               tag)
         prompt = 'Choose a different version (%s): '.format(tag)
 
-        choice = input(prompt).strip() or tagLatest  # nosec
+        choice = input(prompt).strip() or latest_tag  # nosec
         if choice in tags:
             break
         else:
             logging.error('Chosen tag %s is not valid', choice)
 
-    manifestURL = releases[tags.index(choice)].get('manifestURL')
+    manifest_url = releases[tags.index(choice)].get('manifestURL')
 
     response = client.invoke(FunctionName='panther-logtypes-api',
                              InvocationType='RequestResponse',
                              Payload=json.dumps({
                                  'UpdateManagedSchemas': {
                                      'release': choice,
-                                     'manifestURL': manifestURL
+                                     'manifestURL': manifest_url
                                  }
                              }))
     response_str = response['Payload'].read().decode('utf-8')
@@ -404,8 +404,8 @@ def setup_global_helpers(global_analysis: List[Any]) -> List[Any]:
     return invalid_specs
 
 
-def setup_data_models(
-        data_models: List[Any]) -> Tuple[Dict[str, DataModel], List[Any]]:
+def setup_data_models(data_models: List[Any]
+                     ) -> Tuple[Dict[str, DataModel], List[Any]]:
     invalid_specs = []
     # log_type_to_data_model is a dict used to map LogType to a unique
     # data model, ensuring there is at most one DataModel per LogType
@@ -439,9 +439,9 @@ def setup_data_models(
     return log_type_to_data_model, invalid_specs
 
 
-def setup_run_tests(
-        log_type_to_data_model: Dict[str, DataModel], analysis: List[Any],
-        minimum_tests: int) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
+def setup_run_tests(log_type_to_data_model: Dict[str, DataModel],
+                    analysis: List[Any], minimum_tests: int
+                   ) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
     invalid_specs = []
     failed_tests: DefaultDict[str, list] = defaultdict(list)
     for analysis_spec_filename, dir_name, analysis_spec in analysis:
@@ -530,9 +530,8 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
     return filtered_analysis
 
 
-def classify_analysis(
-    specs: List[Tuple[str, str, Any, Any]]
-) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
+def classify_analysis(specs: List[Tuple[str, str, Any, Any]]
+                     ) -> Tuple[List[Any], List[Any], List[Any], List[Any]]:
 
     # First determine the type of each file
     data_models = []
@@ -842,7 +841,7 @@ def run() -> None:
     logging.basicConfig(format='[%(levelname)s]: %(message)s',
                         level=logging.DEBUG if args.debug else logging.INFO)
 
-    if hasattr(args, 'filter') and args.filter is not None:
+    if getattr(args, 'filter', None) is not None:
         args.filter = parse_filter(args.filter)
 
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,7 +26,6 @@ jmespath==0.10.0
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
--e git+git@github.com:panther-labs/panther_analysis_tool.git@95e3ff2806676faa6098d6e0ef2365a50ed4d902#egg=panther_analysis_tool
 pbr==5.5.1
 ply==3.11
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,22 +1,24 @@
 # functional dependencies
-boto3==1.16.35
+boto3==1.17.5
 jsonpath-ng==1.5.2
 ruamel.yaml==0.16.12
-schema==0.7.2
+schema==0.7.4
 # ci dependencies
 bandit==1.7.0
-mypy==0.790
+mypy==0.800
 pylint==2.6.0
-pyfakefs==4.3.2
+pyfakefs==4.3.3
 yapf==0.30.0
 nose==1.3.7
-PyYAML==5.3.1
+PyYAML==5.4.1
 ## The following requirements were added by pip freeze:
 astroid==2.4.2
-botocore==1.19.35
+botocore==1.20.5
 contextlib2==0.6.0.post1
+ddt==1.2.1
 decorator==4.4.2
 gitdb==4.0.5
+gitdb2==2.0.5
 GitPython==3.1.11
 importlib-metadata==3.3.0
 isort==5.6.4
@@ -24,6 +26,7 @@ jmespath==0.10.0
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
+-e git+git@github.com:panther-labs/panther_analysis_tool.git@95e3ff2806676faa6098d6e0ef2365a50ed4d902#egg=panther_analysis_tool
 pbr==5.5.1
 ply==3.11
 python-dateutil==2.8.1
@@ -31,6 +34,7 @@ ruamel.yaml.clib==0.2.2
 s3transfer==0.3.3
 six==1.15.0
 smmap==3.0.4
+smmap2==2.0.5
 stevedore==3.3.0
 toml==0.10.2
 typed-ast==1.4.1


### PR DESCRIPTION
### Background

Closes [this issue](https://github.com/panther-labs/panther/issues/2639) 
We want to implement a CLI way to update managed schemas until FE team picks up the task to expose the functionality in the UI.

### Changes

* Adds `update-schemas` sub-command to fetch the available updates and choose the version to install

### Testing

* Ran the task against a deployed Panther version
