### PR TITLE
add path to output file path

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -210,6 +210,14 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
     # The colon character is not valid in filenames.
     current_time = datetime.now().isoformat(timespec="seconds").replace(":", "-")
     filename = "panther-analysis-{}.zip".format(current_time)
+    if args.out:
+        if not os.path.isdir(args.out):
+            logging.info(
+                "Creating directory: %s",
+                args.out,
+            )
+            os.mkdir(args.out)
+        filename = args.out.rstrip("/") + "/" + filename
     with zipfile.ZipFile(filename, "w", zipfile.ZIP_DEFLATED) as zip_out:
         # Always zip the helpers and data models
         analysis = []
@@ -227,7 +235,6 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
             # datamodels may not have python body
             if "Filename" in analysis_spec:
                 zip_out.write(os.path.join(dir_name, analysis_spec["Filename"]))
-
     return 0, filename
 
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -216,7 +216,7 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
                 "Creating directory: %s",
                 args.out,
             )
-            os.mkdir(args.out)
+            os.makedirs(args.out)
         filename = args.out.rstrip("/") + "/" + filename
     with zipfile.ZipFile(filename, "w", zipfile.ZIP_DEFLATED) as zip_out:
         # Always zip the helpers and data models

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -187,6 +187,7 @@ class TestPantherAnalysisTool(TestCase):
         args = pat.setup_parser().parse_args(
             'zip --path tests/fixtures/valid_analysis --out tmp/'.split())
         return_code, out_filename = pat.zip_analysis(args)
+        assert_true(out_filename.startswith("tmp/"))
         statinfo = os.stat(out_filename)
         assert_true(statinfo.st_size > 0)
         assert_equal(return_code, 0)


### PR DESCRIPTION
### Background

Asana URL: Closes https://app.asana.com/0/1199975676341842/1199956661047411/f

The `zip` command was not honoring the `out` option

### Changes

* create output dir if it doesn't exist
* move the output file based on the input
* update to test to check for appropriate location of output file

### Testing

* `make ci`
* manual testing with no `out` option:

```
% python panther_analysis_tool/main.py zip --path ./tests/fixtures/valid_analysis 
[INFO]: Testing analysis packs in ./tests/fixtures/valid_analysis

AWS.IAM.MFAEnabled
        [PASS] Root MFA not enabled fails compliance
        [PASS] User MFA not enabled fails compliance

AWS.IAM.BetaTest
        [PASS] Root MFA not enabled fails compliance
        [PASS] User MFA not enabled fails compliance

IAM.MFAEnabled Extra Fields
        [PASS] Root MFA not enabled triggers a violation.

AWS.CloudTrail.MFAEnabled
        [PASS] Root MFA not enabled fails compliance
        [PASS] User MFA not enabled fails compliance
        [PASS] User MFA enabled passes compliance.
                [PASS] [dedup] test
                [PASS] [title] test does not have MFA enabled

DataModel.BruteForceByIP
        [PASS] Normal OneLogin Login Event
        [PASS] Failed OneLogin Login Event
                [PASS] [title] User [Bob Cat] from IP [1.2.3.4] has exceeded the failed logins threshold
        [PASS] GSuite Normal Login Event
        [PASS] GSuite Failed Login Event
                [PASS] [title] User [bob@example.com] from IP [4.3.2.1] has exceeded the failed logins threshold

AWS.CloudTrail.MFAEnabled.Extra.Fields
        [PASS] Root MFA not enabled fails compliance
        [PASS] User MFA not enabled fails compliance

--------------------------
Panther CLI Test Summary
        Path: ./tests/fixtures/valid_analysis
        Passed: 6
        Failed: 0
        Invalid: 0

[INFO]: Zipping analysis packs in ./tests/fixtures/valid_analysis to .
[INFO]: ./panther-analysis-2021-03-11T11-26-40.zip
```
