### PR TITLE
Allow Advanced PAT Users to Ignore Extra Fields

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -33,10 +33,9 @@ from datetime import datetime
 from fnmatch import fnmatch
 from importlib.abc import Loader
 from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple
-
+from distutils.util import strtobool
 import boto3
 import semver
-from distutils.util import strtobool
 from ruamel.yaml import YAML
 from ruamel.yaml import parser as YAMLParser
 from ruamel.yaml import scanner as YAMLScanner
@@ -965,7 +964,7 @@ def run() -> None:
     if getattr(args, "filter", None) is not None:
         args.filter = parse_filter(args.filter)
 
-    global RULE_SCHEMA, POLICY_SCHEMA
+    global RULE_SCHEMA, POLICY_SCHEMA  # pylint: disable=global-variable-undefined
     RULE_SCHEMA, POLICY_SCHEMA = get_rule_policy_schema(bool(args.ignore_extra_keys))
 
     try:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -982,6 +982,7 @@ def run() -> None:
         level=logging.DEBUG if args.debug else logging.INFO,
     )
 
+    args.filter = None
     if getattr(args, "filter", None) is not None:
         args.filter = parse_filter(args.filter_list)
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -972,6 +972,11 @@ def set_env(key: str, value: str) -> None:
     os.environ[key] = value
 
 
+def set_rule_policy_schema(args: argparse.Namespace) -> None:
+    global RULE_SCHEMA, POLICY_SCHEMA  # pylint: disable=global-statement
+    RULE_SCHEMA, POLICY_SCHEMA = get_rule_policy_schema(bool(args.ignore_extra_keys))
+
+
 def run() -> None:
     parser = setup_parser()
     # if no args are passed, print the help output
@@ -981,13 +986,10 @@ def run() -> None:
         format="[%(levelname)s]: %(message)s",
         level=logging.DEBUG if args.debug else logging.INFO,
     )
-
+    set_rule_policy_schema(args)
     args.filter = None
     if getattr(args, "filter", None) is not None:
         args.filter = parse_filter(args.filter_list)
-
-    global RULE_SCHEMA, POLICY_SCHEMA  # pylint: disable=global-statement
-    RULE_SCHEMA, POLICY_SCHEMA = get_rule_policy_schema(bool(args.ignore_extra_keys))
 
     try:
         return_code, out = args.func(args)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -56,9 +56,6 @@ from panther_analysis_tool.schemas import (
     get_rule_policy_schema
 )
 from panther_analysis_tool.test_case import DataModel, TestCase
-
-global RULE_SCHEMA, POLICY_SCHEMA
-
 DATA_MODEL_LOCATION = "./data_models"
 HELPERS_LOCATION = "./global_helpers"
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -56,7 +56,7 @@ from panther_analysis_tool.schemas import (
     get_rule_policy_schema
 )
 from panther_analysis_tool.test_case import DataModel, TestCase
-RULE_SCHEMA, POLICY_SCHEMA = Schema, Schema
+RULE_SCHEMA, POLICY_SCHEMA = Schema({}), Schema({})
 DATA_MODEL_LOCATION = "./data_models"
 HELPERS_LOCATION = "./global_helpers"
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -731,7 +731,6 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         metavar="KEY=VALUE",
         nargs="+",
-        type=List[str],
         dest='filter_list',
     )
     test_parser.add_argument(
@@ -791,7 +790,6 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         metavar="KEY=VALUE",
         nargs="+",
-        type=List[str],
         dest='filter_list',
     )
     zip_parser.add_argument(
@@ -857,7 +855,6 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         metavar="KEY=VALUE",
         nargs="+",
-        type=List[str],
         dest='filter_list',
     )
     upload_parser.add_argument("--skip-tests", action="store_true", dest="skip_tests")

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -16,6 +16,7 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
+#  pylint: disable=too-many-lines
 
 import argparse
 import base64

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -725,7 +725,14 @@ def setup_parser() -> argparse.ArgumentParser:
         help="The relative path to Panther policies and rules.",
         required=False,
     )
-    test_parser.add_argument("--filter", required=False, metavar="KEY=VALUE", nargs="+")
+    test_parser.add_argument(
+        "--filter",
+        required=False,
+        metavar="KEY=VALUE",
+        nargs="+",
+        type=list,
+        dest='filter_list',
+    )
     test_parser.add_argument(
         "--minimum-tests",
         default="0",
@@ -778,7 +785,14 @@ def setup_parser() -> argparse.ArgumentParser:
         help="The path to write zipped policies and rules to.",
         required=False,
     )
