### PR TITLE
Support case-insensitive lookup for test cases

### DIFF
--- a/tests/unit/panther_analysis_tool/test_test_case.py
+++ b/tests/unit/panther_analysis_tool/test_test_case.py
@@ -1,0 +1,20 @@
+import unittest
+from panther_analysis_tool.test_case import TestCase as PantherTestCase
+
+
+class TestPantherTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self.data = {"username": "someone@company.com", "ip": "10.0.0.1"}
+        self.data_model = None
+        self.test_case = PantherTestCase(self.data, self.data_model)
+
+    def test_get(self) -> None:
+        self.assertEqual(self.test_case.get('username'), self.data['username'])
+
+    def test_missing_key_lookup(self) -> None:
+        with self.assertRaises(KeyError):
+            _ = self.test_case['unknown']
+
+    def test_case_insensitive_lookup(self):
+        self.assertEqual(self.test_case['Username'], self.data['username'])
+


### PR DESCRIPTION
### Background

Addresses case-sensitive lookup support: https://app.asana.com/0/1200124882238265/1200116099665098

### Changes

* `TestCase`: Add case-insensitive lookup partial support for top-level fields only.
* `TestCase`: Remove non-required overrides for the Mapping sub-class and use inherited behavior.

### Testing

* Unit tests
* Executed `panther_analysis_tool test` on the latest master branch of `panther-analysis`.
