### PR TITLE
Port Panther Rules Engine rule execution logic and flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,11 @@ unit:
 
 integration:
 	pipenv run panther_analysis_tool test --path tests/fixtures/detections/valid_analysis
+	rm -rf panther-analysis
+	git clone https://github.com/panther-labs/panther-analysis.git
+	cd panther-analysis && cat requirements.txt | grep -v 'panther-analysis-tool==' > requirements.ci.txt
+	cd panther-analysis && pip install -r requirements.ci.txt
+	cd panther-analysis && pipenv run panther_analysis_tool --version && pipenv run panther_analysis_tool test --path .
 
 test: unit
 

--- a/panther_analysis_tool/destination.py
+++ b/panther_analysis_tool/destination.py
@@ -1,0 +1,10 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class FakeDestination:
+    """Stub class as a replacement for the Destination class
+    that wraps alert output metadata."""
+
+    destination_id: str
+    destination_display_name: str

--- a/panther_analysis_tool/exceptions.py
+++ b/panther_analysis_tool/exceptions.py
@@ -17,7 +17,7 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from typing import TypeVar
+from typing import Any, TypeVar
 
 AnyExceptionType = TypeVar("AnyExceptionType", bound="Exception")
 
@@ -38,3 +38,12 @@ class PantherError(Exception):
         if len(self.args) > 1:
             return f'{self.args[0]}: {", ".join(map(str, self.args[1:]))}'
         return self.args[0]
+
+
+class FunctionReturnTypeError(PantherError):
+    pass
+
+
+class UnknownDestinationError(PantherError):
+    def result(self) -> Any:
+        return self.args[1]

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -124,8 +124,12 @@ SET_FIELDS = [
     "Tags",
 ]
 
+# Available destination names for use by rules in tests
 AVAILABLE_DESTINATION_NAMES = ("ExampleDestinationName",)
 
+# The rule executor needs to map any destination names returned by the `destination` function
+# to actual destination objects. We are using a fake Destination dataclass, since we
+# just need the name and identifier fields.
 OUTPUT_DISPLAY_NAMES = {
     name: FakeDestination(destination_id=str(uuid4()), destination_display_name=name)
     for name in AVAILABLE_DESTINATION_NAMES

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -26,7 +26,6 @@ import json
 import logging
 import mimetypes
 import os
-import pathlib
 import re
 import subprocess  # nosec
 import sys
@@ -1309,7 +1308,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "default": None,
         "type": str,
         "action": "append",
-        "help": "A destination name that may be returned by the destination() function. "
+        "help": "A destination name that may be returned by the destinations function. "
         "Repeat the argument to define more than one name.",
     }
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -841,7 +841,7 @@ def setup_run_tests(
                 dict(
                     id=analysis_id,
                     analysisType=analysis_type,
-                    path=pathlib.Path(module_code_path),
+                    path=module_code_path,
                     versionId="0000-0000-0000",
                 )
             )
