### PR TITLE
PAT NotEQuals Filtering & Skip Test Disabled Options

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1462,7 +1462,7 @@ def zip_managed_schemas(args: argparse.Namespace) -> Tuple[int, str]:
 
 
 # Parses the filters, expects a list of strings
-def parse_filter(filters: List[str]) -> (Dict[str, Any], Dict[str, Any]):
+def parse_filter(filters: List[str]) -> [Dict[str, Any], Dict[str, Any]]:
     parsed_filters = {}
     parsed_filters_inverted = {}
     for filt in filters:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -836,7 +836,9 @@ def print_summary(
             print(err_message.format(spec_filename, spec_error))
 
 
-def filter_analysis(analysis: List[Any], filters: Dict[str, List], filters_inverted: Dict[str, List]) -> List[Any]:
+def filter_analysis(
+        analysis: List[Any], filters: Dict[str, List], filters_inverted: Dict[str, List]
+) -> List[Any]:
     if filters is None:
         return analysis
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -675,7 +675,9 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
         specs[key] = filter_analysis(specs[key], args.filter, args.filter_inverted)
 
     if all((len(specs[key]) == 0 for key in specs)):
-        return 1, ["No analysis in {} matched filters {} - {}".format(args.path, args.filter, args.filter_inverted)]
+        return 1, [
+            f"No analysis in {args.path} matched filters {args.filter} - {args.filter_inverted}"
+        ]
 
     # import each data model, global, policy, or rule and run its tests
     # first import the globals

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1462,7 +1462,7 @@ def zip_managed_schemas(args: argparse.Namespace) -> Tuple[int, str]:
 
 
 # Parses the filters, expects a list of strings
-def parse_filter(filters: List[str]) -> [Dict[str, Any], Dict[str, Any]]:
+def parse_filter(filters: List[str]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     parsed_filters = {}
     parsed_filters_inverted = {}
     for filt in filters:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1513,6 +1513,8 @@ def run() -> None:
 
     if getattr(args, "filter", None) is not None:
         args.filter, args.filter_inverted = parse_filter(args.filter)
+    if getattr(args, "filter_inverted", None) is None:
+        args.filter_inverted = {}
 
     # Although not best practice, the alternative is ugly and significantly harder to maintain.
     if bool(getattr(args, "ignore_extra_keys", None)):

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -96,6 +96,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_load_policy_specs_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {DETECTIONS_FIXTURES_PATH}'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 1)
         assert_equal(invalid_specs[0][0],
@@ -104,24 +105,28 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_policies_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {DETECTIONS_FIXTURES_PATH}/valid_analysis/policies'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
     def test_rules_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {DETECTIONS_FIXTURES_PATH}/valid_analysis/rules'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
     def test_queries_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {DETECTIONS_FIXTURES_PATH}/valid_analysis/queries'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
     def test_scheduled_rules_from_folder(self):
         args = pat.setup_parser().parse_args(f'test --path {DETECTIONS_FIXTURES_PATH}/valid_analysis/scheduled_rules'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
@@ -137,6 +142,7 @@ class TestPantherAnalysisTool(TestCase):
             try:
                 os.chdir(valid_rule_path)
                 args = pat.setup_parser().parse_args('test'.split())
+                args.filter_inverted = {}
                 return_code, invalid_specs = pat.test_analysis(args)
             finally:
                 os.chdir(original_path)
@@ -150,6 +156,7 @@ class TestPantherAnalysisTool(TestCase):
             original_path = os.getcwd()
             os.chdir(valid_rule_path)
             args = pat.setup_parser().parse_args('test --path ./'.split())
+            args.filter_inverted = {}
             return_code, invalid_specs = pat.test_analysis(args)
             os.chdir(original_path)
         # asserts are outside of the pause to ensure the fakefs gets resumed
@@ -276,6 +283,7 @@ class TestPantherAnalysisTool(TestCase):
     def test_with_minimum_tests(self):
         args = pat.setup_parser().parse_args(
             f'test --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --minimum-tests 1'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
@@ -283,6 +291,7 @@ class TestPantherAnalysisTool(TestCase):
     def test_with_minimum_tests_failing(self):
         args = pat.setup_parser().parse_args(
             f'test --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --minimum-tests 2'.split())
+        args.filter_inverted = {}
         return_code, invalid_specs = pat.test_analysis(args)
         # Failing, because some of the fixtures only have one test case
         assert_equal(return_code, 1)


### PR DESCRIPTION
### References

Closes https://app.asana.com/0/1200360676535738/1200356830724953/f

### Background

Request for the ability to use `!=` for filtering tags as well as an extra optional flag to skip tests for disabled detections.

### Changes

* Added inverted filtering functionality
* Added flag that allows for the skipping of tests for disabled detections

### Testing

* `make test`
* `make integration`
