### PR TITLE
Allow individual modules to be imported without loading main.py

### DIFF
--- a/bin/panther_analysis_tool
+++ b/bin/panther_analysis_tool
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 
-import panther_analysis_tool
-panther_analysis_tool.main.run()
+from panther_analysis_tool import main
+main.run()

--- a/panther_analysis_tool/__init__.py
+++ b/panther_analysis_tool/__init__.py
@@ -16,5 +16,3 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
-from panther_analysis_tool import main


### PR DESCRIPTION
### Background

`main.py` potentially performs global changes, such as modifying the logging configuration that could possibly affect other code that imports individual standalone modules or sub-packages.

Relates to https://app.asana.com/0/1200441743569436/1200434121289973

### Changes

* Update executable program to import `main` specifically.

### Testing

* CI