-    zip_parser.add_argument("--filter", required=False, metavar="KEY=VALUE", nargs="+")
+    zip_parser.add_argument(
+        "--filter",
+        required=False,
+        metavar="KEY=VALUE",
+        nargs="+",
+        type=list,
+        dest='filter_list',
+    )
     zip_parser.add_argument(
         "--minimum-tests",
         default="0",
@@ -837,7 +851,14 @@ def setup_parser() -> argparse.ArgumentParser:
         help="Meant for advanced users; allows skipping of extra keys from schema validation.",
         required=False,
     )
-    upload_parser.add_argument("--filter", required=False, metavar="KEY=VALUE", nargs="+")
+    upload_parser.add_argument(
+        "--filter",
+        required=False,
+        metavar="KEY=VALUE",
+        nargs="+",
+        type=list,
+        dest='filter_list',
+    )
     upload_parser.add_argument("--skip-tests", action="store_true", dest="skip_tests")
     upload_parser.set_defaults(func=upload_analysis)
 
@@ -964,7 +985,7 @@ def run() -> None:
     )
 
     if getattr(args, "filter", None) is not None:
-        args.filter = parse_filter(args.filter)
+        args.filter = parse_filter(args.filter_list)
 
     global RULE_SCHEMA, POLICY_SCHEMA  # pylint: disable=global-statement
     RULE_SCHEMA, POLICY_SCHEMA = get_rule_policy_schema(bool(args.ignore_extra_keys))

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -41,6 +41,7 @@ from ruamel.yaml import parser as YAMLParser
 from ruamel.yaml import scanner as YAMLScanner
 from schema import (
     Optional,
+    Schema,
     SchemaError,
     SchemaForbiddenKeyError,
     SchemaMissingKeyError,
@@ -55,6 +56,7 @@ from panther_analysis_tool.schemas import (
     get_rule_policy_schema
 )
 from panther_analysis_tool.test_case import DataModel, TestCase
+RULE_SCHEMA, POLICY_SCHEMA = Schema, Schema
 DATA_MODEL_LOCATION = "./data_models"
 HELPERS_LOCATION = "./global_helpers"
 
@@ -964,7 +966,7 @@ def run() -> None:
     if getattr(args, "filter", None) is not None:
         args.filter = parse_filter(args.filter)
 
-    global RULE_SCHEMA, POLICY_SCHEMA  # pylint: disable=global-variable-undefined
+    global RULE_SCHEMA, POLICY_SCHEMA
     RULE_SCHEMA, POLICY_SCHEMA = get_rule_policy_schema(bool(args.ignore_extra_keys))
 
     try:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -966,7 +966,7 @@ def run() -> None:
     if getattr(args, "filter", None) is not None:
         args.filter = parse_filter(args.filter)
 
-    global RULE_SCHEMA, POLICY_SCHEMA
+    global RULE_SCHEMA, POLICY_SCHEMA  # pylint: disable=global-statement
     RULE_SCHEMA, POLICY_SCHEMA = get_rule_policy_schema(bool(args.ignore_extra_keys))
 
     try:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -108,14 +108,14 @@ def load_analysis_specs(directories: List[str]) -> Iterator[Tuple[str, str, Any,
     """Loads the analysis specifications from a file.
 
     Args:
-        directory: The relative path to Panther policies or rules.
+        directories: The relative path to Panther policies or rules.
 
     Yields:
         A tuple of the relative filepath, directory name, and loaded analysis specification dict.
     """
     # setup a list of paths to ensure we do not import the same files
     # multiple times, which can happen when testing from root directory without filters
-    loaded_specs = []
+    loaded_specs: List[Any] = []
     for directory in directories:
         for relative_path, _, file_list in os.walk(directory):
             # setup yaml object
@@ -559,10 +559,10 @@ def classify_analysis(
     invalid_specs = []
     # each analysis type must have a unique id, track used ids and
     # add any duplicates to the invalid_specs
-    analysis_ids = []
+    analysis_ids: List[Any] = []
 
     for analysis_spec_filename, dir_name, analysis_spec, error in specs:
-        keys = list()
+        keys: List[Any] = list()
         try:
             # check for parsing errors from json.loads (ValueError) / yaml.safe_load (YAMLError)
             if error:
@@ -668,7 +668,7 @@ def run_tests(
         # using a dictionary to map between the tests and their outcomes
         # assume the test passes (default "PASS")
         # until failure condition is found (set to "FAIL")
-        test_result = defaultdict(lambda: "PASS")
+        test_result: Dict[Any, str] = defaultdict(lambda: "PASS")
         # check expected result
         if result != unit_test["ExpectedResult"]:
             test_result["outcome"] = "FAIL"
@@ -731,7 +731,7 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         metavar="KEY=VALUE",
         nargs="+",
-        type=list,
+        type=List[str],
         dest='filter_list',
     )
     test_parser.add_argument(
@@ -791,7 +791,7 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         metavar="KEY=VALUE",
         nargs="+",
-        type=list,
+        type=List[str],
         dest='filter_list',
     )
     zip_parser.add_argument(
@@ -857,7 +857,7 @@ def setup_parser() -> argparse.ArgumentParser:
         required=False,
         metavar="KEY=VALUE",
         nargs="+",
-        type=list,
+        type=List[str],
         dest='filter_list',
     )
     upload_parser.add_argument("--skip-tests", action="store_true", dest="skip_tests")

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -59,7 +59,7 @@ GLOBAL_SCHEMA = Schema(
 )
 
 
-def get_rule_policy_schema(ignore_extra_keys=False) -> Tuple[Schema, Schema]:
+def get_rule_policy_schema(ignore_extra_keys: bool = False) -> Tuple[Schema, Schema]:
     #  pylint: disable=invalid-name
     POLICY_SCHEMA = Schema(
         {

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -57,68 +57,72 @@ GLOBAL_SCHEMA = Schema(
     ignore_extra_keys=False,
 )
 
-POLICY_SCHEMA = Schema(
-    {
-        "AnalysisType": Or("policy"),
-        "Enabled": bool,
-        "Filename": str,
-        "PolicyID": And(str, NAME_ID_VALIDATION_REGEX),
-        "ResourceTypes": [str],
-        "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
-        Optional("ActionDelaySeconds"): int,
-        Optional("AutoRemediationID"): str,
-        Optional("AutoRemediationParameters"): object,
-        Optional("Description"): str,
-        Optional("DisplayName"): And(str, NAME_ID_VALIDATION_REGEX),
-        Optional("OutputIds"): [str],
-        Optional("Reference"): str,
-        Optional("Runbook"): str,
-        Optional("Suppressions"): [str],
-        Optional("Tags"): [str],
-        Optional("Reports"): {str: list},
-        Optional("Tests"): [
-            {
-                "Name": str,
-                Optional(
-                    "ResourceType"
-                ): str,  # Not needed anymore, optional for backwards compatibility
-                "ExpectedResult": bool,
-                "Resource": object,
-            }
-        ],
-    },
-    ignore_extra_keys=False,
-)  # Prevent user typos on optional fields
 
-RULE_SCHEMA = Schema(
-    {
-        "AnalysisType": Or("rule"),
-        "Enabled": bool,
-        "Filename": str,
-        "RuleID": And(str, NAME_ID_VALIDATION_REGEX),
-        "LogTypes": [str],
-        "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
-        Optional("Description"): str,
-        Optional("DedupPeriodMinutes"): int,
-        Optional("DisplayName"): And(str, NAME_ID_VALIDATION_REGEX),
-        Optional("OutputIds"): [str],
-        Optional("Reference"): str,
-        Optional("Runbook"): str,
-        Optional("SummaryAttributes"): [str],
-        Optional("Suppressions"): [str],
-        Optional("Threshold"): int,
-        Optional("Tags"): [str],
-        Optional("Reports"): {str: list},
-        Optional("Tests"): [
-            {
-                "Name": str,
-                Optional(
-                    "LogType"
-                ): str,  # Not needed anymore, optional for backwards compatibility
-                "ExpectedResult": bool,
-                "Log": object,
-            }
-        ],
-    },
-    ignore_extra_keys=False,
-)  # Prevent user typos on optional fields
+def get_rule_policy_schema(ignore_extra_keys=False):
+    POLICY_SCHEMA = Schema(
+        {
+            "AnalysisType": Or("policy"),
+            "Enabled": bool,
+            "Filename": str,
+            "PolicyID": And(str, NAME_ID_VALIDATION_REGEX),
+            "ResourceTypes": [str],
+            "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
+            Optional("ActionDelaySeconds"): int,
+            Optional("AutoRemediationID"): str,
+            Optional("AutoRemediationParameters"): object,
+            Optional("Description"): str,
+            Optional("DisplayName"): And(str, NAME_ID_VALIDATION_REGEX),
+            Optional("OutputIds"): [str],
+            Optional("Reference"): str,
+            Optional("Runbook"): str,
+            Optional("Suppressions"): [str],
+            Optional("Tags"): [str],
+            Optional("Reports"): {str: list},
+            Optional("Tests"): [
+                {
+                    "Name": str,
+                    Optional(
+                        "ResourceType"
+                    ): str,  # Not needed anymore, optional for backwards compatibility
+                    "ExpectedResult": bool,
+                    "Resource": object,
+                }
+            ],
+        },
+        ignore_extra_keys=ignore_extra_keys,
+    )  # Prevent user typos on optional fields
+
+    RULE_SCHEMA = Schema(
+        {
+            "AnalysisType": Or("rule"),
+            "Enabled": bool,
+            "Filename": str,
+            "RuleID": And(str, NAME_ID_VALIDATION_REGEX),
+            "LogTypes": [str],
+            "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
+            Optional("Description"): str,
+            Optional("DedupPeriodMinutes"): int,
+            Optional("DisplayName"): And(str, NAME_ID_VALIDATION_REGEX),
+            Optional("OutputIds"): [str],
+            Optional("Reference"): str,
+            Optional("Runbook"): str,
+            Optional("SummaryAttributes"): [str],
+            Optional("Suppressions"): [str],
+            Optional("Threshold"): int,
+            Optional("Tags"): [str],
+            Optional("Reports"): {str: list},
+            Optional("Tests"): [
+                {
+                    "Name": str,
+                    Optional(
+                        "LogType"
+                    ): str,  # Not needed anymore, optional for backwards compatibility
+                    "ExpectedResult": bool,
+                    "Log": object,
+                }
+            ],
+        },
+        ignore_extra_keys=ignore_extra_keys,
+    )  # Prevent user typos on optional fields
+
+    return RULE_SCHEMA, POLICY_SCHEMA

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -58,7 +58,7 @@ GLOBAL_SCHEMA = Schema(
 )
 
 
-def get_rule_policy_schema(ignore_extra_keys=False):
+def get_rule_policy_schema(ignore_extra_keys=False) -> (Schema, Schema):
     #  pylint: disable=invalid-name
     POLICY_SCHEMA = Schema(
         {

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from schema import And, Optional, Or, Regex, Schema
+from typing import Tuple
 
 NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9_. ()-]+$")
 
@@ -58,7 +59,7 @@ GLOBAL_SCHEMA = Schema(
 )
 
 
-def get_rule_policy_schema(ignore_extra_keys=False) -> (Schema, Schema):
+def get_rule_policy_schema(ignore_extra_keys=False) -> Tuple[Schema, Schema]:
     #  pylint: disable=invalid-name
     POLICY_SCHEMA = Schema(
         {

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -59,6 +59,7 @@ GLOBAL_SCHEMA = Schema(
 
 
 def get_rule_policy_schema(ignore_extra_keys=False):
+    #  pylint: disable=invalid-name
     POLICY_SCHEMA = Schema(
         {
             "AnalysisType": Or("policy"),

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -17,8 +17,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from schema import And, Optional, Or, Regex, Schema
 from typing import Tuple
+from schema import And, Optional, Or, Regex, Schema
 
 NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9_. ()-]+$")
 

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -5,6 +5,7 @@ from pyfakefs.fake_filesystem_unittest import TestCase, Pause
 from nose.tools import (assert_equal, assert_false, assert_is_instance,
                         assert_is_none, assert_true, raises, nottest,
                         with_setup)
+from schema import SchemaWrongKeyError
 
 from panther_analysis_tool import main as pat
 
@@ -17,13 +18,13 @@ class TestPantherAnalysisTool(TestCase):
         self.fs.add_real_directory(self.fixture_path)
 
     def test_valid_json_policy_spec(self):
-        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs(['tests/fixtures']):
             if spec_filename == 'example_policy.json':
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
 
     def test_valid_yaml_policy_spec(self):
-        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs(['tests/fixtures']):
             if spec_filename == 'example_policy.yml':
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
@@ -38,12 +39,12 @@ class TestPantherAnalysisTool(TestCase):
         expected_output = '{} not in list of valid keys: {}'
         # test successful regex match and correct error returned
         test_str = "Wrong key 'DisplaName' in {'DisplaName':'one','Enabled':true, 'Filename':'sample'}"
-        exc = Exception(test_str)
+        exc = SchemaWrongKeyError(test_str)
         err = pat.handle_wrong_key_error(exc, sample_keys)
         assert_equal(str(err), expected_output.format("'DisplaName'", sample_keys))
         # test failing regex match
         test_str = "Will not match"
-        exc = Exception(test_str)
+        exc = SchemaWrongKeyError(test_str)
         err = pat.handle_wrong_key_error(exc, sample_keys)
         assert_equal(str(err),  expected_output.format("UNKNOWN_KEY", sample_keys))
 

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -50,6 +50,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_load_policy_specs_from_folder(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures'.split())
+        args.filter = None
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
         assert_equal(invalid_specs[0][0],
@@ -150,12 +151,14 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_minimum_tests(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --minimum-tests 1'.split())
+        args.filter = None
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
     def test_with_minimum_tests_failing(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --minimum-tests 2'.split())
+        args.filter = None
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because some of the fixtures only have one test case
         assert_equal(return_code, 1)
@@ -178,6 +181,7 @@ class TestPantherAnalysisTool(TestCase):
 
         args = pat.setup_parser().parse_args(
             'zip --path tests/fixtures/valid_analysis --out tmp/'.split())
+        args.filter = None
         return_code, out_filename = pat.zip_analysis(args)
         statinfo = os.stat(out_filename)
         assert_true(statinfo.st_size > 0)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -11,6 +11,7 @@ from panther_analysis_tool import main as pat
 
 
 class TestPantherAnalysisTool(TestCase):
+    print(f"{os.getcwd()}\n{os.listdir()}")
     fixture_path = 'tests/fixtures/'
 
     def setUp(self):
@@ -76,6 +77,7 @@ class TestPantherAnalysisTool(TestCase):
             os.chdir(valid_rule_path)
             args = pat.setup_parser().parse_args('test'.split())
             pat.set_rule_policy_schema(args)
+            args.filter = None
             return_code, invalid_specs = pat.test_analysis(args)
             os.chdir(original_path)
         # asserts are outside of the pause to ensure the fakefs gets resumed

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -144,7 +144,7 @@ class TestPantherAnalysisTool(TestCase):
         pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
-        self.equal = assert_equal(return_code, 1)
+        assert_equal(return_code, 1)
         assert_equal(len(invalid_specs), 4)
 
     def test_unknown_exception(self):

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -91,7 +91,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_parse_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter AnalysisType=policy,global Severity=Critical'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         assert_true('AnalysisType' in args.filter.keys())
         assert_true('policy' in args.filter['AnalysisType'])
         assert_true('global' in args.filter['AnalysisType'])
@@ -100,7 +100,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter AnalysisType=policy,global'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
@@ -114,35 +114,35 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_invalid_rule_definition(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=Critical RuleID=AWS.CloudTrail.MFAEnabled'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
         assert_equal(len(invalid_specs), 4)
 
     def test_invalid_rule_test(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter RuleID=Example.Rule.Invalid.Test'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
         assert_equal(len(invalid_specs), 4)
 
     def test_invalid_characters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
-        assert_equal(return_code, 1)
+        self.equal = assert_equal(return_code, 1)
         assert_equal(len(invalid_specs), 4)
 
     def test_unknown_exception(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter RuleID=Example.Rule.Unknown.Exception'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
         assert_equal(len(invalid_specs), 4)
 
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
@@ -162,7 +162,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_minimum_tests_no_passing(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter PolicyID=IAM.MFAEnabled.Required.Tests --minimum-tests 2'.split())
-        args.filter = pat.parse_filter(args.filter)
+        args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because while there are two unit tests they both have expected result False
         assert_equal(return_code, 1)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -51,6 +51,7 @@ class TestPantherAnalysisTool(TestCase):
     def test_load_policy_specs_from_folder(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures'.split())
         args.filter = None
+        pat.set_rule_policy_schema(args)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
         assert_equal(invalid_specs[0][0],
@@ -59,6 +60,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_rules_from_folder(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis/policies'.split())
+        pat.set_rule_policy_schema(args)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
@@ -73,6 +75,7 @@ class TestPantherAnalysisTool(TestCase):
             original_path = os.getcwd()
             os.chdir(valid_rule_path)
             args = pat.setup_parser().parse_args('test'.split())
+            pat.set_rule_policy_schema(args)
             return_code, invalid_specs = pat.test_analysis(args)
             os.chdir(original_path)
         # asserts are outside of the pause to ensure the fakefs gets resumed
@@ -93,6 +96,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_parse_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter AnalysisType=policy,global Severity=Critical'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         assert_true('AnalysisType' in args.filter.keys())
         assert_true('policy' in args.filter['AnalysisType'])
@@ -102,6 +106,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter AnalysisType=policy,global'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
@@ -116,6 +121,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_invalid_rule_definition(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=Critical RuleID=AWS.CloudTrail.MFAEnabled'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
@@ -123,6 +129,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_invalid_rule_test(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter RuleID=Example.Rule.Invalid.Test'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
@@ -130,6 +137,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_invalid_characters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter Severity=High PolicyID=AWS.IAM.MFAEnabled'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         self.equal = assert_equal(return_code, 1)
@@ -137,6 +145,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_unknown_exception(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter RuleID=Example.Rule.Unknown.Exception'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
@@ -144,6 +153,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_tag_filters(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --filter Tags=AWS,CIS'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
@@ -151,6 +161,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_minimum_tests(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --minimum-tests 1'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = None
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
@@ -158,6 +169,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_minimum_tests_failing(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis --minimum-tests 2'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = None
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because some of the fixtures only have one test case
@@ -166,6 +178,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_with_minimum_tests_no_passing(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures --filter PolicyID=IAM.MFAEnabled.Required.Tests --minimum-tests 2'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = pat.parse_filter(args.filter_list)
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because while there are two unit tests they both have expected result False
@@ -181,6 +194,7 @@ class TestPantherAnalysisTool(TestCase):
 
         args = pat.setup_parser().parse_args(
             'zip --path tests/fixtures/valid_analysis --out tmp/'.split())
+        pat.set_rule_policy_schema(args)
         args.filter = None
         return_code, out_filename = pat.zip_analysis(args)
         statinfo = os.stat(out_filename)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -14,7 +14,6 @@ class TestPantherAnalysisTool(TestCase):
     fixture_path = 'tests/fixtures/'
 
     def setUp(self):
-        print(f"{os.getcwd()}\n{os.listdir()}")
         self.setUpPyfakefs()
         self.fs.add_real_directory(self.fixture_path)
 
@@ -91,6 +90,7 @@ class TestPantherAnalysisTool(TestCase):
             original_path = os.getcwd()
             os.chdir(valid_rule_path)
             args = pat.setup_parser().parse_args('test --path ./'.split())
+            pat.set_rule_policy_schema(args)
             args.filter = None
             return_code, invalid_specs = pat.test_analysis(args)
             os.chdir(original_path)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -11,10 +11,10 @@ from panther_analysis_tool import main as pat
 
 
 class TestPantherAnalysisTool(TestCase):
-    print(f"{os.getcwd()}\n{os.listdir()}")
     fixture_path = 'tests/fixtures/'
 
     def setUp(self):
+        print(f"{os.getcwd()}\n{os.listdir()}")
         self.setUpPyfakefs()
         self.fs.add_real_directory(self.fixture_path)
 
@@ -62,6 +62,7 @@ class TestPantherAnalysisTool(TestCase):
     def test_rules_from_folder(self):
         args = pat.setup_parser().parse_args('test --path tests/fixtures/valid_analysis/policies'.split())
         pat.set_rule_policy_schema(args)
+        args.filter = None
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
@@ -90,6 +91,7 @@ class TestPantherAnalysisTool(TestCase):
             original_path = os.getcwd()
             os.chdir(valid_rule_path)
             args = pat.setup_parser().parse_args('test --path ./'.split())
+            args.filter = None
             return_code, invalid_specs = pat.test_analysis(args)
             os.chdir(original_path)
         # asserts are outside of the pause to ensure the fakefs gets resumed


### PR DESCRIPTION
### References

Asana Task URL: https://app.asana.com/0/1199975676341842/1199956661047416/f

### Background

Right now if you add an extraneous field to a detection specification file, PAT will fail to load that file considering it invalid.  This is to prevent users from accidentally mistyping an optional field and having it be dropped silently. 

It would be nice if this functionality could be overwritten so that users can add custom meta data fields which don't get translated over to Panther but which can contain useful information about the detection for a given organization.

### Changes

* Hacky solution to allow for configurable `ignore_extra_fields` flag

### Testing

* Tested `zip` `test` and `upload` with a rule specification that was not expected
