### PR TITLE
Add alert_context output

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -88,6 +88,7 @@ SCHEDULED_RULE = "scheduled_rule"
 RULE = "rule"
 
 RESERVED_FUNCTIONS = [
+    "alert_context",
     "dedup",
     "title",
     "description",
@@ -808,6 +809,8 @@ def setup_run_tests(
             analysis_funcs["run"] = module.policy
         elif analysis_type in [RULE, SCHEDULED_RULE]:
             analysis_funcs["run"] = module.rule
+            if "alert_context" in dir(module):
+                analysis_funcs["alert_context"] = module.alert_context
             if "dedup" in dir(module):
                 analysis_funcs["dedup"] = module.dedup
             if "title" in dir(module):
@@ -1189,6 +1192,8 @@ def validate_outputs(function_name: str, function_output: Any) -> Tuple[bool, An
                 f"Expected [{function_name}] to be any of the following: "
                 f"{str(VALID_SEVERITIES)}, got [{str(function_output)}] instead."
             )
+    elif function_name == "alert_context":
+        is_valid = isinstance(function_output, dict)
     elif function_name == "destinations":
         # Type checking for destinations
         if isinstance(function_output, list):

--- a/tests/fixtures/detections/valid_analysis/rules/example_rule_generated_functions.py
+++ b/tests/fixtures/detections/valid_analysis/rules/example_rule_generated_functions.py
@@ -8,6 +8,8 @@ def rule(event):
 def title(event):
     return 'THIS IS AN EXAMPLE TITLE'
 
+def alert_context(event):
+    return {'ip': '1.1.1.1'}
 
 def description(event):
     return 'THIS IS AN EXAMPLE DESCRIPTION.'

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -230,6 +230,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_validate_outputs(self):
         example_valid_outputs = [
+            ("alert_context", {"hello": "goodbye"}),
             ("dedup", "example title"),
             ("title", "example title"),
             ("description", "example description"),
@@ -240,6 +241,7 @@ class TestPantherAnalysisTool(TestCase):
             ("destinations", []),
         ]
         example_invalid_outputs = [
+            ("alert_context", ["hello", "goodbye"]),
             ("dedup", None),
             ("title", None),
             ("description", None),


### PR DESCRIPTION
### Background

Add the output of `alert_context` functions to the test results

### Changes

* add the output of `alert_context` to rule test results

### Testing

* `make test`

```bash
% panther_analysis_tool test --filter RuleID=AWS.Root.Activity
[INFO]: Testing analysis packs in .

AWS.Root.Activity
	[PASS] Root Activity - CreateServiceLinkedRole
	[PASS] Root Activity
		[PASS] [alert_context] {'sourceIPAddress': '111.111.111.111', 'userIdentityAccountId': '123456789012', 'userIdentityArn': 'arn:aws:iam::123456789012:root', 'eventTime': '2019-01-01T00:00:00Z', 'mfaUsed': None}
		[PASS] [dedup] 111.111.111.111:sample-account
		[PASS] [title] AWS root activity detected from [111.111.111.111] in account [sample-account]
	[PASS] IAMUser Activity
	[PASS] Root User Failed Activity
	[PASS] Successful Root Login
		[PASS] [alert_context] {'sourceIPAddress': '111.111.111.111', 'userIdentityAccountId': '123456789012', 'userIdentityArn': 'arn:aws:iam::123456789012:root', 'eventTime': '2019-01-01T00:00:00Z', 'mfaUsed': 'No'}
		[PASS] [dedup] 111.111.111.111:sample-account
		[PASS] [title] AWS root login detected from [111.111.111.111] in account [sample-account]

--------------------------
Panther CLI Test Summary
	Path: .
	Passed: 1
	Failed: 0
	Invalid: 0

 %
```
