### PR TITLE
Support for Log Types & Resource Types Validation

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1213,13 +1213,13 @@ def setup_parser() -> argparse.ArgumentParser:
     )
     publish_parser.add_argument(
         "--github-owner",
-        help="The github owner of the repsitory",
+        help="The github owner of the repository",
         type=str,
         default="panther-labs",
     )
     publish_parser.add_argument(
         "--github-repository",
-        help="The github repsitory name",
+        help="The github repository name",
         type=str,
         default="panther-analysis",
     )

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -585,7 +585,9 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
 
     # First classify each file, always include globals and data models location
     specs, invalid_specs = classify_analysis(
-        list(load_analysis_specs(search_directories))
+        list(load_analysis_specs(search_directories)),
+        getattr(args, "ignore_logtypes_validation", False),
+        getattr(args, "ignore_resourcetypes_validation", False)
     )
 
     if all((len(specs[key]) == 0 for key in specs)):
@@ -771,7 +773,9 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
 
 
 def classify_analysis(
-    specs: List[Tuple[str, str, Any, Any]]
+    specs: List[Tuple[str, str, Any, Any]],
+    ignore_logtypes_validation: bool = False,
+    ignore_resourcetypes_validation: bool = False,
 ) -> Tuple[Dict[str, List[Any]], List[Any]]:
 
     # First setup return dict containing different
