### PR TITLE
Add zip-schemas command to Panther analysis tool to streamline the release process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,5 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+
+.vim/

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -843,7 +843,8 @@ def zip_managed_schemas(args: argparse.Namespace) -> Tuple[int, str]:
         repo_url = "https://github.com/panther-labs/panther-analysis"
         repo_dir = os.path.join(tmp_dir, "panther-analysis")
 
-        logging.info("Cloning %s tag of %s %s", args.release, repo_url, repo_dir)
+        logging.info("Cloning %s tag of %s %s", args.release, repo_url,
+                     repo_dir)
         result = subprocess.run([
             "git", "clone", "--branch", args.release, "--depth", "1", "-c",
             "advice.detachedHead=false", repo_url, repo_dir

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -862,14 +862,14 @@ def zip_managed_schemas(args: argparse.Namespace) -> Tuple[int, str]:
                           args.release)
             return 1, ""
 
-        logging.info('Building manifest.yml for %d managed schemas found in release %s',
-                     len(filenames), args.release)
+        logging.info(
+            'Building manifest.yml for %d managed schemas found in release %s',
+            len(filenames), args.release)
         for filename in filenames:
             with open(filename) as f:
                 lines = f.readlines()
                 manifest.append("---\n")
                 manifest.extend(lines)
-
 
     archive = os.path.join(args.out,
                            'managed-schemas-{}.zip'.format(args.release))

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -843,7 +843,7 @@ def zip_managed_schemas(args: argparse.Namespace) -> Tuple[int, str]:
         repo_url = "https://github.com/panther-labs/panther-analysis"
         repo_dir = os.path.join(tmp_dir, "panther-analysis")
 
-        logging.info("Cloning %s tag of %s", args.release, repo_url, repo_dir)
+        logging.info("Cloning %s tag of %s %s", args.release, repo_url, repo_dir)
         result = subprocess.run([
             "git", "clone", "--branch", args.release, "--depth", "1", "-c",
             "advice.detachedHead=false", repo_url, repo_dir

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -849,7 +849,7 @@ def zip_managed_schemas(args: argparse.Namespace) -> Tuple[int, str]:
             logging.error("Invalid release tag %s", rel)
             return 1, ""
 
-        logging.info("Cloning %s tag of %s %s", rel, repo_url, repo_dir)
+        logging.info("Cloning %s tag of %s", rel, repo_url)
         # nosec
         cmd = [
             "git", "clone", "--branch", rel, "--depth", "1", "-c",

--- a/panther_analysis_tool/test_case.py
+++ b/panther_analysis_tool/test_case.py
@@ -41,7 +41,7 @@ class TestCase(Mapping):
     def __getitem__(self, arg: str) -> Any:
         return self._data.get(arg, None)
 
-    def __contains__(self, key: str) -> bool:
+    def __contains__(self, key: object) -> bool:
         return key in self._data
 
     def __iter__(self) -> Iterator:

--- a/requirements-top-level.txt
+++ b/requirements-top-level.txt
@@ -3,6 +3,7 @@ boto3
 jsonpath-ng
 ruamel.yaml
 schema
+semver
 # ci dependencies
 bandit
 mypy

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ boto3==1.17.5
 jsonpath-ng==1.5.2
 ruamel.yaml==0.16.12
 schema==0.7.4
+semver==2.13.0
 # ci dependencies
 bandit==1.7.0
 mypy==0.800
@@ -26,6 +27,7 @@ jmespath==0.10.0
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
+-e git+git@github.com:panther-labs/panther_analysis_tool.git@e1e3e63f43307598b81704ea057dfbc1861622a8#egg=panther_analysis_tool
 pbr==5.5.1
 ply==3.11
 python-dateutil==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,7 +27,6 @@ jmespath==0.10.0
 lazy-object-proxy==1.4.3
 mccabe==0.6.1
 mypy-extensions==0.4.3
--e git+git@github.com:panther-labs/panther_analysis_tool.git@e1e3e63f43307598b81704ea057dfbc1861622a8#egg=panther_analysis_tool
 pbr==5.5.1
 ply==3.11
 python-dateutil==2.8.1


### PR DESCRIPTION
### Background

The release process should be as simple as possible.
Adding the code to package the managed schemas in PAT will help with that.
The `zip-schemas` sub-command does a shallow clone of a specific tag from the `panther-analysis` repository and packages a `manifest.yml` into a `.zip` archive to be attached to releases.  

#### Usage
```sh
$ panther_analysis_tool zip-schemas --release=v1.16.0
$ panther_analysis_tool zip-schemas --release=v1.16.0 --out=/tmp/
```
`--release` is a required argument for the release tag to package.
`--out` sets the output _directory_ (defaults to `.`).

### Changes

* Adds `zip-schemas`  command.

### Testing

* ran `zip-schemas`