### PR TITLE
Ignore Dot-Files

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -156,6 +156,9 @@ def load_analysis_specs(directories: List[str]) -> Iterator[Tuple[str, str, Any,
     loaded_specs: List[Any] = []
     for directory in directories:
         for relative_path, _, file_list in os.walk(directory):
+            # Skip hidden folders
+            if relative_path.split('/')[-1].startswith("."):
+                continue
             # setup yaml object
             yaml = YAML(typ="safe")
             # If the user runs with no path args, filter to make sure
@@ -179,6 +182,9 @@ def load_analysis_specs(directories: List[str]) -> Iterator[Tuple[str, str, Any,
                     logging.debug("Skipping path %s", relative_path)
                     continue
             for filename in sorted(file_list):
+                # Skip hidden files
+                if filename.startswith("."):
+                    continue
                 spec_filename = os.path.abspath(os.path.join(relative_path, filename))
                 # skip loading files that have already been imported
                 if spec_filename in loaded_specs:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -157,7 +157,7 @@ def load_analysis_specs(directories: List[str]) -> Iterator[Tuple[str, str, Any,
     for directory in directories:
         for relative_path, _, file_list in os.walk(directory):
             # Skip hidden folders
-            if relative_path.split('/')[-1].startswith("."):
+            if relative_path.split('/')[-1].startswith(".") and relative_path != "./":
                 continue
             # setup yaml object
             yaml = YAML(typ="safe")

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -157,7 +157,8 @@ def load_analysis_specs(directories: List[str]) -> Iterator[Tuple[str, str, Any,
     for directory in directories:
         for relative_path, _, file_list in os.walk(directory):
             # Skip hidden folders
-            if relative_path.split('/')[-1].startswith(".") and relative_path != "./":
+            if relative_path.split('/')[-1].startswith(".") and \
+                relative_path != "./" and relative_path != ".":
                 continue
             # setup yaml object
             yaml = YAML(typ="safe")


### PR DESCRIPTION
Closes https://app.asana.com/0/1199906407795548/1200249363083484/f

### Background

PAT attempts to load all of the YAML and JSON files found in the specified PATH, this however includes dot-files (nix hidden folders and hidden files)

### Changes

* Added conditional to skip dot-files 

### Testing

* See attached SS (ignore the failing tests, those are non-related 😄 )
 * Created a directory `.bad_rules` which contained a malformed detection `example_bad_rule.yml` and `example_bad_rule.py`
 * Created a malformed detection in the root directory `.example_bad_rule.yml` and `.example_bad_rule.py`

# Testing - Prior to changes

![image](https://user-images.githubusercontent.com/71197790/116586774-d2a6f180-a8e7-11eb-909d-bdb21b8141dc.png)

# Testing - After changes

![image](https://user-images.githubusercontent.com/71197790/116587028-13066f80-a8e8-11eb-94e6-4dbfc27d397f.png)
