### PR TITLE
Specification file validation doesn't catch invalid sets

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -92,11 +92,28 @@ SCHEMAS: Dict[str, Schema] = {
     SCHEDULED_RULE: RULE_SCHEMA,
 }
 
+SET_FIELDS = [
+    "LogTypes",
+    "PackIDs",
+    "OutputIds",
+    "SummaryAttributes",
+    "Suppressions",
+    "Tags",
+]
+
 
 # exception for conflicting ids
 class AnalysisIDConflictException(Exception):
     def __init__(self, analysis_id: str):
         self.message = "Conflicting AnalysisID: [{}]".format(analysis_id)
+        super().__init__(self.message)
+
+
+# exception for conflicting ids
+class AnalysisContainsDuplicatesException(Exception):
+    def __init__(self, analysis_id: str, invalid_fields: List[str]):
+        self.message = "Specification with duplicates AnalysisID: [{}] : [{}]" \
+            .format(analysis_id, ', '.join(x for x in invalid_fields))
         super().__init__(self.message)
 
 
@@ -803,6 +820,10 @@ def classify_analysis(
             analysis_id = lookup_analysis_id(analysis_spec, analysis_type)
             if analysis_id in analysis_ids:
                 raise AnalysisIDConflictException(analysis_id)
+            # check for duplicates where panther expects a unique set
+            invalid_fields = contains_invalid_field_set(analysis_spec)
+            if invalid_fields:
+                raise AnalysisContainsDuplicatesException(analysis_id, invalid_fields)
             analysis_ids.append(analysis_id)
             # add the validated analysis type to the classified specs
             if analysis_type in [POLICY, RULE, SCHEDULED_RULE]:
@@ -846,6 +867,25 @@ def lookup_analysis_id(analysis_spec: Any, analysis_type: str) -> str:
     if analysis_type in [RULE, SCHEDULED_RULE]:
         analysis_id = analysis_spec["RuleID"]
     return analysis_id
+
+
+def contains_invalid_field_set(analysis_spec: Any) -> List[str]:
+    """Checks if the fields that Panther expects as sets have duplicates, returns True if invalid.
+
+    :param analysis_spec: Loaded YAML specification file
+    :return: bool - whether or not the specifications file is valid where False denotes valid.
+    """
+    invalid_fields = []
+    for field in SET_FIELDS:
+        if field not in analysis_spec:
+            continue
+        # Handle special case where we need to test for lowercase tags
+        if field == "Tags":
+            if len(analysis_spec[field]) != len(set(x.lower() for x in analysis_spec[field])):
+                invalid_fields.append("LowerTags")
+        if len(analysis_spec[field]) != len(set(analysis_spec[field])):
+            invalid_fields.append(field)
+    return invalid_fields
 
 
 def handle_wrong_key_error(err: SchemaWrongKeyError, keys: list) -> Exception:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -112,7 +112,7 @@ class AnalysisIDConflictException(Exception):
 # exception for conflicting ids
 class AnalysisContainsDuplicatesException(Exception):
     def __init__(self, analysis_id: str, invalid_fields: List[str]):
-        self.message = "Specification with duplicates AnalysisID: [{}] : [{}]" \
+        self.message = "Specification file for [{}] contains fields with duplicate values: [{}]" \
             .format(analysis_id, ', '.join(x for x in invalid_fields))
         super().__init__(self.message)
 

--- a/tests/fixtures/example_set_duplicates.py
+++ b/tests/fixtures/example_set_duplicates.py
@@ -1,0 +1,2 @@
+def rule(event):
+    return True

--- a/tests/fixtures/example_set_duplicates.yml
+++ b/tests/fixtures/example_set_duplicates.yml
@@ -1,0 +1,32 @@
+AnalysisType: rule
+Enabled: true
+Filename: example_set_duplicates.py
+RuleID: Example.Rule.Set.Duplicates
+LogTypes:
+  - AWS.CloudTrail
+  - AWS.CloudTrail
+Severity: Low
+DisplayName: Example Rule to Check the Format of the Spec
+Tags:
+  - Tags
+  - Tags
+  - tags
+Runbook: Find out who changed the spec format.
+Reference: https://www.link-to-info.io
+SummaryAttributes:
+  - example_dupe
+  - example_dupe
+OutputIds:
+  - 1234
+  - 1234
+Suppressions:
+  - asdf
+  - asdf
+Tests:
+  -
+    Name: Name to describe our first test.
+    ExpectedResult: true
+    Log:
+      {
+        "field1": "value1",
+      }

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -65,7 +65,7 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 1)
         assert_equal(invalid_specs[0][0],
                      f'{FIXTURES_PATH}/example_malformed_policy.yml')
-        assert_equal(len(invalid_specs), 7)
+        assert_equal(len(invalid_specs), 8)
 
     def test_policies_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {FIXTURES_PATH}/valid_analysis/policies'.split())
@@ -152,7 +152,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_invalid_rule_test(self):
         args = pat.setup_parser().parse_args(
@@ -160,7 +160,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_invalid_characters(self):
         args = pat.setup_parser().parse_args(
@@ -168,7 +168,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_unknown_exception(self):
         args = pat.setup_parser().parse_args(
@@ -176,7 +176,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_with_invalid_mocks(self):
         args = pat.setup_parser().parse_args(
@@ -184,7 +184,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_validate_outputs(self):
         example_valid_outputs = [
@@ -250,7 +250,7 @@ class TestPantherAnalysisTool(TestCase):
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because while there are two unit tests they both have expected result False
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_zip_analysis(self):
         # Note: This is a workaround for CI


### PR DESCRIPTION
Closes https://app.asana.com/0/1200175800812961/1199956661047427/f

### Background

When validating the specification file of a detection, `panther_analysis_tool` does not validate that 'set' fields have unique values. 

### Changes

* Added support for validating duplicates in fields where Panther expects a set instead of a list. 
* Added a test for duplicates in set fields and incremented expected invalid specs.

### Testing

* `make test`
* `panther_analysis_tool zip --path=/tmp/asdf` -- See SS below

![image](https://user-images.githubusercontent.com/71197790/115626179-20f63800-a2cb-11eb-872a-78b7efdd33fd.png)
