### PR TITLE
Support for Mocking in Unit Tests & Generated Alert Fields

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -36,7 +36,7 @@ from distutils.util import strtobool
 from fnmatch import fnmatch
 from importlib.abc import Loader
 from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple
-from unittest.mock import patch, MagicMock
+from unittest.mock import MagicMock, patch
 
 import boto3
 import botocore
@@ -45,25 +45,14 @@ import semver
 from ruamel.yaml import YAML
 from ruamel.yaml import parser as YAMLParser
 from ruamel.yaml import scanner as YAMLScanner
-from schema import (
-    Optional,
-    Schema,
-    SchemaError,
-    SchemaForbiddenKeyError,
-    SchemaMissingKeyError,
-    SchemaUnexpectedTypeError,
-    SchemaWrongKeyError,
-)
+from schema import (Optional, Schema, SchemaError, SchemaForbiddenKeyError,
+                    SchemaMissingKeyError, SchemaUnexpectedTypeError,
+                    SchemaWrongKeyError)
 
-from panther_analysis_tool.schemas import (
-    DATA_MODEL_SCHEMA,
-    GLOBAL_SCHEMA,
-    PACK_SCHEMA,
-    POLICY_SCHEMA,
-    RULE_SCHEMA,
-    SCHEDULED_QUERY_SCHEMA,
-    TYPE_SCHEMA,
-)
+from panther_analysis_tool.schemas import (DATA_MODEL_SCHEMA, GLOBAL_SCHEMA,
+                                           PACK_SCHEMA, POLICY_SCHEMA,
+                                           RULE_SCHEMA, SCHEDULED_QUERY_SCHEMA,
+                                           TYPE_SCHEMA)
 from panther_analysis_tool.test_case import DataModel, TestCase
 
 DATA_MODEL_LOCATION = "./data_models"

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1007,10 +1007,11 @@ def validate_outputs(function_name: str, function_output: Any) -> (bool, Any):
         valid = isinstance(function_output, str)
 
     if not valid and out == function_output:
-        if function_name != "destinations":
-            expected_type = "string"
-        else:
+        if function_name == "destinations":
             expected_type = "list"