@@ -1169,25 +1169,26 @@ def _run_tests(
                     strict_check = (
                         function_name == "destinations" and destination_names_strict_check
                     )
-                    assertion = _check_auxiliary_function_result(
+                    aux_function_result = _evaluate_auxiliary_function_result(
                         function_name, rule_result, strict_check
                     )
 
                     # The function has not been executed, nothing to display
-                    if assertion["display"] is None:
+                    if aux_function_result["display"] is None:
                         continue
 
-                    if assertion["failed"]:
+                    if aux_function_result["failed"]:
                         # Mark the test as failed if an auxiliary function fails
                         test_result[function_name] = test_result["outcome"] = "FAIL"
                         failed_tests[analysis_id].append(f"{unit_test['Name']}:{function_name}")
 
                     auxiliary_functions_result_message += f"\t\t[{test_result[function_name]}] "
-                    if assertion["has_invalid_type"]:
+                    if aux_function_result["has_invalid_type"]:
                         auxiliary_functions_result_message += "[INVALID TYPE] "
                     auxiliary_functions_result_message += (
-                        f"[{function_name}] {assertion['display']}\n"
+                        f"[{function_name}] {aux_function_result['display']}\n"
                     )
+                auxiliary_functions_result_message = auxiliary_functions_result_message.rstrip()
 
         # print results
         print("\t[{}] {}".format(test_result["outcome"], unit_test["Name"]))
@@ -1197,7 +1198,7 @@ def _run_tests(
     return failed_tests
 
 
-def _check_auxiliary_function_result(
+def _evaluate_auxiliary_function_result(
     function_name: str, rule_result: RuleResult, strict_check: bool
 ) -> Dict[str, Any]:
     """Determine whether an auxiliary function for a rule raised an error"""

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1174,7 +1174,7 @@ def _run_tests(
                     )
 
                     # The function has not been executed, nothing to display
-                    if assertion['display'] is None:
+                    if assertion["display"] is None:
                         continue
 
                     if assertion["failed"]:
@@ -1185,7 +1185,9 @@ def _run_tests(
                     auxiliary_functions_result_message += f"\t\t[{test_result[function_name]}] "
                     if assertion["has_invalid_type"]:
                         auxiliary_functions_result_message += "[INVALID TYPE] "
-                    auxiliary_functions_result_message += f"[{function_name}] {assertion['display']}\n"
+                    auxiliary_functions_result_message += (
+                        f"[{function_name}] {assertion['display']}\n"
+                    )
 
         # print results
         print("\t[{}] {}".format(test_result["outcome"], unit_test["Name"]))

--- a/panther_analysis_tool/rule.py
+++ b/panther_analysis_tool/rule.py
@@ -31,7 +31,10 @@ from types import ModuleType
 from typing import Any, Callable, List, Optional
 
 from panther_analysis_tool.enriched_event import PantherEvent
-from panther_analysis_tool.exceptions import FunctionReturnTypeError, UnknownDestinationError
+from panther_analysis_tool.exceptions import (
+    FunctionReturnTypeError,
+    UnknownDestinationError,
+)
 from panther_analysis_tool.util import id_to_path, import_file_as_module, store_modules
 
 # Temporary alias for compatibility
@@ -377,9 +380,11 @@ class Rule:
 
         try:
             rule_result.title_defined = self._is_function_defined("title")
-            rule_result.title_output = self._get_title(event,
-                                                       function_defined=rule_result.title_defined,
-                                                       use_default_on_exception=batch_mode)
+            rule_result.title_output = self._get_title(
+                event,
+                function_defined=rule_result.title_defined,
+                use_default_on_exception=batch_mode,
+            )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.title_exception = err
 
@@ -388,7 +393,7 @@ class Rule:
             rule_result.description_output = self._get_description(
                 event,
                 function_defined=rule_result.description_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.description_exception = err
@@ -398,7 +403,7 @@ class Rule:
             rule_result.reference_output = self._get_reference(
                 event,
                 function_defined=rule_result.reference_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.reference_exception = err
@@ -408,7 +413,7 @@ class Rule:
             rule_result.severity_output = self._get_severity(
                 event,
                 function_defined=rule_result.severity_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.severity_exception = err
@@ -418,7 +423,7 @@ class Rule:
             rule_result.runbook_output = self._get_runbook(
                 event,
                 function_defined=rule_result.runbook_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.runbook_exception = err
@@ -426,9 +431,11 @@ class Rule:
         try:
             rule_result.destinations_defined = self._is_function_defined(DESTINATIONS_FUNCTION)
             rule_result.destinations_output = self._get_destinations(
-                event, outputs, outputs_names,
+                event,
+                outputs,
+                outputs_names,
                 function_defined=rule_result.destinations_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.destinations_exception = err
@@ -436,9 +443,10 @@ class Rule:
         try:
             rule_result.dedup_defined = self._is_function_defined(DEDUP_FUNCTION)
             rule_result.dedup_output = self._get_dedup(
-                event, rule_result.title_output,
+                event,
+                rule_result.title_output,
                 function_defined=rule_result.dedup_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.dedup_exception = err
@@ -448,7 +456,7 @@ class Rule:
             rule_result.alert_context_output = self._get_alert_context(
                 event,
                 function_defined=rule_result.alert_context_defined,
-                use_default_on_exception=batch_mode
+                use_default_on_exception=batch_mode,
             )
         except Exception as err:  # pylint: disable=broad-except
             rule_result.alert_context_exception = err
@@ -460,7 +468,7 @@ class Rule:
         # defaults to True and will pass the events thru
         if self.rule_type == TYPE_SCHEDULED_RULE and not hasattr(self._module, "rule"):
             return True
-        return self._run_command(self._module.rule, event, bool)
+        return self._run_command(self._module.rule, event, bool)  # type: ignore[attr-defined]
 
     def _get_alert_context(
         self, event: PantherEvent, function_defined: bool, use_default_on_exception: bool = True
@@ -493,7 +501,11 @@ class Rule:
     # If the rule match had a custom title, use the title as a deduplication string
     # If no title and no dedup function is defined, return the default dedup string.
     def _get_dedup(
-        self, event: PantherEvent, title: Optional[str], function_defined: bool, use_default_on_exception: bool = True,
+        self,
+        event: PantherEvent,
+        title: Optional[str],
+        function_defined: bool,
+        use_default_on_exception: bool = True,
     ) -> str:
         if not function_defined:
             if title:
@@ -568,8 +580,7 @@ class Rule:
             return description[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
         return description
 
-    # pylint: disable=too-many-return-statements
-    def _get_destinations(
+    def _get_destinations(  # pylint: disable=too-many-return-statements,too-many-arguments
         self,
         event: PantherEvent,
         outputs: dict,
@@ -739,7 +750,9 @@ class Rule:
             raise
         return severity
 
-    def _get_title(self, event: PantherEvent, function_defined: bool, use_default_on_exception: bool) -> Optional[str]:
+    def _get_title(
+        self, event: PantherEvent, function_defined: bool, use_default_on_exception: bool
+    ) -> Optional[str]:
         if not function_defined:
             return None
 

--- a/panther_analysis_tool/rule.py
+++ b/panther_analysis_tool/rule.py
@@ -28,7 +28,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import Any, Callable, List, Optional
+from typing import Any, Callable, List, Optional, Dict
 
 from panther_analysis_tool.enriched_event import PantherEvent
 from panther_analysis_tool.exceptions import (
@@ -353,7 +353,7 @@ class Rule:
 
         return importer.get_module(identifier, resource)
 
-    def _check_defined_functions(self):
+    def _check_defined_functions(self) -> Dict[str, bool]:
         function_definitions = {}
         for name in AUXILIARY_FUNCTIONS:
             function_definitions[name] = self._is_function_defined(name)
@@ -565,7 +565,7 @@ class Rule:
 
         return dedup_string
 
-    def _get_dedup_fallback(self, title):
+    def _get_dedup_fallback(self, title: Optional[str]) -> str:
         if title:
             # If no dedup function is defined but the rule
             # had a title, use the title as dedup string

--- a/tests/fixtures/detections/destinations/example_available_destination_name.py
+++ b/tests/fixtures/detections/destinations/example_available_destination_name.py
@@ -1,0 +1,6 @@
+def rule(event):
+    return True
+
+
+def destinations(event):
+    return ['Pagerduty']

--- a/tests/fixtures/detections/destinations/example_available_destination_name.yml
+++ b/tests/fixtures/detections/destinations/example_available_destination_name.yml
@@ -1,0 +1,20 @@
+AnalysisType: rule
+Enabled: true
+Filename: example_available_destination_name.py
+RuleID: Example.Rule.Available.Destination
+LogTypes:
+  - AWS.CloudTrail
+Severity: Low
+DisplayName: Example Rule to Check the Format of the Spec
+Tags:
+  - Tag1
+Runbook: Find out who changed the spec format.
+Reference: https://www.link-to-info.io
+Tests:
+  -
+    Name: Name to describe our first test
+    ExpectedResult: true
+    Log:
+      {
+        "field1": "value1",
+      }

--- a/tests/fixtures/detections/example_unhandled_exception_on_import.py
+++ b/tests/fixtures/detections/example_unhandled_exception_on_import.py
@@ -1,0 +1,4 @@
+import unknown_module
+
+def rule(event):
+    return True

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 from datetime import datetime
+import logging
 import os
 import shutil
 
@@ -34,6 +35,9 @@ FIXTURES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../'
 DETECTIONS_FIXTURES_PATH = os.path.join(FIXTURES_PATH, 'detections')
 
 print('Using fixtures path:', FIXTURES_PATH)
+
+if os.environ.get('PANTHER_ANALYSIS_TOOL_DEBUG'):
+    logging.getLogger().setLevel(logging.DEBUG)
 
 
 class TestPantherAnalysisTool(TestCase):

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -36,9 +36,6 @@ DETECTIONS_FIXTURES_PATH = os.path.join(FIXTURES_PATH, 'detections')
 
 print('Using fixtures path:', FIXTURES_PATH)
 
-if os.environ.get('PANTHER_ANALYSIS_TOOL_DEBUG'):
-    logging.getLogger().setLevel(logging.DEBUG)
-
 
 class TestPantherAnalysisTool(TestCase):
     def setUp(self):

--- a/tests/unit/panther_analysis_tool/test_rule.py
+++ b/tests/unit/panther_analysis_tool/test_rule.py
@@ -68,12 +68,34 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
         with self.assertRaisesRegex(ValueError, r'one of "body", "path" must be defined'):
             Rule({'id': 'test_create_rule_missing_body', 'versionId': 'version'})
 
-    def test_create_rule_defined_body_and_path(self) -> None:
+    def test_create_rule_defined_both_body_and_path(self) -> None:
         with self.assertRaises(ValueError):
             Rule({'id': 'test_create_rule_missing_body',
                   'versionId': 'version',
                   'body': 'def rule(event): pass',
-                  'path': pathlib.Path()})
+                  'path': '/rules/myrule.py'})
+
+    def test_create_rule_wrong_body_type(self) -> None:
+        with self.assertRaises(ValueError):
+            Rule({'id': 'test_create_rule_missing_body',
+                  'versionId': 'version',
+                  'body': None})
+
+        with self.assertRaises(TypeError):
+            Rule({'id': 'test_create_rule_missing_body',
+                  'versionId': 'version',
+                  'body': ['def rule(event): pass']})
+
+    def test_create_rule_wrong_path_type(self) -> None:
+        with self.assertRaises(ValueError):
+            Rule({'id': 'test_create_rule_missing_body',
+                  'versionId': 'version',
+                  'path': None})
+
+        with self.assertRaises(TypeError):
+            Rule({'id': 'test_create_rule_missing_body',
+                  'versionId': 'version',
+                  'path': ['/rules/myrule.py']})
 
     def test_create_rule_missing_version(self) -> None:
         exception = False

--- a/tests/unit/panther_analysis_tool/test_rule.py
+++ b/tests/unit/panther_analysis_tool/test_rule.py
@@ -64,17 +64,8 @@ class TestRule(TestCase):  # pylint: disable=too-many-public-methods
 
         self.assertTrue(exception)
 
-    def test_create_rule_missing_body(self) -> None:
-        exception = False
-        try:
-            Rule({'id': 'test_create_rule_missing_body', 'versionId': 'version'})
-        except AssertionError:
-            exception = True
-
-        self.assertTrue(exception)
-
     def test_create_rule_missing_body_and_path(self) -> None:
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, r'one of "body", "path" must be defined'):
             Rule({'id': 'test_create_rule_missing_body', 'versionId': 'version'})
 
     def test_create_rule_defined_body_and_path(self) -> None:


### PR DESCRIPTION
Closes https://app.asana.com/0/1200441743569436/1200267145879888

### Background

In order to mirror the behavior during of the core rule executor and eventually share the code between Panther Engine and PAT, the corresponding module is being transferred from the Engine here. The previous rule execution logic must be adapted / replaced by encapsulated functionality in the `Rule` class.

### Changes

* Add an integration test that checks that all detections defined `panther-analysis` pass.
* Allow a path to be passed directly to the `Rule` executor for importing the rule code as module, rather than creating a new temporary file containing the raw code.
* Adapt test setup procedure to instantiate `Rule` and utilize the `RuleResult` for evaluating and displaying execution results. 

### Testing

* Unit tests
* Run tests on `panther-analysis`: `panther_analysis_tool test --path .`