### PR TITLE
Fix bug in test - add global_helpers to search dir

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -678,8 +678,11 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
         "." + DATA_MODEL_LOCATION,
     ):
         absolute_dir_path = os.path.abspath(os.path.join(args.path, directory))
+        absolute_helper_path = os.path.abspath(directory)
         if os.path.exists(absolute_dir_path):
             search_directories.append(absolute_dir_path)
+        if os.path.exists(absolute_helper_path):
+            search_directories.append(absolute_helper_path)
 
     # First classify each file, always include globals and data models location
     specs, invalid_specs = classify_analysis(list(load_analysis_specs(search_directories)))

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -679,7 +679,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     ):
         absolute_dir_path = os.path.abspath(os.path.join(args.path, directory))
         absolute_helper_path = os.path.abspath(directory)
-        
+
         if os.path.exists(absolute_dir_path):
             search_directories.append(absolute_dir_path)
         if os.path.exists(absolute_helper_path):

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -679,6 +679,7 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     ):
         absolute_dir_path = os.path.abspath(os.path.join(args.path, directory))
         absolute_helper_path = os.path.abspath(directory)
+        
         if os.path.exists(absolute_dir_path):
             search_directories.append(absolute_dir_path)
         if os.path.exists(absolute_helper_path):


### PR DESCRIPTION
### Background

Fix a bug in test that causes the global_helpers directory to not get added to the search path when --path is not ".". This would cause tests to fail when rule had dependencies in global_helpers.

### Changes

Adds each `HELPERS_LOCATION` and `DATA_MODEL_LOCATION` to search_directories - if the path exists, regardless of what --path is passed to `test`. 

### Testing

- Create a rule that has a dependency in global_helpers.
- Test a specific rule (or a single directory of rules) with `panther_analysis_tool test --path path/to/rule`