@@ -788,6 +792,9 @@ def classify_analysis(
 
     for analysis_spec_filename, dir_name, analysis_spec, error in specs:
         keys: List[Any] = list()
+        tmp_logtypes: Any = None
+        tmp_logtypes_key: Any = None
+        tmp_resourcetypes: Any = None
         try:
             # check for parsing errors from json.loads (ValueError) / yaml.safe_load (YAMLError)
             if error:
@@ -798,6 +805,29 @@ def classify_analysis(
             # validate the particular analysis type schema
             analysis_schema = SCHEMAS[analysis_type]
             keys = list(analysis_schema.schema.keys())
+            # Temporarily set schema definition to ignore validation
+            if ignore_logtypes_validation:
+                if "LogTypes" in analysis_spec:
+                    # Workaround since this is stored as "Or('LogTypes', 'ScheduledQueries'): [str]"
+                    for each_key in analysis_schema.schema.keys():
+                        if str(each_key) == "Or('LogTypes', 'ScheduledQueries')":
+                            tmp_logtypes_key = each_key
+                            break
+                    tmp_logtypes = analysis_schema.schema[tmp_logtypes_key]
+                    analysis_schema.schema[tmp_logtypes_key] = [str]
+            if ignore_resourcetypes_validation:
+                if "ResourceTypes" in analysis_spec:
+                    tmp_resourcetypes = analysis_schema.schema["ResourceTypes"]
+                    analysis_schema.schema["ResourceTypes"] = [str]
+            # Special case for ScheduledQueries to only validate the types
+            if "ScheduledQueries" in analysis_spec:
+                for each_key in analysis_schema.schema.keys():
+                    if str(each_key) == "Or('LogTypes', 'ScheduledQueries')":
+                        tmp_logtypes_key = each_key
+                        break
+                if not tmp_logtypes:
+                    tmp_logtypes = analysis_schema.schema[tmp_logtypes_key]
+                analysis_schema.schema[tmp_logtypes_key] = [str]
             analysis_schema.validate(analysis_spec)
             # lookup the analysis type id and validate there aren't any conflicts
             analysis_id = lookup_analysis_id(analysis_spec, analysis_type)
@@ -815,8 +845,18 @@ def classify_analysis(
                 )
         except SchemaWrongKeyError as err:
             invalid_specs.append((analysis_spec_filename, handle_wrong_key_error(err, keys)))
+        except SchemaError as err:
+            # Intercept the error to trim it down, otherwise the error message becomes confusing and unreadable
+            error = err
+            err_str = str(err)
+            first_half = err_str.split(':')[0]
+            second_half = err_str.split(')')[-1]
+            if "LogTypes" in str(err):
+                error = SchemaError(f"{first_half}: LOG_TYPE_REGEX{second_half}")
+            elif "ResourceTypes" in str(err):
+                error = SchemaError(f"{first_half}: RESOURCE_TYPE_REGEX{second_half}")
+            invalid_specs.append((analysis_spec_filename, error))
         except (
-            SchemaError,
             SchemaMissingKeyError,
             SchemaForbiddenKeyError,
             SchemaUnexpectedTypeError,
@@ -827,6 +867,12 @@ def classify_analysis(
             # Catch arbitrary exceptions thrown by bad specification files
             invalid_specs.append((analysis_spec_filename, err))
             continue
+        finally:
+            # Restore original values
+            if tmp_logtypes and tmp_logtypes_key:
+                analysis_schema.schema[tmp_logtypes_key] = tmp_logtypes
+            if tmp_resourcetypes:
+                analysis_schema.schema["ResourceTypes"] = tmp_resourcetypes
 
     return classified_specs, invalid_specs
 
@@ -1097,6 +1143,20 @@ def setup_parser() -> argparse.ArgumentParser:
         "type": strtobool,
         "help": "Meant for advanced users; allows skipping of extra keys from schema validation.",
     }
+    ignore_logtypes_validation = "--ignore-logtypes-validation"
+    ignore_logtypes_validation_arg: Dict[str, Any] = {
+        "required": False,
+        "default": False,
+        "type": strtobool,
+        "help": "Meant for advanced users; allows skipping of log types validation.",
+    }
+    ignore_resourcetypes_validation = "--ignore-resourcetypes-validation"
+    ignore_resourcetypes_validation_arg: Dict[str, Any] = {
+        "required": False,
+        "default": False,
+        "type": strtobool,
+        "help": "Meant for advanced users; allows skipping of resource types validation"
+    }
 
     parser = argparse.ArgumentParser(
         description="Panther Analysis Tool: A command line tool for "
@@ -1129,6 +1189,8 @@ def setup_parser() -> argparse.ArgumentParser:
     test_parser.add_argument(min_test_name, **min_test_arg)
     test_parser.add_argument(path_name, **path_arg)
     test_parser.add_argument(ignore_extra_keys_name, **ignore_extra_keys_arg)
+    test_parser.add_argument(ignore_logtypes_validation, **ignore_logtypes_validation_arg)
+    test_parser.add_argument(ignore_resourcetypes_validation, **ignore_resourcetypes_validation_arg)
     test_parser.set_defaults(func=test_analysis)
 
     publish_parser = subparsers.add_parser(
@@ -1185,6 +1247,8 @@ def setup_parser() -> argparse.ArgumentParser:
     upload_parser.add_argument(path_name, **path_arg)
     upload_parser.add_argument(skip_test_name, **skip_test_arg)
     upload_parser.add_argument(ignore_extra_keys_name, **ignore_extra_keys_arg)
+    upload_parser.add_argument(ignore_logtypes_validation, **ignore_logtypes_validation_arg)
+    upload_parser.add_argument(ignore_resourcetypes_validation, **ignore_resourcetypes_validation_arg)
     upload_parser.set_defaults(func=upload_analysis)
 
     update_schemas_parser = subparsers.add_parser(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -772,11 +772,12 @@ def filter_analysis(analysis: List[Any], filters: Dict[str, List]) -> List[Any]:
     return filtered_analysis
 
 
+# pylint: disable=too-many-locals,too-many-statements
 def classify_analysis(
     specs: List[Tuple[str, str, Any, Any]],
     ignore_logtypes_validation: bool = False,
     ignore_resourcetypes_validation: bool = False,
-) -> Tuple[Dict[str, List[Any]], List[Any]]:  # pylint: disable=too-many-locals,too-many-statements
+) -> Tuple[Dict[str, List[Any]], List[Any]]:
 
     # First setup return dict containing different
     # types of detections, meta types that can be zipped

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -26,7 +26,7 @@ RESOURCE_TYPE_REGEX = Regex(
     r"|EC2\.NetworkACL|EC2\.SecurityGroup|EC2\.Volume|EC2\.VPC|ECS\.Cluster|EKS\.Cluster|ELBV2"
     r"\.ApplicationLoadBalancer|GuardDuty\.Detector\.Meta|GuardDuty\.Detector|IAM\.Group|IAM"
     r"\.Policy|IAM\.Role|IAM\.RootUser|IAM\.User|KMS\.Key|Lambda\.Function|PasswordPolicy|RDS"
-    r"\.Instance|Redshift\.Cluster|S3\.Bucket|WAF\.Regional\.WebACL|WAF\.WebACL)$ "
+    r"\.Instance|Redshift\.Cluster|S3\.Bucket|WAF\.Regional\.WebACL|WAF\.WebACL)$"
 )
 LOG_TYPE_REGEX = Regex(
     r"^(Apache\.AccessCombined|Apache\.AccessCommon|AWS\.ALB|AWS\.AuroraMySQLAudit|AWS"
@@ -47,7 +47,7 @@ LOG_TYPE_REGEX = Regex(
     r"|Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\.LoginAs"
     r"|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|Slack"
     r"\.IntegrationLogs|Sophos\.Central|Suricata\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog"
-    r"\.RFC5424|Zeek\.DNS)$ "
+    r"\.RFC5424|Zeek\.DNS)$"
 )
 
 TYPE_SCHEMA = Schema(

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -20,29 +20,34 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from schema import And, Optional, Or, Regex, Schema
 
 NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9_. ()-]+$")
-RESOURCE_TYPE_REGEX = Regex(r"^AWS\.(ACM\.Certificate|CloudFormation\.Stack|CloudTrail\.Meta|CloudTrail|CloudWatch"
-                            r"\.LogGroup|Config\.Recorder\.Meta|Config\.Recorder|DynamoDB\.Table|EC2\.AMI|EC2"
-                            r"\.Instance|EC2\.NetworkACL|EC2\.SecurityGroup|EC2\.Volume|EC2\.VPC|ECS\.Cluster|EKS"
-                            r"\.Cluster|ELBV2\.ApplicationLoadBalancer|GuardDuty\.Detector\.Meta|GuardDuty\.Detector"
-                            r"|IAM\.Group|IAM\.Policy|IAM\.Role|IAM\.RootUser|IAM\.User|KMS\.Key|Lambda\.Function"
-                            r"|PasswordPolicy|RDS\.Instance|Redshift\.Cluster|S3\.Bucket|WAF\.Regional\.WebACL|WAF"
-                            r"\.WebACL)$")
+RESOURCE_TYPE_REGEX = Regex(
+    r"^AWS\.(ACM\.Certificate|CloudFormation\.Stack|CloudTrail\.Meta|CloudTrail|CloudWatch"
+    r"\.LogGroup|Config\.Recorder\.Meta|Config\.Recorder|DynamoDB\.Table|EC2\.AMI|EC2\.Instance"
+    r"|EC2\.NetworkACL|EC2\.SecurityGroup|EC2\.Volume|EC2\.VPC|ECS\.Cluster|EKS\.Cluster|ELBV2"
+    r"\.ApplicationLoadBalancer|GuardDuty\.Detector\.Meta|GuardDuty\.Detector|IAM\.Group|IAM"
+    r"\.Policy|IAM\.Role|IAM\.RootUser|IAM\.User|KMS\.Key|Lambda\.Function|PasswordPolicy|RDS"
+    r"\.Instance|Redshift\.Cluster|S3\.Bucket|WAF\.Regional\.WebACL|WAF\.WebACL)$ "
+)
 LOG_TYPE_REGEX = Regex(
-    r"^(Apache\.AccessCombined|Apache\.AccessCommon|AWS\.ALB|AWS\.AuroraMySQLAudit|AWS\.CloudTrail|AWS"
-    r"\.CloudTrailDigest|AWS\.CloudTrailInsight|AWS\.CloudWatchEvents|AWS\.GuardDuty|AWS\.S3ServerAccess|AWS\.VPCDns"
-    r"|AWS\.VPCFlow|Box\.Event|CiscoUmbrella\.CloudFirewall|CiscoUmbrella\.DNS|CiscoUmbrella\.IP|CiscoUmbrella\.Proxy"
-    r"|Cloudflare\.Firewall|Cloudflare\.HttpRequest|Cloudflare\.Spectrum|Crowdstrike\.AIDMaster|Crowdstrike"
-    r"\.DNSRequest|Crowdstrike\.GroupIdentity|Crowdstrike\.ManagedAssets|Crowdstrike\.NetworkConnect|Crowdstrike"
-    r"\.NetworkListen|Crowdstrike\.NotManagedAssets|Crowdstrike\.ProcessRollup2|Crowdstrike\.UserIdentity|Crowdstrike"
-    r"\.UserInfo|Duo\.Administrator|Duo\.Authentication|Duo\.OfflineEnrollment|Duo\.Telephony|Fastly\.Access|Fluentd"
-    r"\.Syslog3164|Fluentd\.Syslog5424|GCP\.AuditLog|GitLab\.API|GitLab\.Audit|GitLab\.Exceptions|GitLab\.Git|GitLab"
-    r"\.Integrations|GitLab\.Production|Gravitational\.TeleportAudit|GSuite\.Reports|Juniper\.Access|Juniper\.Audit"
-    r"|Juniper\.Firewall|Juniper\.MWS|Juniper\.Postgres|Juniper\.Security|Lacework\.Events|Microsoft365\.Audit"
-    r"\.AzureActiveDirectory|Microsoft365\.Audit\.Exchange|Microsoft365\.Audit\.General|Microsoft365\.Audit"
-    r"\.SharePoint|Microsoft365\.DLP\.All|Nginx\.Access|Okta\.SystemLog|OneLogin\.Events|Osquery\.Batch|Osquery"
-    r"\.Differential|Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\.LoginAs"
-    r"|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|Slack\.IntegrationLogs|Sophos\.Central"
-    r"|Suricata\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog\.RFC5424|Zeek\.DNS)$"
+    r"^(Apache\.AccessCombined|Apache\.AccessCommon|AWS\.ALB|AWS\.AuroraMySQLAudit|AWS"
+    r"\.CloudTrail|AWS\.CloudTrailDigest|AWS\.CloudTrailInsight|AWS\.CloudWatchEvents|AWS"
+    r"\.GuardDuty|AWS\.S3ServerAccess|AWS\.VPCDns|AWS\.VPCFlow|Box\.Event|CiscoUmbrella"
+    r"\.CloudFirewall|CiscoUmbrella\.DNS|CiscoUmbrella\.IP|CiscoUmbrella\.Proxy|Cloudflare"
+    r"\.Firewall|Cloudflare\.HttpRequest|Cloudflare\.Spectrum|Crowdstrike\.AIDMaster|Crowdstrike"
+    r"\.DNSRequest|Crowdstrike\.GroupIdentity|Crowdstrike\.ManagedAssets|Crowdstrike"
+    r"\.NetworkConnect|Crowdstrike\.NetworkListen|Crowdstrike\.NotManagedAssets|Crowdstrike"
+    r"\.ProcessRollup2|Crowdstrike\.UserIdentity|Crowdstrike\.UserInfo|Duo\.Administrator|Duo"
+    r"\.Authentication|Duo\.OfflineEnrollment|Duo\.Telephony|Fastly\.Access|Fluentd\.Syslog3164"
+    r"|Fluentd\.Syslog5424|GCP\.AuditLog|GitLab\.API|GitLab\.Audit|GitLab\.Exceptions|GitLab\.Git"
+    r"|GitLab\.Integrations|GitLab\.Production|Gravitational\.TeleportAudit|GSuite\.Reports"
+    r"|Juniper\.Access|Juniper\.Audit|Juniper\.Firewall|Juniper\.MWS|Juniper\.Postgres|Juniper"
+    r"\.Security|Lacework\.Events|Microsoft365\.Audit\.AzureActiveDirectory|Microsoft365\.Audit"
+    r"\.Exchange|Microsoft365\.Audit\.General|Microsoft365\.Audit\.SharePoint|Microsoft365\.DLP"
+    r"\.All|Nginx\.Access|Okta\.SystemLog|OneLogin\.Events|Osquery\.Batch|Osquery\.Differential"
+    r"|Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\.LoginAs"
+    r"|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|Slack"
+    r"\.IntegrationLogs|Sophos\.Central|Suricata\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog"
+    r"\.RFC5424|Zeek\.DNS)$ "
 )
 
 TYPE_SCHEMA = Schema(

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -47,7 +47,7 @@ LOG_TYPE_REGEX = Regex(
     r"|Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\.LoginAs"
     r"|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|Slack"
     r"\.IntegrationLogs|Sophos\.Central|Suricata\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog"
-    r"\.RFC5424|Zeek\.DNS)$"
+    r"\.RFC5424|Zeek\.DNS|Custom\.[A-Za-z0-9-]+)$"
 )
 
 TYPE_SCHEMA = Schema(

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -20,6 +20,30 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 from schema import And, Optional, Or, Regex, Schema
 
 NAME_ID_VALIDATION_REGEX = Regex(r"^[A-Za-z0-9_. ()-]+$")
+RESOURCE_TYPE_REGEX = Regex(r"^AWS\.(ACM\.Certificate|CloudFormation\.Stack|CloudTrail\.Meta|CloudTrail|CloudWatch"
+                            r"\.LogGroup|Config\.Recorder\.Meta|Config\.Recorder|DynamoDB\.Table|EC2\.AMI|EC2"
+                            r"\.Instance|EC2\.NetworkACL|EC2\.SecurityGroup|EC2\.Volume|EC2\.VPC|ECS\.Cluster|EKS"
+                            r"\.Cluster|ELBV2\.ApplicationLoadBalancer|GuardDuty\.Detector\.Meta|GuardDuty\.Detector"
+                            r"|IAM\.Group|IAM\.Policy|IAM\.Role|IAM\.RootUser|IAM\.User|KMS\.Key|Lambda\.Function"
+                            r"|PasswordPolicy|RDS\.Instance|Redshift\.Cluster|S3\.Bucket|WAF\.Regional\.WebACL|WAF"
+                            r"\.WebACL)$")
+LOG_TYPE_REGEX = Regex(
+    r"^(Apache\.AccessCombined|Apache\.AccessCommon|AWS\.ALB|AWS\.AuroraMySQLAudit|AWS\.CloudTrail|AWS"
+    r"\.CloudTrailDigest|AWS\.CloudTrailInsight|AWS\.CloudWatchEvents|AWS\.GuardDuty|AWS\.S3ServerAccess|AWS\.VPCDns"
+    r"|AWS\.VPCFlow|Box\.Event|CiscoUmbrella\.CloudFirewall|CiscoUmbrella\.DNS|CiscoUmbrella\.IP|CiscoUmbrella\.Proxy"
+    r"|Cloudflare\.Firewall|Cloudflare\.HttpRequest|Cloudflare\.Spectrum|Crowdstrike\.AIDMaster|Crowdstrike"
+    r"\.DNSRequest|Crowdstrike\.GroupIdentity|Crowdstrike\.ManagedAssets|Crowdstrike\.NetworkConnect|Crowdstrike"
+    r"\.NetworkListen|Crowdstrike\.NotManagedAssets|Crowdstrike\.ProcessRollup2|Crowdstrike\.UserIdentity|Crowdstrike"
+    r"\.UserInfo|Duo\.Administrator|Duo\.Authentication|Duo\.OfflineEnrollment|Duo\.Telephony|Fastly\.Access|Fluentd"
+    r"\.Syslog3164|Fluentd\.Syslog5424|GCP\.AuditLog|GitLab\.API|GitLab\.Audit|GitLab\.Exceptions|GitLab\.Git|GitLab"
+    r"\.Integrations|GitLab\.Production|Gravitational\.TeleportAudit|GSuite\.Reports|Juniper\.Access|Juniper\.Audit"
+    r"|Juniper\.Firewall|Juniper\.MWS|Juniper\.Postgres|Juniper\.Security|Lacework\.Events|Microsoft365\.Audit"
+    r"\.AzureActiveDirectory|Microsoft365\.Audit\.Exchange|Microsoft365\.Audit\.General|Microsoft365\.Audit"
+    r"\.SharePoint|Microsoft365\.DLP\.All|Nginx\.Access|Okta\.SystemLog|OneLogin\.Events|Osquery\.Batch|Osquery"
+    r"\.Differential|Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\.LoginAs"
+    r"|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|Slack\.IntegrationLogs|Sophos\.Central"
+    r"|Suricata\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog\.RFC5424|Zeek\.DNS)$"
+)
 
 TYPE_SCHEMA = Schema(
     {
@@ -35,7 +59,7 @@ DATA_MODEL_SCHEMA = Schema(
         "AnalysisType": Or("datamodel"),
         "DataModelID": And(str, NAME_ID_VALIDATION_REGEX),
         "Enabled": bool,
-        "LogTypes": [str],
+        "LogTypes": And([str], [LOG_TYPE_REGEX]),
         "Mappings": [
             {
                 "Name": str,
@@ -77,7 +101,7 @@ POLICY_SCHEMA = Schema(
         "Enabled": bool,
         "Filename": str,
         "PolicyID": And(str, NAME_ID_VALIDATION_REGEX),
-        "ResourceTypes": [str],
+        "ResourceTypes": And([str], [RESOURCE_TYPE_REGEX]),
         "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
         Optional("ActionDelaySeconds"): int,
         Optional("AutoRemediationID"): str,
@@ -113,7 +137,7 @@ RULE_SCHEMA = Schema(
         "Enabled": bool,
         "Filename": str,
         "RuleID": And(str, NAME_ID_VALIDATION_REGEX),
-        Or("LogTypes", "ScheduledQueries"): [str],
+        Or("LogTypes", "ScheduledQueries"): And([str], [LOG_TYPE_REGEX]),
         "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
         Optional("Description"): str,
         Optional("DedupPeriodMinutes"): int,

--- a/tests/fixtures/aws_globals.yml
+++ b/tests/fixtures/aws_globals.yml
@@ -3,7 +3,7 @@ Filename: aws_globals.py
 PolicyID: aws_globals
 Enabled: true
 ResourceTypes:
-  - AWS.Dummy.Type
+  - AWS.CloudTrail
 Tags:
   - AWS
 Severity: Info

--- a/tests/fixtures/example_malformed_policy.yml
+++ b/tests/fixtures/example_malformed_policy.yml
@@ -2,8 +2,8 @@ AnalysisType: policy
 DisplayName: MFA Is Not Enabled For User
 PolicyID: AWS.IAM.MFANotEnabled
 ResourceTypes:
-  - AWS.IAM.RootUser.Snapshot
-  - AWS.IAM.User.Snapshot
+  - AWS.IAM.RootUser
+  - AWS.IAM.User
 Tags:
   - AWS Managed Rules - Security, Identity & Compliance
   - AWS

--- a/tests/fixtures/example_policy.json
+++ b/tests/fixtures/example_policy.json
@@ -7,8 +7,8 @@
 	"PolicyID": "AWS.IAM.MFAEnabled.2",
 	"Enabled": true,
 	"ResourceTypes": [
-		"AWS.IAM.RootUser.Snapshot",
-		"AWS.IAM.User.Snapshot"
+		"AWS.IAM.RootUser",
+		"AWS.IAM.User"
 	],
 	"Tags": [
 		"AWS Managed Rules - Security, Identity & Compliance",

--- a/tests/fixtures/example_policy.yml
+++ b/tests/fixtures/example_policy.yml
@@ -6,8 +6,8 @@ Severity: High
 PolicyID: IAM.MFAEnabled
 Enabled: true
 ResourceTypes:
-  - AWS.IAM.RootUser.Snapshot
-  - AWS.IAM.User.Snapshot
+  - AWS.IAM.RootUser
+  - AWS.IAM.User
 Tags:
   - AWS Managed Rules - Security, Identity & Compliance
   - AWS

--- a/tests/fixtures/example_policy_bad_resource_type.py
+++ b/tests/fixtures/example_policy_bad_resource_type.py
@@ -1,0 +1,2 @@
+def policy(resource):
+    return True

--- a/tests/fixtures/example_policy_bad_resource_type.yml
+++ b/tests/fixtures/example_policy_bad_resource_type.yml
@@ -1,0 +1,18 @@
+AnalysisType: policy
+Filename: example_policy_bad_resource_type.py
+DisplayName: MFA Is Enabled For User
+Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
+Severity: High
+PolicyID: Example.Bad.Resource.Type
+Enabled: true
+ResourceTypes:
+  - AWS.IAM.RootUserz
+  - AWS.IAM.Userz
+Tags:
+  - bad_resource_type
+Runbook: >
+  Find out who disabled MFA on the account.
+Reference: https://www.link-to-info.io
+Suppressions:
+  - aws:resource:1
+  - aws:.*:other-resource

--- a/tests/fixtures/example_policy_import.yml
+++ b/tests/fixtures/example_policy_import.yml
@@ -5,7 +5,7 @@ Severity: Info
 PolicyID: AWS.Import
 Enabled: true
 ResourceTypes:
-  - AWS.Import.Test
+  - AWS.CloudTrail
 Tests:
   -
     Name: Always Returns True

--- a/tests/fixtures/example_policy_missing_policy_file.yml
+++ b/tests/fixtures/example_policy_missing_policy_file.yml
@@ -4,8 +4,8 @@ Severity: High
 PolicyID: Policy.Does.Not.Exist
 Enabled: true
 ResourceTypes:
-  - AWS.IAM.RootUser.Snapshot
-  - AWS.IAM.User.Snapshot
+  - AWS.IAM.RootUser
+  - AWS.IAM.User
 Tags:
   - AWS Managed Rules - Security, Identity & Compliance
   - AWS

--- a/tests/fixtures/example_policy_required_tests.yml
+++ b/tests/fixtures/example_policy_required_tests.yml
@@ -6,8 +6,8 @@ Severity: High
 PolicyID: IAM.MFAEnabled.Required.Tests 
 Enabled: true
 ResourceTypes:
-  - AWS.IAM.RootUser.Snapshot
-  - AWS.IAM.User.Snapshot
+  - AWS.IAM.RootUser
+  - AWS.IAM.User
 Tags:
   - AWS Managed Rules - Security, Identity & Compliance
   - AWS

--- a/tests/fixtures/example_rule_bad_log_type.py
+++ b/tests/fixtures/example_rule_bad_log_type.py
@@ -1,0 +1,2 @@
+def rule(event):
+    return True

--- a/tests/fixtures/example_rule_bad_log_type.yml
+++ b/tests/fixtures/example_rule_bad_log_type.yml
@@ -1,0 +1,19 @@
+AnalysisType: rule 
+Filename: example_rule_bad_log_type.py
+DisplayName: MFA Rule
+Description: MFA is a security best practice that adds an extra layer of protection for your AWS account logins.
+Severity: High
+Threshold: 5
+RuleID: Example.Bad.Log.Type
+Enabled: true
+SummaryAttributes:
+  - p_log_type
+  - p_any_ip_addresses
+LogTypes:
+  - AWS.CloudTrailz
+Tags:
+  - bad_log_type
+Runbook: >
+  Find out who disabled MFA on the account.
+Reference: https://www.link-to-info.io
+      

--- a/tests/fixtures/example_rule_invalid_mocks.yml
+++ b/tests/fixtures/example_rule_invalid_mocks.yml
@@ -5,7 +5,7 @@ Severity: Critical
 RuleID: Example.Rule.Invalid.Mock
 Enabled: true
 LogTypes:
-  - Example.Mock
+  - AWS.CloudTrail
 Reference: https://www.link-to-info.io
 Tests:
   -

--- a/tests/fixtures/example_rule_invalid_test.yml
+++ b/tests/fixtures/example_rule_invalid_test.yml
@@ -3,7 +3,7 @@ Enabled: true
 Filename: example_rule_invalid_test.py
 RuleID: Example.Rule.Invalid.Test
 LogTypes:
-  - Log.Type.Here
+  - AWS.CloudTrail
 Severity: Low
 DisplayName: Example Rule to Check the Format of the Spec
 Tags:

--- a/tests/fixtures/example_unhandled_exception.yml
+++ b/tests/fixtures/example_unhandled_exception.yml
@@ -3,7 +3,7 @@ Enabled: true
 Filename: example_unhandled_exception.py
 RuleID: Example.Rule.Unknown.Exception
 LogTypes:
-  - Log.Type.Here
+  - AWS.CloudTrail
 Severity: Low
 DisplayName: Example Rule to Check the Format of the Spec
 Tags:

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -268,25 +268,6 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 1)
         self.equal = assert_equal(len(invalid_specs), 7)
 
-    def test_invalid_resource_type_ignore_validation(self):
-        args = pat.setup_parser().parse_args(
-            f'test --path {FIXTURES_PATH} --filter Tags=bad_resource_type --ignore-logtypes-validation=true '
-            f'--ignore-resourcetypes-validation=true'.split())
-        args.filter = pat.parse_filter(args.filter)
-        return_code, invalid_specs = pat.test_analysis(args)
-        assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 9)
-
-    def test_invalid_log_type_ignore_validation(self):
-        self.args = pat.setup_parser().parse_args(
-            f'test --path {FIXTURES_PATH} --filter Tags=bad_log_type --ignore-logtypes-validation=true ' \
-            f'--ignore-resourcetypes-validation=true'.split())
-        args = self.args
-        args.filter = pat.parse_filter(args.filter)
-        return_code, invalid_specs = pat.test_analysis(args)
-        assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 9)
-
     def test_zip_analysis(self):
         # Note: This is a workaround for CI
         try:

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -65,7 +65,7 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 1)
         assert_equal(invalid_specs[0][0],
                      f'{FIXTURES_PATH}/example_malformed_policy.yml')
-        assert_equal(len(invalid_specs), 7)
+        assert_equal(len(invalid_specs), 9)
 
     def test_policies_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {FIXTURES_PATH}/valid_analysis/policies'.split())
@@ -152,7 +152,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 6)
 
     def test_invalid_rule_test(self):
         args = pat.setup_parser().parse_args(
@@ -160,7 +160,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 6)
 
     def test_invalid_characters(self):
         args = pat.setup_parser().parse_args(
@@ -168,7 +168,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 5)
+        assert_equal(len(invalid_specs), 7)
 
     def test_unknown_exception(self):
         args = pat.setup_parser().parse_args(
@@ -176,7 +176,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 6)
 
     def test_with_invalid_mocks(self):
         args = pat.setup_parser().parse_args(
@@ -184,7 +184,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 6)
 
     def test_validate_outputs(self):
         example_valid_outputs = [
@@ -250,7 +250,41 @@ class TestPantherAnalysisTool(TestCase):
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because while there are two unit tests they both have expected result False
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 6)
+
+    def test_invalid_resource_type(self):
+        args = pat.setup_parser().parse_args(
+            f'test --path {FIXTURES_PATH} --filter PolicyID=Example.Bad.Resource.Type'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 6)
+
+    def test_invalid_log_type(self):
+        args = pat.setup_parser().parse_args(
+            f'test --path {FIXTURES_PATH} --filter RuleID=Example.Bad.Log.Type'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 6)
+
+    def test_invalid_resource_type_ignore_validation(self):
+        args = pat.setup_parser().parse_args(
+            f'test --path {FIXTURES_PATH} --filter Tags=bad_resource_type --ignore-logtypes-validation=true '
+            f'--ignore-resourcetypes-validation=true'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 8)
+
+    def test_invalid_log_type_ignore_validation(self):
+        args = pat.setup_parser().parse_args(
+            f'test --path {FIXTURES_PATH} --filter Tags=bad_log_type --ignore-logtypes-validation=true '
+            f'--ignore-resourcetypes-validation=true'.split())
+        args.filter = pat.parse_filter(args.filter)
+        return_code, invalid_specs = pat.test_analysis(args)
+        assert_equal(return_code, 1)
+        assert_equal(len(invalid_specs), 8)
 
     def test_zip_analysis(self):
         # Note: This is a workaround for CI

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -168,7 +168,7 @@ class TestPantherAnalysisTool(TestCase):
         args.filter = pat.parse_filter(args.filter)
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
-        assert_equal(len(invalid_specs), 4)
+        assert_equal(len(invalid_specs), 5)
 
     def test_unknown_exception(self):
         args = pat.setup_parser().parse_args(


### PR DESCRIPTION
Closes https://app.asana.com/0/1200175800812961/1199956661047407/f

### Background

The Panther backend validates the `LogTypes` and `DetectionTypes` fields, however we currently do not support this validation in `panther_analysis_tool`. This PR adds support for validating these fields to provide users more consistency and advanced warning when using `panther_analysis_tool`.

Note that any additions in Panther necessitate changes here as well -- another case where we need some type of shared libraries between the two repositories

### Changes

* Added support via Regex for LogTypes and ResourceTypes
* Added flags that allow a user to ignore these validations for cases where there are custom LogTypes and ResourceTypes present
* Fixed typo `repsitory` -> `repository`

### Testing

* `make test`
* Tested in local environment, see attached SS
![image](https://user-images.githubusercontent.com/71197790/115790966-99c1c680-a395-11eb-9ca4-1314084303f5.png)