+        else:
+            expected_type = "string"
+
         out = AttributeError(
             f'Expected [{function_name}] to return a [{expected_type}], '
             f'got [{type(function_output)}] instead'

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -78,6 +78,10 @@ CUSTOM_FUNCTIONS = [
     "dedup", "title", "description", "reference", "severity", "runbook", "destinations"
 ]
 
+VALID_SEVERITIES = [
+    "INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"
+]
+
 SCHEMAS: Dict[str, Schema] = {
     DATAMODEL: DATA_MODEL_SCHEMA,
     GLOBAL: GLOBAL_SCHEMA,
@@ -931,6 +935,17 @@ def run_tests(  # pylint: disable=too-many-locals,too-many-statements
                         test_result[func] = "FAIL"
                         test_result["outcome"] = "FAIL"
                     func_out_valid_type = False
+                    # severity value validation
+                    if func == "severity":
+                        if str(func_out).upper() not in VALID_SEVERITIES:
+                            func_out = AssertionError(
+                                f'Expected severity to be any of the following: '
+                                f'{str(VALID_SEVERITIES)}, got [{str(func_out)}] instead.'
+                            )
+                            test_result[func] = "FAIL"
+                            test_result["outcome"] = "FAIL"
+
+                    # type validation
                     if func == "destinations":
                         if isinstance(func_out, list) and all(isinstance(x, str) for x in func_out):
                             func_out_valid_type = True

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -887,12 +887,8 @@ def run_tests(  # pylint: disable=too-many-locals,too-many-statements
                     result = analysis_funcs["run"](test_case)
             else:
                 result = analysis_funcs["run"](test_case)
-        except AttributeError as err:
+        except (AttributeError, KeyError) as err:
             logging.warning("AttributeError: {%s}", err)
-            failed_tests[analysis.get("PolicyID") or analysis["RuleID"]].append(unit_test["Name"])
-            continue
-        except KeyError as err:
-            logging.warning("KeyError: {%s}", err)
             failed_tests[analysis.get("PolicyID") or analysis["RuleID"]].append(unit_test["Name"])
             continue
         except Exception as err:  # pylint: disable=broad-except

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -858,7 +858,7 @@ def handle_wrong_key_error(err: SchemaWrongKeyError, keys: list) -> Exception:
         return exc
 
 
-def run_tests(
+def run_tests(  # pylint: disable=too-many-locals,too-many-statements
     analysis: Dict[str, Any],
     analysis_funcs: Dict[str, Any],
     analysis_data_models: Dict[str, DataModel],
@@ -939,7 +939,7 @@ def run_tests(
                 func_out = analysis_funcs[func](test_case)
                 func_out_valid_type = False
                 if func == "destinations":
-                    if isinstance(func_out, list) and all([isinstance(x, str) for x in func_out]):
+                    if isinstance(func_out, list) and all(isinstance(x, str) for x in func_out):
                         func_out_valid_type = True
                 else:
                     func_out_valid_type = isinstance(func_out, str)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -868,7 +868,7 @@ def run_tests(  # pylint: disable=too-many-locals,too-many-statements
         print("\tNo tests configured for {}".format(analysis_id))
         return failed_tests
 
-    for unit_test in analysis["Tests"]:
+    for unit_test in analysis["Tests"]:  # pylint: disable=too-many-nested-blocks
         try:
             entry = unit_test.get("Resource") or unit_test["Log"]
             log_type = entry.get("p_log_type", "")

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -936,7 +936,7 @@ def _run_tests(
         if unit_test["ExpectedResult"]:
             verify_result = _verify_test_run(test_case, mock_methods, analysis_funcs)
             for function_name in verify_result:
-                if verify_result[function_name] is not None and not verify_result[function_name]:
+                if verify_result[function_name] != "PASS":
                     test_result[function_name] = test_result["outcome"] = "FAIL"
     return failed_tests
 
@@ -946,7 +946,7 @@ def _verify_test_run(
     mock_methods: Dict[str, MagicMock],
     analysis_funcs: Dict[str, Any],
 ) -> Dict[str, Any]:
-    test_run_result: Dict[str, str] = defaultdict(lambda: "PASS").fromkeys(RESERVED_FUNCTIONS)
+    test_run_result: Dict[str, str] = defaultdict(lambda: "PASS")
     for func in RESERVED_FUNCTIONS:
         if analysis_funcs.get(func):
             try:
@@ -963,10 +963,11 @@ def _verify_test_run(
                 func_out = err
                 test_run_result[func] = "FAIL"
 
-            func_out_valid_type = False
+            func_out_valid_type = True
             # severity value validation
             valid_output, func_out = validate_outputs(func, func_out)
             if not valid_output or isinstance(func_out, (AttributeError, AssertionError)):
+                func_out_valid_type = False
                 test_run_result[func] = "FAIL"
 
             print(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -74,7 +74,7 @@ QUERY = "scheduled_query"
 SCHEDULED_RULE = "scheduled_rule"
 RULE = "rule"
 
-CUSTOM_FUNCTIONS = [
+RESERVED_FUNCTIONS = [
     "dedup", "title", "description", "reference", "severity", "runbook", "destinations"
 ]
 
@@ -947,8 +947,8 @@ def _verify_test_run(
     mock_methods: Dict[str, MagicMock],
     analysis_funcs: Dict[str, Any],
 ) -> Dict[str, Any]:
-    test_run_result = dict.fromkeys(CUSTOM_FUNCTIONS)
-    for func in CUSTOM_FUNCTIONS:
+    test_run_result = dict.fromkeys(RESERVED_FUNCTIONS)
+    for func in RESERVED_FUNCTIONS:
         if analysis_funcs.get(func):
             try:
                 if mock_methods:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -571,7 +571,6 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     Returns:
         A tuple of the return code, and a list of tuples containing invalid specs and their error.
     """
-    failed_tests: DefaultDict[str, list] = defaultdict(list)
     logging.info("Testing analysis packs in %s\n", args.path)
 
     # First classify each file, always include globals and data models location
@@ -819,7 +818,7 @@ def classify_analysis(
             invalid_specs.append((analysis_spec_filename, err))
             continue
 
-    return (classified_specs, invalid_specs)
+    return classified_specs, invalid_specs
 
 
 def lookup_analysis_id(analysis_spec: Any, analysis_type: str) -> str:

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -98,6 +98,9 @@ POLICY_SCHEMA = Schema(
                 ): str,  # Not needed anymore, optional for backwards compatibility
                 "ExpectedResult": bool,
                 "Resource": object,
+                Optional(
+                    "Mocks"
+                ): object,
             }
         ],
     },
@@ -131,6 +134,9 @@ RULE_SCHEMA = Schema(
                 ): str,  # Not needed anymore, optional for backwards compatibility
                 "ExpectedResult": bool,
                 "Log": object,
+                Optional(
+                    "Mocks"
+                ): object,
             }
         ],
     },

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,7 +31,7 @@ jmespath==0.10.0
 lazy-object-proxy==1.5.2
 mccabe==0.6.1
 mypy-extensions==0.4.3
-panther-analysis-tool==0.3.5
+panther-analysis-tool==0.5.0
 pathspec==0.8.1
 pbr==5.5.1
 ply==3.11

--- a/tests/fixtures/example_rule_invalid_mocks.py
+++ b/tests/fixtures/example_rule_invalid_mocks.py
@@ -1,0 +1,8 @@
+import boto3
+from datetime import date
+
+IGNORED_USERS = {}
+
+
+def rule(event):
+    return True

--- a/tests/fixtures/example_rule_invalid_mocks.yml
+++ b/tests/fixtures/example_rule_invalid_mocks.yml
@@ -1,0 +1,32 @@
+AnalysisType: rule
+Filename: example_rule_invalid_mocks.py
+DisplayName: Example Rule Invalid Mock
+Severity: Critical
+RuleID: Example.Rule.Invalid.Mock
+Enabled: true
+LogTypes:
+  - Example.Mock
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: Example Mocking Test
+    ExpectedResult: true
+    Log:
+      {
+        "field1": "value1",
+      }
+    Mocks:
+      [
+        {
+          "objectName": "boto3",
+          "returnValue": "example_boto3_return_value"
+        },
+        {
+          "objectName": "date",
+          "returnValue": ["example_date_return_value"]
+        },
+        {
+          "objectName": "badmock",
+          "returnValue": "badmockdata"
+        }
+      ]

--- a/tests/fixtures/example_rule_invalid_mocks.yml
+++ b/tests/fixtures/example_rule_invalid_mocks.yml
@@ -25,7 +25,7 @@ Tests:
           "objectName": "date",
           "returnValue": ["example_date_return_value"]
         },
-        {
+        {  # This is an invalid mock as `badmock` is not an object present in the python module
           "objectName": "badmock",
           "returnValue": "badmockdata"
         }

--- a/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.py
+++ b/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.py
@@ -1,0 +1,25 @@
+from panther import test_helper  # pylint: disable=import-error
+
+IGNORED_USERS = {}
+
+
+def rule(event):
+    if event['UserName'] in IGNORED_USERS:
+        return False
+
+    if 'CredentialReport' not in event:
+        return False
+
+    cred_report = event.get('CredentialReport', {})
+    if not cred_report:
+        return True
+
+    return (test_helper() and
+            cred_report.get('PasswordEnabled', False) and
+            cred_report.get('MfaActive', False))
+
+def dedup(event):
+    return event['UserName']
+
+def title(event):
+    return '{} does not have MFA enabled'.format(event['UserName'])

--- a/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.py
+++ b/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.py
@@ -1,25 +1,29 @@
-from panther import test_helper  # pylint: disable=import-error
-
 IGNORED_USERS = {}
 
 
 def rule(event):
-    if event['UserName'] in IGNORED_USERS:
-        return False
+    return True
 
-    if 'CredentialReport' not in event:
-        return False
-
-    cred_report = event.get('CredentialReport', {})
-    if not cred_report:
-        return True
-
-    return (test_helper() and
-            cred_report.get('PasswordEnabled', False) and
-            cred_report.get('MfaActive', False))
-
-def dedup(event):
-    return event['UserName']
 
 def title(event):
-    return '{} does not have MFA enabled'.format(event['UserName'])
+    return 'THIS IS AN EXAMPLE TITLE'
+
+
+def description(event):
+    return 'THIS IS AN EXAMPLE DESCRIPTION.'
+
+
+def destinations(event):
+    return ["ExampleDestinationName"]
+
+
+def runbook(event):
+    return 'THIS IS AN EXAMPLE RUNBOOK VALUE.'
+
+
+def reference(event):
+    return 'THIS IS AN EXAMPLE REFERENCE.'
+
+
+def severity(event):
+    return 'CRITICAL'

--- a/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.yml
+++ b/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.yml
@@ -1,0 +1,58 @@
+AnalysisType: rule 
+Filename: example_rule.py
+DisplayName: MFA Rule
+Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
+Severity: High
+Threshold: 5
+RuleID: AWS.CloudTrail.MFAEnabled
+Enabled: true
+SummaryAttributes:
+  - p_log_type
+  - p_any_ip_addresses
+LogTypes:
+  - AWS.CloudTrail
+Tags:
+  - AWS Managed Rules - Security, Identity & Compliance
+  - AWS
+  - CIS
+  - SOC2
+Runbook: >
+  Find out who disabled MFA on the account.
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: Root MFA not enabled fails compliance
+    ExpectedResult: false
+    Log:
+      Arn: arn:aws:iam::123456789012:user/root
+      CreateDate: 2019-01-01T00:00:00Z
+      CredentialReport:
+        MfaActive: false
+        PasswordEnabled: true
+      UserName: root
+  -
+    Name: User MFA not enabled fails compliance
+    ExpectedResult: false
+    Log:
+      {
+        "Arn": "arn:aws:iam::123456789012:user/test",
+        "CreateDate": "2019-01-01T00:00:00",
+        "CredentialReport": {
+          "MfaActive": false,
+          "PasswordEnabled": true
+        },
+        "UserName": "test"
+      }
+  -
+    Name: User MFA enabled passes compliance.
+    ExpectedResult: true
+    Log:
+      {
+        "Arn": "arn:aws:iam::123456789012:user/test",
+        "CreateDate": "2019-01-01T00:00:00",
+        "CredentialReport": {
+          "MfaActive": true,
+          "PasswordEnabled": true
+        },
+        "UserName": "test"
+      }

--- a/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.yml
+++ b/tests/fixtures/valid_analysis/rules/example_rule_generated_functions.yml
@@ -1,10 +1,10 @@
-AnalysisType: rule 
-Filename: example_rule.py
+AnalysisType: rule
+Filename: example_rule_generated_functions.py
 DisplayName: MFA Rule
 Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
 Severity: High
 Threshold: 5
-RuleID: AWS.CloudTrail.MFAEnabled
+RuleID: AWS.CloudTrail.MFAEnabledGenerated
 Enabled: true
 SummaryAttributes:
   - p_log_type
@@ -21,8 +21,8 @@ Runbook: >
 Reference: https://www.link-to-info.io
 Tests:
   -
-    Name: Root MFA not enabled fails compliance
-    ExpectedResult: false
+    Name: Example Test
+    ExpectedResult: true
     Log:
       Arn: arn:aws:iam::123456789012:user/root
       CreateDate: 2019-01-01T00:00:00Z
@@ -30,29 +30,3 @@ Tests:
         MfaActive: false
         PasswordEnabled: true
       UserName: root
-  -
-    Name: User MFA not enabled fails compliance
-    ExpectedResult: false
-    Log:
-      {
-        "Arn": "arn:aws:iam::123456789012:user/test",
-        "CreateDate": "2019-01-01T00:00:00",
-        "CredentialReport": {
-          "MfaActive": false,
-          "PasswordEnabled": true
-        },
-        "UserName": "test"
-      }
-  -
-    Name: User MFA enabled passes compliance.
-    ExpectedResult: true
-    Log:
-      {
-        "Arn": "arn:aws:iam::123456789012:user/test",
-        "CreateDate": "2019-01-01T00:00:00",
-        "CredentialReport": {
-          "MfaActive": true,
-          "PasswordEnabled": true
-        },
-        "UserName": "test"
-      }

--- a/tests/fixtures/valid_analysis/rules/example_rule_mocks.py
+++ b/tests/fixtures/valid_analysis/rules/example_rule_mocks.py
@@ -1,0 +1,25 @@
+from panther import test_helper # pylint: disable=import-error
+
+IGNORED_USERS = {}
+
+
+def rule(event):
+    if event['UserName'] in IGNORED_USERS:
+        return False
+
+    if 'CredentialReport' not in event:
+        return False
+
+    cred_report = event.get('CredentialReport', {})
+    if not cred_report:
+        return True
+
+    return (test_helper() and
+            cred_report.get('PasswordEnabled', False) and
+            cred_report.get('MfaActive', False))
+
+def dedup(event):
+    return event['UserName']
+
+def title(event):
+    return '{} does not have MFA enabled'.format(event['UserName'])

--- a/tests/fixtures/valid_analysis/rules/example_rule_mocks.py
+++ b/tests/fixtures/valid_analysis/rules/example_rule_mocks.py
@@ -1,25 +1,15 @@
-from panther import test_helper # pylint: disable=import-error
+import boto3
+from datetime import date
+from unittest.mock import MagicMock
 
 IGNORED_USERS = {}
 
 
 def rule(event):
-    if event['UserName'] in IGNORED_USERS:
-        return False
+    return all(isinstance(x, MagicMock) for x in [boto3, boto3.client, date])
 
-    if 'CredentialReport' not in event:
-        return False
-
-    cred_report = event.get('CredentialReport', {})
-    if not cred_report:
-        return True
-
-    return (test_helper() and
-            cred_report.get('PasswordEnabled', False) and
-            cred_report.get('MfaActive', False))
-
-def dedup(event):
-    return event['UserName']
 
 def title(event):
-    return '{} does not have MFA enabled'.format(event['UserName'])
+    return f"BOTO3: {isinstance(boto3, MagicMock)} - " \
+           f"BOTO3.CLIENT: {isinstance(boto3.client, MagicMock)} - " \
+           f"DATE: {isinstance(date, MagicMock)}"

--- a/tests/fixtures/valid_analysis/rules/example_rule_mocks.yml
+++ b/tests/fixtures/valid_analysis/rules/example_rule_mocks.yml
@@ -1,0 +1,59 @@
+AnalysisType: rule 
+Filename: example_rule_mocks.py
+DisplayName: MFA Rule
+Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
+Severity: High
+Threshold: 5
+RuleID: AWS.CloudTrail.MFAEnabledMocks
+Enabled: true
+SummaryAttributes:
+  - p_log_type
+  - p_any_ip_addresses
+LogTypes:
+  - AWS.CloudTrail
+Tags:
+  - AWS Managed Rules - Security, Identity & Compliance
+  - AWS
+  - CIS
+  - SOC2
+Runbook: >
+  Find out who disabled MFA on the account.
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: Root MFA not enabled fails compliance
+    ExpectedResult: false
+    Log:
+      Arn: arn:aws:iam::123456789012:user/root
+      CreateDate: 2019-01-01T00:00:00Z
+      CredentialReport:
+        MfaActive: false
+        PasswordEnabled: true
+      UserName: root
+  -
+    Name: User MFA not enabled fails compliance
+    ExpectedResult: false
+    Log:
+      {
+        "Arn": "arn:aws:iam::123456789012:user/test",
+        "CreateDate": "2019-01-01T00:00:00",
+        "CredentialReport": {
+          "MfaActive": false,
+          "PasswordEnabled": true
+        },
+        "UserName": "test"
+      }
+  -
+    Name: User MFA enabled passes compliance.
+    ExpectedResult: true
+    Log:
+      {
+        "Arn": "arn:aws:iam::123456789012:user/test",
+        "CreateDate": "2019-01-01T00:00:00",
+        "CredentialReport": {
+          "MfaActive": true,
+          "PasswordEnabled": true
+        },
+        "UserName": "test"
+      }
+      

--- a/tests/fixtures/valid_analysis/rules/example_rule_mocks.yml
+++ b/tests/fixtures/valid_analysis/rules/example_rule_mocks.yml
@@ -21,8 +21,8 @@ Runbook: >
 Reference: https://www.link-to-info.io
 Tests:
   -
-    Name: Root MFA not enabled fails compliance
-    ExpectedResult: false
+    Name: Example Mocking Test
+    ExpectedResult: true
     Log:
       Arn: arn:aws:iam::123456789012:user/root
       CreateDate: 2019-01-01T00:00:00Z
@@ -30,30 +30,14 @@ Tests:
         MfaActive: false
         PasswordEnabled: true
       UserName: root
-  -
-    Name: User MFA not enabled fails compliance
-    ExpectedResult: false
-    Log:
-      {
-        "Arn": "arn:aws:iam::123456789012:user/test",
-        "CreateDate": "2019-01-01T00:00:00",
-        "CredentialReport": {
-          "MfaActive": false,
-          "PasswordEnabled": true
+    Mocks:
+      [
+        {
+          "objectName": "boto3",
+          "returnValue": "example_boto3_return_value"
         },
-        "UserName": "test"
-      }
-  -
-    Name: User MFA enabled passes compliance.
-    ExpectedResult: true
-    Log:
-      {
-        "Arn": "arn:aws:iam::123456789012:user/test",
-        "CreateDate": "2019-01-01T00:00:00",
-        "CredentialReport": {
-          "MfaActive": true,
-          "PasswordEnabled": true
-        },
-        "UserName": "test"
-      }
-      
+        {
+          "objectName": "date",
+          "returnValue": ["example_date_return_value"]
+        }
+      ]

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -2,6 +2,7 @@ from datetime import datetime
 import os
 
 from pyfakefs.fake_filesystem_unittest import TestCase, Pause
+from schema import SchemaWrongKeyError
 from nose.tools import (assert_equal, assert_false, assert_is_instance,
                         assert_is_none, assert_true, raises, nottest,
                         with_setup)
@@ -17,20 +18,20 @@ class TestPantherAnalysisTool(TestCase):
         self.fs.add_real_directory(self.fixture_path)
 
     def test_valid_json_policy_spec(self):
-        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs(['tests/fixtures']):
             if spec_filename.endswith('example_policy.json'):
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
 
     def test_valid_yaml_policy_spec(self):
-        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs(['tests/fixtures']):
             if spec_filename.endswith('example_policy.yml'):
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
 
     def test_valid_pack_spec(self):
         pack_loaded = False
-        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs('tests/fixtures'):
+        for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs(['tests/fixtures']):
             if spec_filename.endswith('sample-pack.yml'):
                 assert_is_instance(loaded_spec, dict)
                 assert_true(loaded_spec != {})
@@ -47,12 +48,12 @@ class TestPantherAnalysisTool(TestCase):
         expected_output = '{} not in list of valid keys: {}'
         # test successful regex match and correct error returned
         test_str = "Wrong key 'DisplaName' in {'DisplaName':'one','Enabled':true, 'Filename':'sample'}"
-        exc = Exception(test_str)
+        exc = SchemaWrongKeyError(test_str)
         err = pat.handle_wrong_key_error(exc, sample_keys)
         assert_equal(str(err), expected_output.format("'DisplaName'", sample_keys))
         # test failing regex match
         test_str = "Will not match"
-        exc = Exception(test_str)
+        exc = SchemaWrongKeyError(test_str)
         err = pat.handle_wrong_key_error(exc, sample_keys)
         assert_equal(str(err),  expected_output.format("UNKNOWN_KEY", sample_keys))
 


### PR DESCRIPTION
### Background
Asana URL: Closes https://app.asana.com/0/1199940726973098/1199936555115825/f

Mocking Support within Unit Tests have been added in Panther's Rules Engine. 
Similarly, generated alert fields are also fully supported in Panther's Rules Engine.

### Changes

* Added support for mocking in unit tests
* Added support for generated alert fields (with type checking)
* General housekeeping/refactoring

### Testing

* `make test --path=./test/` (custom test files)
* `make unit`
* `make integration`
