### PR TITLE
Add requirements

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include requirements.txt

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1177,7 +1177,7 @@ def setup_parser() -> argparse.ArgumentParser:
         + "managing Panther policies and rules.",
         prog="panther_analysis_tool",
     )
-    parser.add_argument("--version", action="version", version="panther_analysis_tool 0.6.0")
+    parser.add_argument("--version", action="version", version="panther_analysis_tool 0.6.1")
     parser.add_argument("--debug", action="store_true", dest="debug")
     subparsers = parser.add_subparsers()
 

--- a/setup.py
+++ b/setup.py
@@ -20,14 +20,14 @@ with open('requirements.txt') as f:
 setup(
     name='panther_analysis_tool',
     packages=['panther_analysis_tool'],
-    version='0.6.0',
+    version='0.6.1',
     license='AGPL-3.0',
     description=
     'Panther command line interface for writing, testing, and packaging policies/rules.',
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.6.0.tar.gz',
+    download_url = 'https://github.com/panther-labs/panther_analysis_tool/archive/v0.6.1.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=install_requires,


### PR DESCRIPTION
### Background

When @georgepsarakis modified the `setup.py` file, it broke new pip installs as it relied on the existence of a file that is not present in the pip package. This PR adds a manifest file which I believe indicates to pip to include this file.

### Changes

* Add manifest file
* Bump to 0.6.1

### Testing

* None, not sure how to test
