### PR TITLE
Copy rule executor and result aggregator from Engine

### DIFF
--- a/panther_analysis_tool/rule.py
+++ b/panther_analysis_tool/rule.py
@@ -1,0 +1,695 @@
+"""
+Panther Analysis Tool is a command line interface for writing,
+testing, and packaging policies/rules.
+Copyright (C) 2020 Panther Labs Inc
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+import logging
+import os
+import re
+import tempfile
+import traceback
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional
+
+from panther_analysis_tool.enriched_event import PantherEvent
+from panther_analysis_tool.util import id_to_path, import_file_as_module, store_modules
+
+# Temporary alias for compatibility
+get_logger = logging.getLogger
+
+TYPE_RULE = "RULE"
+TYPE_SCHEDULED_RULE = "SCHEDULED_RULE"
+
+ERROR_TYPE_RULE = "RULE_ERROR"
+ERROR_TYPE_SCHEDULED_RULE = "SCHEDULED_RULE_ERROR"
+
+_RULE_FOLDER = os.path.join(tempfile.gettempdir(), "rules")
+
+# Maximum size for a dedup string
+MAX_DEDUP_STRING_SIZE = 1000
+
+# Maximum size for a generated field
+MAX_GENERATED_FIELD_SIZE = 1000
+
+# Maximum number of destinations
+MAX_DESTINATIONS_SIZE = 10
+
+# The limit for DDB is 400kb per item (we store this one in DDB) and
+# the limit for SQS/SNS is 256KB. The limit of 200kb is an approximation - the other
+# fields included in the request will be less than the remaining 56kb
+MAX_ALERT_CONTEXT_SIZE = 200 * 1024  # 200kb
+
+ALERT_CONTEXT_ERROR_KEY = "_error"
+
+TRUNCATED_STRING_SUFFIX = "... (truncated)"
+
+DEFAULT_RULE_DEDUP_PERIOD_MINS = 60
+
+# Used to check dynamic severity output
+SEVERITY_TYPES = ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+
+# pylint: disable=too-many-instance-attributes,unsubscriptable-object
+@dataclass
+class RuleResult:
+    """Class containing the result of running a rule"""
+
+    rule_id: str
+    rule_severity: str
+    setup_exception: Optional[Exception] = None
+
+    matched: Optional[bool] = None  # rule output
+    rule_exception: Optional[Exception] = None
+
+    dedup_output: Optional[str] = None
+    dedup_exception: Optional[Exception] = None
+
+    title_output: Optional[str] = None
+    title_exception: Optional[Exception] = None
+
+    description_output: Optional[str] = None
+    description_exception: Optional[Exception] = None
+
+    reference_output: Optional[str] = None
+    reference_exception: Optional[Exception] = None
+
+    severity_output: Optional[str] = None
+    severity_exception: Optional[Exception] = None
+
+    runbook_output: Optional[str] = None
+    runbook_exception: Optional[Exception] = None
+
+    destinations_output: Optional[List[str]] = None
+    destinations_exception: Optional[Exception] = None
+
+    alert_context: Optional[str] = None
+    alert_context_exception: Optional[Exception] = None
+
+    input_exception: Optional[Exception] = None
+
+    @property
+    def fatal_error(self) -> Optional[Exception]:
+        """Provide any error that would stop evaluation
+        or None, if no blocking error is found"""
+        exception = None
+        if self.setup_exception:
+            exception = self.setup_exception
+        elif self.rule_exception:
+            exception = self.rule_exception
+        elif self.input_exception:
+            exception = self.input_exception
+        return exception
+
+    @property
+    def error_type(self) -> Optional[str]:
+        """Returns the type of the exception, None if there was no error"""
+        fatal_error = self.fatal_error
+        if fatal_error is None:
+            return None
+        return type(fatal_error).__name__
+
+    @property
+    def short_error_message(self) -> Optional[str]:
+        """Returns short error message, None if there was no error"""
+        fatal_error = self.fatal_error
+        if fatal_error is None:
+            return None
+        return repr(fatal_error)
+
+    @property
+    def error_message(self) -> Optional[str]:
+        """Returns formatted error message with traceback"""
+        exception = self.fatal_error
+        if exception is None:
+            return None
+
+        trace = traceback.format_tb(exception.__traceback__)
+        # we only take last element of trace which will show the
+        # rule file name and line of the error, for example:
+        #    division by zero: AlwaysFail.py, line 4, in rule 1/0
+        file_trace = trace[len(trace) - 1].strip().replace("\n", "")
+        # this looks like: File "/tmp/rules/AlwaysFail.py", line 4, in rule 1/0 BUT
+        # we want just the file name
+        return str(exception) + ": " + re.sub(r'File.*/(.*[.]py)"', r"\1", file_trace)
+
+    @property
+    def errored(self) -> bool:
+        """Returns whether any of the rule functions raised an error"""
+        return bool(
+            self.rule_exception
+            or self.title_exception
+            or self.dedup_exception
+            or self.alert_context_exception
+            or self.description_exception
+            or self.reference_exception
+            or self.severity_exception
+            or self.runbook_exception
+            or self.destinations_exception
+            or self.setup_exception
+            or self.input_exception
+        )
+
+    @property
+    def rule_evaluation_failed(self) -> bool:
+        """Returns whether the rule function raises an error or an import error occurred"""
+        return bool(self.rule_exception or self.setup_exception)
+
+
+# pylint: disable=too-many-instance-attributes
+class Rule:
+    """Panther rule metadata and imported module."""
+
+    # pylint: disable=too-many-branches,too-many-statements
+    def __init__(self, config: Mapping):
+        """Create new rule from a dict.
+
+        Args:
+            config: Dictionary that we expect to have the following keys:
+                analysisType: either RULE or SCHEDULED_RULE
+                id: Unique rule identifier
+                body: The rule body
+                (Optional) version: The version of the rule
+                (Optional) dedupPeriodMinutes: The period during which
+                    the events will be deduplicated
+        """
+        self.logger = get_logger()
+
+        # Check for required string fields
+        for each_field in ["id", "body", "versionId"]:
+            if not (each_field in config) or not isinstance(config[each_field], str):
+                raise AssertionError('Field "%s" of type str is required field' % each_field)
+
+        if (
+            not "analysisType" in config
+        ):  # backwards compatible check for data from before we returned this
+            self.rule_type = TYPE_RULE
+        else:
+            self.rule_type = config["analysisType"]
+        self.rule_id = config["id"]
+        self.rule_body = config["body"]
+        self.rule_version = config["versionId"]
+
+        # TODO: severity and other rule metadata is not passed through when we run rule tests.
+        #       https://app.asana.com/0/1200360676535738/1200403272293475
+        if "severity" in config:
+            self.rule_severity = config["severity"]
+        else:
+            self.rule_severity = None
+
+        if not ("dedupPeriodMinutes" in config) or not isinstance(
+            config["dedupPeriodMinutes"], int
+        ):
+            self.rule_dedup_period_mins = DEFAULT_RULE_DEDUP_PERIOD_MINS
+        else:
+            self.rule_dedup_period_mins = config["dedupPeriodMinutes"]
+
+        if not ("tags" in config) or not isinstance(config["tags"], list):
+            self.rule_tags = list()
+        else:
+            config["tags"].sort()
+            self.rule_tags = config["tags"]
+
+        if "reports" not in config:
+            self.rule_reports = dict()
+        else:
+            # Reports are Dict[str, List[str]]
+            # Sorting the List before setting it
+            for values in config["reports"].values():
+                values.sort()
+            self.rule_reports = config["reports"]
+
+        self._store_rule()
+
+        self._setup_exception = None
+        try:
+            self._module = self._import_rule_as_module()
+            if not hasattr(self._module, "rule"):
+                raise AssertionError("rule needs to have a method named 'rule'")
+        except Exception as err:  # pylint: disable=broad-except
+            self._setup_exception = err
+            return
+
+        self._default_dedup_string = "defaultDedupString:{}".format(self.rule_id)
+
+    @property
+    def module(self) -> Any:
+        """Used to expose the loaded python module to the engine,
+        solely added in to support unit test mocking"""
+        return self._module
+
+    @property
+    def setup_exception(self) -> Any:
+        """Used to expose the setup exception to the engine"""
+        return self._setup_exception
+
+    def run(
+        self, event: PantherEvent, outputs: dict, outputs_names: dict, batch_mode: bool = True
+    ) -> RuleResult:
+        """
+        Analyze a log line with this rule and return True, False, or an error.
+        :param event: The event to run the rule against
+        :param outputs: Destinations loaded from the panther-outputs-api
+        :param outputs_names: Destinations mapped by their display name
+        :param batch_mode: Whether the rule runs as part of the log analysis
+        or as part of a simple rule test. In batch mode, title/dedup functions
+        are not checked if the rule won't trigger an alert and also title()/dedup()
+        won't raise exceptions, so that an alert won't be missed.
+        """
+        rule_result = RuleResult(rule_id=self.rule_id, rule_severity=self.rule_severity)
+        # If there was an error setting up the rule
+        # return early
+        if self._setup_exception:
+            rule_result.setup_exception = self._setup_exception
+            return rule_result
+
+        try:
+            rule_result.matched = self._run_rule(event)
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.rule_exception = err
+
+        if batch_mode and not rule_result.matched:
+            # In batch mode (log analysis), there is no need to run the title/dedup functions
+            # if the rule isn't going to trigger an alert
+            return rule_result
+
+        try:
+            rule_result.title_output = self._get_title(event, use_default_on_exception=batch_mode)
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.title_exception = err
+
+        try:
+            rule_result.description_output = self._get_description(
+                event, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.description_exception = err
+
+        try:
+            rule_result.reference_output = self._get_reference(
+                event, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.reference_exception = err
+
+        try:
+            rule_result.severity_output = self._get_severity(
+                event, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.severity_exception = err
+
+        try:
+            rule_result.runbook_output = self._get_runbook(
+                event, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.runbook_exception = err
+
+        try:
+            rule_result.destinations_output = self._get_destinations(
+                event, outputs, outputs_names, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.destinations_exception = err
+
+        try:
+            rule_result.dedup_output = self._get_dedup(
+                event, rule_result.title_output, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.dedup_exception = err
+
+        try:
+            rule_result.alert_context = self._get_alert_context(
+                event, use_default_on_exception=batch_mode
+            )
+        except Exception as err:  # pylint: disable=broad-except
+            rule_result.alert_context_exception = err
+
+        return rule_result
+
+    def _run_rule(self, event: PantherEvent) -> bool:
+        # for scheduled rules the rule function is optional,
+        # defaults to True and will pass the events thru
+        if self.rule_type == TYPE_SCHEDULED_RULE and not hasattr(self._module, "rule"):
+            return True
+        return self._run_command(self._module.rule, event, bool)
+
+    def _get_alert_context(
+        self, event: PantherEvent, use_default_on_exception: bool = True
+    ) -> Optional[str]:
+        if not hasattr(self._module, "alert_context"):
+            return None
+
+        try:
+            command = getattr(self._module, "alert_context")
+            alert_context = self._run_command(command, event, Mapping)
+            serialized_alert_context = json.dumps(alert_context, default=PantherEvent.json_encoder)
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                return json.dumps({ALERT_CONTEXT_ERROR_KEY: repr(err)})
+            raise
+
+        if len(serialized_alert_context) > MAX_ALERT_CONTEXT_SIZE:
+            # If context exceeds max size, return empty one
+            alert_context_error = (
+                "alert_context size is [{}] characters,"
+                " bigger than maximum of [{}] characters".format(
+                    len(serialized_alert_context), MAX_ALERT_CONTEXT_SIZE
+                )
+            )
+            return json.dumps({ALERT_CONTEXT_ERROR_KEY: alert_context_error})
+
+        return serialized_alert_context
+
+    # Returns the dedup string for this rule match
+    # If the rule match had a custom title, use the title as a deduplication string
+    # If no title and no dedup function is defined, return the default dedup string.
+    def _get_dedup(
+        self, event: PantherEvent, title: Optional[str], use_default_on_exception: bool = True
+    ) -> str:
+        if not hasattr(self._module, "dedup"):
+            if title:
+                # If no dedup function is defined but the rule
+                # had a title, use the title as dedup string
+                return title
+            # If no dedup function defined, return default dedup string
+            return self._default_dedup_string
+
+        try:
+            command = getattr(self._module, "dedup")
+            dedup_string = self._run_command(command, event, str)
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info(
+                    "dedup method raised exception. "
+                    'Defaulting dedup string to "%s". Exception: %s',
+                    self.rule_id,
+                    err,
+                )
+                return self._default_dedup_string
+            raise
+
+        if not dedup_string:
+            # If dedup string is None or empty, return the default dedup string
+            return self._default_dedup_string
+
+        if len(dedup_string) > MAX_DEDUP_STRING_SIZE:
+            # If dedup_string exceeds max size, truncate it
+            self.logger.info(
+                "maximum dedup string size is [%d] characters. "
+                "Dedup string for rule with ID [%s] is [%d] characters. Truncating.",
+                MAX_DEDUP_STRING_SIZE,
+                self.rule_id,
+                len(dedup_string),
+            )
+            num_characters_to_keep = MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)
+            return dedup_string[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
+
+        return dedup_string
+
+    def _get_description(
+        self, event: PantherEvent, use_default_on_exception: bool = True
+    ) -> Optional[str]:
+        if not hasattr(self._module, "description"):
+            return None
+
+        try:
+            command = getattr(self._module, "description")
+            description = self._run_command(command, event, str)
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info(
+                    "description method for rule with id [%s] raised exception. "
+                    "Using default Exception: %s",
+                    self.rule_id,
+                    err,
+                )
+                return ""
+            raise
+
+        if len(description) > MAX_GENERATED_FIELD_SIZE:
+            # If generated field exceeds max size, truncate it
+            self.logger.info(
+                "maximum field [description] length is [%d]. "
+                "[%d] for rule with ID [%s] . Truncating.",
+                MAX_GENERATED_FIELD_SIZE,
+                len(description),
+                self.rule_id,
+            )
+            num_characters_to_keep = MAX_GENERATED_FIELD_SIZE - len(TRUNCATED_STRING_SUFFIX)
+            return description[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
+        return description
+
+    # pylint: disable=too-many-return-statements
+    def _get_destinations(
+        self,
+        event: PantherEvent,
+        outputs: dict,
+        outputs_display_names: dict,
+        use_default_on_exception: bool = True,
+    ) -> Optional[List[str]]:
+        if not hasattr(self._module, "destinations"):
+            return None
+
+        try:
+            command = getattr(self._module, "destinations")
+            destinations = self._run_command(command, event, list())
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info("destinations method raised exception. Exception: %s", err)
+                return None
+            raise
+        # Return early if destinations returned None
+        if destinations is None:
+            return None
+
+        # Return early if destinations is an empty list (alert dest. suppression)
+        if len(destinations) == 0:
+            return ["SKIP"]
+
+        # Check for (in)valid destinations
+        invalid_destinations = []
+        standardized_destinations = []
+
+        # Standardize the destinations
+        for each_destination in destinations:
+            # case for valid display name
+            if (
+                each_destination in outputs_display_names
+                and outputs_display_names[each_destination].destination_id
+                not in standardized_destinations
+            ):
+                standardized_destinations.append(
+                    outputs_display_names[each_destination].destination_id
+                )
+            # case for valid UUIDv4
+            elif each_destination in outputs and each_destination not in standardized_destinations:
+                standardized_destinations.append(each_destination)
+            else:
+                invalid_destinations.append(each_destination)
+
+        if invalid_destinations:
+            if use_default_on_exception:
+                self.logger.info(
+                    "destinations method yielded invalid destinations: %s",
+                    str(invalid_destinations),
+                )
+                return None
+            raise ValueError("Invalid Destinations: {}".format(str(invalid_destinations)))
+
+        if len(standardized_destinations) > MAX_DESTINATIONS_SIZE:
+            # If generated field exceeds max size, truncate it
+            self.logger.info(
+                "maximum len of destinations [%d] for rule "
+                "with ID [%s] is [%d] fields. Truncating.",
+                MAX_DESTINATIONS_SIZE,
+                self.rule_id,
+                len(standardized_destinations),
+            )
+            return standardized_destinations[:MAX_DESTINATIONS_SIZE]
+        return standardized_destinations
+
+    def _get_reference(
+        self, event: PantherEvent, use_default_on_exception: bool = True
+    ) -> Optional[str]:
+        if not hasattr(self._module, "reference"):
+            return None
+
+        try:
+            command = getattr(self._module, "reference")
+            reference = self._run_command(command, event, str)
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info(
+                    "reference method for rule with id [%s] raised exception. "
+                    "Using default. Exception: %s",
+                    self.rule_id,
+                    err,
+                )
+                return ""
+            raise
+
+        if len(reference) > MAX_GENERATED_FIELD_SIZE:
+            # If generated field exceeds max size, truncate it
+            self.logger.info(
+                "maximum field [reference] length is [%d]. "
+                "[%d] for rule with ID [%s] . Truncating.",
+                MAX_GENERATED_FIELD_SIZE,
+                len(reference),
+                self.rule_id,
+            )
+            num_characters_to_keep = MAX_GENERATED_FIELD_SIZE - len(TRUNCATED_STRING_SUFFIX)
+            return reference[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
+        return reference
+
+    def _get_runbook(
+        self, event: PantherEvent, use_default_on_exception: bool = True
+    ) -> Optional[str]:
+        if not hasattr(self._module, "runbook"):
+            return None
+
+        try:
+            command = getattr(self._module, "runbook")
+            runbook = self._run_command(command, event, str)
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info(
+                    "runbook method for rule with id [%s] raised exception. "
+                    "Using default. Exception: %s",
+                    self.rule_id,
+                    err,
+                )
+                return ""
+            raise
+
+        if len(runbook) > MAX_GENERATED_FIELD_SIZE:
+            # If generated field exceeds max size, truncate it
+            self.logger.info(
+                "maximum field [runbook] length is [%d]. [%d] for rule with ID [%s] . Truncating.",
+                MAX_GENERATED_FIELD_SIZE,
+                len(runbook),
+                self.rule_id,
+            )
+            num_characters_to_keep = MAX_GENERATED_FIELD_SIZE - len(TRUNCATED_STRING_SUFFIX)
+            return runbook[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
+        return runbook
+
+    def _get_severity(
+        self, event: PantherEvent, use_default_on_exception: bool = True
+    ) -> Optional[str]:
+        if not hasattr(self._module, "severity"):
+            return None
+
+        try:
+            command = getattr(self._module, "severity")
+            severity = self._run_command(command, event, str).upper()
+            if severity not in SEVERITY_TYPES:
+                self.logger.info(
+                    "severity method for rule with id [%s] yielded [%s], expected [%s]",
+                    self.rule_id,
+                    severity,
+                    str(SEVERITY_TYPES),
+                )
+                raise AssertionError(
+                    "Expected severity to be any of the following: [%s], got [%s] instead."
+                    % (str(SEVERITY_TYPES), severity)
+                )
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info(
+                    "severity method for rule with id [%s] raised exception. "
+                    "Using default (%s). Exception: %s",
+                    self.rule_id,
+                    self.rule_severity,
+                    err,
+                )
+                return self.rule_severity
+            raise
+        return severity
+
+    def _get_title(self, event: PantherEvent, use_default_on_exception: bool) -> Optional[str]:
+        if not hasattr(self._module, "title"):
+            return None
+
+        try:
+            command = getattr(self._module, "title")
+            title = self._run_command(command, event, str)
+        except Exception as err:  # pylint: disable=broad-except
+            if use_default_on_exception:
+                self.logger.info(
+                    "title method for rule with id [%s] raised exception. "
+                    "Using default. Exception: %s",
+                    self.rule_id,
+                    err,
+                )
+                return self.rule_id
+            raise
+
+        if len(title) > MAX_GENERATED_FIELD_SIZE:
+            # If generated field exceeds max size, truncate it
+            self.logger.info(
+                "maximum field [title] length is [%d]. " "[%d] for rule with ID [%s] . Truncating.",
+                MAX_GENERATED_FIELD_SIZE,
+                len(title),
+                self.rule_id,
+            )
+            num_characters_to_keep = MAX_GENERATED_FIELD_SIZE - len(TRUNCATED_STRING_SUFFIX)
+            return title[:num_characters_to_keep] + TRUNCATED_STRING_SUFFIX
+        return title
+
+    def _store_rule(self) -> None:
+        """Stores rule to disk."""
+        path = id_to_path(_RULE_FOLDER, self.rule_id)
+        self.logger.debug("storing rule in path %s", path)
+        store_modules(path, self.rule_body)
+
+    def _import_rule_as_module(self) -> Any:
+        """Dynamically import a Python module from a file.
+
+        See also: https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
+        """
+        path = id_to_path(_RULE_FOLDER, self.rule_id)
+        mod = import_file_as_module(path, self.rule_id)
+        self.logger.debug("imported module %s from path %s", self.rule_id, path)
+        return mod
+
+    def _run_command(self, function: Callable, event: PantherEvent, expected_type: Any) -> Any:
+        result = function(event)
+        # Branch in case of list
+        if not isinstance(expected_type, list):
+            if not isinstance(result, expected_type):
+                raise Exception(
+                    "rule [{}] function [{}] returned [{}], expected [{}]".format(
+                        self.rule_id,
+                        function.__name__,
+                        type(result).__name__,
+                        expected_type.__name__,
+                    )
+                )
+        else:
+            if result is None:
+                return result
+            if not isinstance(result, list) or not all(isinstance(x, (str, bool)) for x in result):
+                raise Exception(
+                    "rule [{}] function [{}] returned [{}], expected a list".format(
+                        self.rule_id, function.__name__, type(result).__name__
+                    )
+                )
+        return result

--- a/tests/unit/panther_analysis_tool/test_rule.py
+++ b/tests/unit/panther_analysis_tool/test_rule.py
@@ -1,0 +1,640 @@
+"""
+Panther Analysis Tool is a command line interface for writing,
+testing, and packaging policies/rules.
+Copyright (C) 2020 Panther Labs Inc
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as
+published by the Free Software Foundation, either version 3 of the
+License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import dataclasses
+import json
+from typing import Tuple, Optional, Any
+from unittest import TestCase
+
+from panther_analysis_tool.enriched_event import PantherEvent
+
+from panther_analysis_tool.rule import MAX_DEDUP_STRING_SIZE, MAX_GENERATED_FIELD_SIZE, Rule, RuleResult, TRUNCATED_STRING_SUFFIX
+
+
+class TestRule(TestCase):  # pylint: disable=too-many-public-methods
+    # TODO: update type annotation for checked objects to be dataclass in Python 3.8+
+    def assertDataclassEqual(  # pylint: disable=invalid-name
+            self,
+            first: Any,
+            second: Any,
+            fields_as_string: Optional[Tuple[str, ...]] = None) -> None:
+        """
+        Compare two dataclass instances by first converting them to dictionaries.
+        In order to allow comparison for non-comparable objects, such as exception instances,
+        a list of fields to be converted to their string representation can be given.
+        """
+        self.assertIsInstance(first, type(second))
+        fields_as_string = fields_as_string or ()
+        first = dataclasses.asdict(first)
+        second = dataclasses.asdict(second)
+        for string_repr_field in fields_as_string:
+            first[string_repr_field] = str(first[string_repr_field])
+            second[string_repr_field] = str(second[string_repr_field])
+        return self.assertDictEqual(first, second)
+
+    def test_create_rule_missing_id(self) -> None:
+        exception = False
+        try:
+            Rule({'body': 'rule', 'versionId': 'version'})
+        except AssertionError:
+            exception = True
+
+        self.assertTrue(exception)
+
+    def test_create_rule_missing_body(self) -> None:
+        exception = False
+        try:
+            Rule({'id': 'test_create_rule_missing_body', 'versionId': 'version'})
+        except AssertionError:
+            exception = True
+
+        self.assertTrue(exception)
+
+    def test_create_rule_missing_version(self) -> None:
+        exception = False
+        try:
+            Rule({'id': 'test_create_rule_missing_version', 'body': 'rule'})
+        except AssertionError:
+            exception = True
+
+        self.assertTrue(exception)
+
+    def test_rule_default_dedup_time(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True'
+        rule = Rule({'id': 'test_rule_default_dedup_time', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        self.assertEqual(60, rule.rule_dedup_period_mins)
+
+    def test_rule_tags(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True'
+        rule = Rule(
+            {
+                'id': 'test_rule_default_dedup_time',
+                'body': rule_body,
+                'versionId': 'versionId',
+                'tags': ['tag2', 'tag1'],
+                'severity': 'INFO'
+            }
+        )
+
+        self.assertEqual(['tag1', 'tag2'], rule.rule_tags)
+
+    def test_rule_reports(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True'
+        rule = Rule(
+            {
+                'id': 'test_rule_default_dedup_time',
+                'body': rule_body,
+                'versionId': 'versionId',
+                'reports': {
+                    'key1': ['value2', 'value1'],
+                    'key2': ['value1']
+                },
+                'severity': 'INFO'
+            }
+        )
+
+        self.assertEqual({'key1': ['value1', 'value2'], 'key2': ['value1']}, rule.rule_reports)
+
+    def test_create_rule_missing_method(self) -> None:
+        exception = False
+        rule_body = 'def another_method(event):\n\treturn False'
+        try:
+            Rule({'id': 'test_create_rule_missing_method', 'body': rule_body})
+        except AssertionError:
+            exception = True
+
+        self.assertTrue(exception)
+
+    def test_rule_matches(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True'
+        rule = Rule({'id': 'test_rule_matches', 'body': rule_body, 'dedupPeriodMinutes': 100, 'versionId': 'test', 'severity': 'INFO'})
+
+        self.assertEqual('test_rule_matches', rule.rule_id)
+        self.assertEqual(rule_body, rule.rule_body)
+        self.assertEqual('test', rule.rule_version)
+        self.assertEqual(100, rule.rule_dedup_period_mins)
+
+        expected_rule = RuleResult(
+            rule_id='test_rule_matches',
+            matched=True,
+            dedup_output='defaultDedupString:test_rule_matches',
+            rule_severity='INFO',
+        )
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_rule_doesnt_match(self) -> None:
+        rule_body = 'def rule(event):\n\treturn False'
+        rule = Rule({'id': 'test_rule_doesnt_match', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        expected_rule = RuleResult(matched=False, rule_id='test_rule_doesnt_match', rule_severity='INFO')
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_rule_with_dedup(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "testdedup"'
+        rule = Rule({'id': 'test_rule_with_dedup', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        expected_rule = RuleResult(rule_id='test_rule_with_dedup', matched=True, dedup_output='testdedup', rule_severity='INFO')
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_restrict_dedup_size(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn "".join("a" for i in range({}))'. \
+            format(MAX_DEDUP_STRING_SIZE + 1)
+        rule = Rule({'id': 'test_restrict_dedup_size', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_dedup_string_prefix = ''.join('a' for _ in range(MAX_DEDUP_STRING_SIZE - len(TRUNCATED_STRING_SUFFIX)))
+        expected_rule = RuleResult(
+            rule_id='test_restrict_dedup_size',
+            matched=True,
+            dedup_output=expected_dedup_string_prefix + TRUNCATED_STRING_SUFFIX,
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_restrict_title_size(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def dedup(event):\n\treturn "test"\n' \
+                    'def title(event):\n\treturn "".join("a" for i in range({}))'. \
+            format(MAX_GENERATED_FIELD_SIZE + 1)
+        rule = Rule({'id': 'test_restrict_title_size', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_title_string_prefix = ''.join('a' for _ in range(MAX_GENERATED_FIELD_SIZE - len(TRUNCATED_STRING_SUFFIX)))
+        expected_rule = RuleResult(
+            rule_id='test_restrict_title_size',
+            matched=True,
+            dedup_output='test',
+            title_output=expected_title_string_prefix + TRUNCATED_STRING_SUFFIX,
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_empty_dedup_result_to_default(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
+        rule = Rule({'id': 'test_empty_dedup_result_to_default', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_rule = RuleResult(
+            rule_id='test_empty_dedup_result_to_default',
+            matched=True,
+            dedup_output='defaultDedupString:test_empty_dedup_result_to_default',
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_rule_throws_exception(self) -> None:
+        rule_body = 'def rule(event):\n\traise Exception("test")'
+        rule = Rule({'id': 'test_rule_throws_exception', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        rule_result = rule.run(PantherEvent({}, None), {}, {})
+        self.assertIsNone(rule_result.matched)
+        self.assertIsNone(rule_result.dedup_output)
+        self.assertIsNotNone(rule_result.rule_exception)
+
+    def test_invalid_python_syntax(self) -> None:
+        rule_body = 'def rule(test):this is invalid python syntax'
+        rule = Rule({'id': 'test_invalid_python_syntax', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        rule_result = rule.run(PantherEvent({}, None), {}, {})
+        self.assertIsNone(rule_result.matched)
+        self.assertIsNone(rule_result.dedup_output)
+        self.assertIsNone(rule_result.rule_exception)
+
+        self.assertTrue(rule_result.errored)
+        self.assertEqual(rule_result.error_type, "SyntaxError")
+        self.assertIsNotNone(rule_result.short_error_message)
+        self.assertIsNotNone(rule_result.error_message)
+
+    def test_rule_invalid_rule_return(self) -> None:
+        rule_body = 'def rule(event):\n\treturn "test"'
+        rule = Rule({'id': 'test_rule_invalid_rule_return', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        rule_result = rule.run(PantherEvent({}, None), {}, {})
+        self.assertIsNone(rule_result.matched)
+        self.assertIsNone(rule_result.dedup_output)
+        self.assertTrue(rule_result.errored)
+
+        expected_short_msg = "Exception('rule [test_rule_invalid_rule_return] function [rule] returned [str], expected [bool]')"
+        self.assertEqual(expected_short_msg, rule_result.short_error_message)
+        self.assertEqual(rule_result.error_type, 'Exception')
+
+    def test_dedup_throws_exception(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
+        rule = Rule({'id': 'test_dedup_throws_exception', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_rule = RuleResult(
+            rule_id='test_dedup_throws_exception',
+            matched=True,
+            dedup_output='defaultDedupString:test_dedup_throws_exception',
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_dedup_exception_batch_mode(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\traise Exception("test")'
+        rule = Rule({'id': 'test_dedup_throws_exception', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        actual = rule.run(PantherEvent({}, None), {}, {}, batch_mode=False)
+
+        self.assertTrue(actual.matched)
+        self.assertIsNotNone(actual.dedup_exception)
+        self.assertTrue(actual.errored)
+
+    def test_rule_invalid_dedup_return(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn {}'
+        rule = Rule({'id': 'test_rule_invalid_dedup_return', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_rule = RuleResult(
+            rule_id='test_rule_invalid_dedup_return',
+            matched=True,
+            dedup_output='defaultDedupString:test_rule_invalid_dedup_return',
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_rule, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_rule_dedup_returns_empty_string(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef dedup(event):\n\treturn ""'
+        rule = Rule({'id': 'test_rule_dedup_returns_empty_string', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_dedup_returns_empty_string',
+            matched=True,
+            dedup_output='defaultDedupString:test_rule_dedup_returns_empty_string',
+            rule_severity='INFO'
+        )
+        self.assertEqual(rule.run(PantherEvent({}, None), {}, {}), expected_result)
+
+    def test_rule_matches_with_title_without_dedup(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn "title"'
+        rule = Rule({'id': 'test_rule_matches_with_title', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_matches_with_title', matched=True, dedup_output='title', title_output='title', rule_severity='INFO'
+        )
+        self.assertEqual(rule.run(PantherEvent({}, None), {}, {}), expected_result)
+
+    def test_rule_title_throws_exception(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\traise Exception("test")'
+        rule = Rule({'id': 'test_rule_title_throws_exception', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_title_throws_exception',
+            matched=True,
+            dedup_output='test_rule_title_throws_exception',
+            title_output='test_rule_title_throws_exception',
+            rule_severity='INFO'
+        )
+        self.assertEqual(rule.run(PantherEvent({}, None), {}, {}), expected_result)
+
+    def test_rule_invalid_title_return(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn {}'
+        rule = Rule({'id': 'test_rule_invalid_title_return', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_invalid_title_return',
+            matched=True,
+            dedup_output='test_rule_invalid_title_return',
+            title_output='test_rule_invalid_title_return',
+            rule_severity='INFO'
+        )
+        self.assertEqual(rule.run(PantherEvent({}, None), {}, {}), expected_result)
+
+    def test_rule_title_returns_empty_string(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef title(event):\n\treturn ""'
+        rule = Rule({'id': 'test_rule_title_returns_empty_string', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_title_returns_empty_string',
+            matched=True,
+            dedup_output='defaultDedupString:test_rule_title_returns_empty_string',
+            title_output='',
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_alert_context(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef alert_context(event):\n\treturn {"string": "string", "int": 1, "nested": {}}'
+        rule = Rule({'id': 'test_alert_context', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_alert_context',
+            matched=True,
+            dedup_output='defaultDedupString:test_alert_context',
+            alert_context='{"string": "string", "int": 1, "nested": {}}',
+            rule_severity='INFO',
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_alert_context_invalid_return_value(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\ndef alert_context(event):\n\treturn ""'
+        rule = Rule({'id': 'test_alert_context_invalid_return_value', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_alert_context = json.dumps(
+            {
+                '_error':
+                    'Exception(\'rule [test_alert_context_invalid_return_value] function [alert_context] returned [str], expected [Mapping]\')'  # pylint: disable=C0301
+            }
+        )
+        expected_result = RuleResult(
+            rule_id='test_alert_context_invalid_return_value',
+            matched=True,
+            dedup_output='defaultDedupString:test_alert_context_invalid_return_value',
+            alert_context=expected_alert_context,
+            rule_severity='INFO',
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_alert_context_too_big(self) -> None:
+        # Function should generate alert_context exceeding limit
+        alert_context_function = 'def alert_context(event):\n' \
+                                 '\ttest_dict = {}\n' \
+                                 '\tfor i in range(300000):\n' \
+                                 '\t\ttest_dict[str(i)] = "value"\n' \
+                                 '\treturn test_dict'
+        rule_body = 'def rule(event):\n\treturn True\n{}'.format(alert_context_function)
+        rule = Rule({'id': 'test_alert_context_too_big', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        expected_alert_context = json.dumps(
+            {'_error': 'alert_context size is [5588890] characters, bigger than maximum of [204800] characters'}
+        )
+        expected_result = RuleResult(
+            rule_id='test_alert_context_too_big',
+            matched=True,
+            dedup_output='defaultDedupString:test_alert_context_too_big',
+            alert_context=expected_alert_context,
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent({}, None), {}, {}))
+
+    def test_alert_context_immutable_event(self) -> None:
+        alert_context_function = 'def alert_context(event):\n' \
+                                 '\treturn {"headers": event["headers"],\n' \
+                                 '\t\t"get_params": event["query_string_args"]}'
+        rule_body = 'def rule(event):\n\treturn True\n{}'.format(alert_context_function)
+        rule = Rule({'id': 'test_alert_context_immutable_event', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        event = {'headers': {'User-Agent': 'Chrome'}, 'query_string_args': [{'a': '1'}, {'b': '2'}]}
+
+        expected_alert_context = json.dumps({'headers': event['headers'], 'get_params': event['query_string_args']})
+        expected_result = RuleResult(
+            rule_id='test_alert_context_immutable_event',
+            matched=True,
+            dedup_output='defaultDedupString:test_alert_context_immutable_event',
+            alert_context=expected_alert_context,
+            rule_severity='INFO',
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent(event, None), {}, {}))
+
+    def test_alert_context_returns_full_event(self) -> None:
+        alert_context_function = 'def alert_context(event):\n\treturn event'
+        rule_body = 'def rule(event):\n\treturn True\n{}'.format(alert_context_function)
+        rule = Rule({'id': 'test_alert_context_returns_full_event', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+        event = {'test': 'event'}
+
+        expected_alert_context = json.dumps(event)
+        expected_result = RuleResult(
+            rule_id='test_alert_context_returns_full_event',
+            matched=True,
+            dedup_output='defaultDedupString:test_alert_context_returns_full_event',
+            alert_context=expected_alert_context,
+            rule_severity='INFO'
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent(event, None), {}, {}))
+
+    # Generated Fields Tests
+    def test_rule_with_all_generated_fields(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def alert_context(event):\n\treturn {}\n' \
+                    'def title(event):\n\treturn "test_rule_with_all_generated_fields"\n' \
+                    'def description(event):\n\treturn "test description"\n' \
+                    'def severity(event):\n\treturn "HIGH"\n' \
+                    'def reference(event):\n\treturn "test reference"\n' \
+                    'def runbook(event):\n\treturn "test runbook"\n' \
+                    'def destinations(event):\n\treturn []'
+        rule = Rule({'id': 'test_rule_with_all_generated_fields', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_with_all_generated_fields',
+            matched=True,
+            alert_context='{}',
+            title_output='test_rule_with_all_generated_fields',
+            dedup_output='test_rule_with_all_generated_fields',
+            description_output='test description',
+            severity_output='HIGH',
+            reference_output='test reference',
+            runbook_output='test runbook',
+            destinations_output=["SKIP"],
+            rule_severity='INFO',
+        )
+        self.assertEqual(expected_result, rule.run(PantherEvent({}, None), {}, {}, batch_mode=False))
+
+    def test_rule_with_invalid_severity(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def alert_context(event):\n\treturn {}\n' \
+                    'def title(event):\n\treturn "test_rule_with_invalid_severity"\n' \
+                    'def severity(event):\n\treturn "CRITICAL-ISH"\n'
+        rule = Rule({'id': 'test_rule_with_invalid_severity', 'body': rule_body, 'versionId': 'versionId', 'severity': 'INFO'})
+
+        expected_result = RuleResult(
+            rule_id='test_rule_with_invalid_severity',
+            matched=True,
+            alert_context='{}',
+            title_output='test_rule_with_invalid_severity',
+            dedup_output='test_rule_with_invalid_severity',
+            severity_exception=AssertionError(
+                "Expected severity to be any of the following: [['INFO', 'LOW', 'MEDIUM', 'HIGH', "
+                "'CRITICAL']], got [CRITICAL-ISH] instead."
+            ),
+            rule_severity='INFO',
+        )
+        result = rule.run(PantherEvent({}, None), {}, {}, batch_mode=False)
+        self.assertEqual(str(expected_result), str(result))
+        self.assertTrue(result.errored)
+        self.assertIsNotNone(result.severity_exception)
+
+    def test_rule_with_valid_severity_case_insensitive(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def alert_context(event):\n\treturn {}\n' \
+                    'def title(event):\n\treturn "test_rule_with_valid_severity_case_insensitive"\n' \
+                    'def severity(event):\n\treturn "cRiTiCaL"\n'
+        rule = Rule(
+            {
+                'id': 'test_rule_with_valid_severity_case_insensitive',
+                'body': rule_body,
+                'versionId': 'versionId',
+                'severity': 'INFO'
+            }
+        )
+
+        expected_result = RuleResult(
+            matched=True,
+            rule_id='test_rule_with_valid_severity_case_insensitive',
+            alert_context='{}',
+            title_output='test_rule_with_valid_severity_case_insensitive',
+            dedup_output='test_rule_with_valid_severity_case_insensitive',
+            severity_output="CRITICAL",
+            rule_severity='INFO'
+        )
+        result = rule.run(PantherEvent({}, None), {}, {})
+        self.assertEqual(expected_result, result)
+
+    def test_rule_with_invalid_destinations_type(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def alert_context(event):\n\treturn {}\n' \
+                    'def title(event):\n\treturn "test_rule_with_valid_severity_case_insensitive"\n' \
+                    'def severity(event):\n\treturn "cRiTiCaL"\n' \
+                    'def destinations(event):\n\treturn "bad input"\n'
+        rule = Rule(
+            {
+                'id': 'test_rule_with_valid_severity_case_insensitive',
+                'body': rule_body,
+                'versionId': 'versionId',
+                'severity': 'INFO'
+            }
+        )
+
+        expected_result = RuleResult(
+            rule_id='test_rule_with_valid_severity_case_insensitive',
+            matched=True,
+            alert_context='{}',
+            title_output='test_rule_with_valid_severity_case_insensitive',
+            dedup_output='test_rule_with_valid_severity_case_insensitive',
+            severity_output="CRITICAL",
+            destinations_output=None,
+            destinations_exception=Exception(
+                'rule [{}] function [{}] returned [{}], expected a list'.format(rule.rule_id, 'destinations', 'str')
+            ),
+            rule_severity='INFO'
+        )
+        result = rule.run(PantherEvent({}, None), {}, {}, batch_mode=False)
+        self.assertEqual(str(expected_result), str(result))
+        self.assertTrue(result.errored)
+        self.assertIsNotNone(result.destinations_exception)
+
+    def test_rule_with_severity_raising_exception_unit_test(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def title(event):\n\treturn"test_rule_with_severity_raising_exception_unit_test"\n' \
+                    'def severity(event):\n\traise AssertionError("something bad happened")\n'
+        rule = Rule(
+            {
+                'id': 'test_rule_with_severity_raising_exception_unit_test',
+                'body': rule_body,
+                'versionId': 'versionId',
+                'severity': 'INFO'
+            }
+        )
+        expected_result = RuleResult(
+            rule_id='test_rule_with_severity_raising_exception_unit_test',
+            matched=True,
+            title_output='test_rule_with_severity_raising_exception_unit_test',
+            dedup_output='test_rule_with_severity_raising_exception_unit_test',
+            severity_output=None,
+            severity_exception=AssertionError("something bad happened"),
+            rule_severity='INFO',
+        )
+        result = rule.run(PantherEvent({}, None), {}, {}, batch_mode=False)
+        self.assertTrue(result.errored)
+        self.assertIsNotNone(result.severity_exception)
+        # Exception instances cannot be compared
+        self.assertDataclassEqual(expected_result, result, fields_as_string=('severity_exception',))
+
+    def test_rule_with_severity_raising_exception_batch_mode(self) -> None:
+        rule_body = 'def rule(event):\n\treturn True\n' \
+                    'def title(event):\n\treturn"test_rule_with_severity_raising_exception_batch_mode"\n' \
+                    'def severity(event):\n\traise AssertionError("something bad happened")\n'
+        rule = Rule(
+            {
+                'id': 'test_rule_with_severity_raising_exception_batch_mode',
+                'body': rule_body,
+                'versionId': 'versionId',
+                'severity': 'INFO'
+            }
+        )
+
+        expected_result = RuleResult(
+            rule_id='test_rule_with_severity_raising_exception_batch_mode',
+            matched=True,
+            title_output='test_rule_with_severity_raising_exception_batch_mode',
+            dedup_output='test_rule_with_severity_raising_exception_batch_mode',
+            severity_output='INFO',
+            rule_severity='INFO',
+        )
+        result = rule.run(PantherEvent({}, None), {}, {}, batch_mode=True)
+        self.assertEqual(str(expected_result), str(result))
+
+
+class TestRuleResult(TestCase):
+
+    def test_fatal_error(self) -> None:
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO')
+        self.assertIsNone(result.fatal_error)
+        fields = ('rule_exception', 'setup_exception', 'input_exception')
+        exc = TypeError('something went wrong')
+        for field in fields:
+            # https://github.com/python/mypy/issues/1969
+            params = {
+                field: exc,
+                'rule_id': 'failed.rule',
+                'rule_severity': 'INFO',
+            }
+            result = RuleResult(**params)  # type: ignore
+            self.assertIs(result.fatal_error, exc)
+
+    def test_error_type(self) -> None:
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO')
+        self.assertIsNone(result.error_type)
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO', rule_exception=TypeError('something went wrong'))
+        self.assertEqual(result.error_type, 'TypeError')
+
+    def test_short_error_message(self) -> None:
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO')
+        self.assertIsNone(result.short_error_message)
+        result = RuleResult(
+            rule_severity='INFO',
+            rule_id='failed.rule',
+            rule_exception=TypeError('something went wrong'),
+        )
+        self.assertEqual(result.short_error_message, "TypeError('something went wrong')")
+
+    def test_error_message(self) -> None:
+        # Generate traceback
+        try:
+            raise TypeError('rule failed')
+        except TypeError as exception:
+            exc = exception
+
+        result = RuleResult(rule_exception=exc, rule_id='failed.rule', rule_severity='INFO')
+        self.assertRegex(  # type: ignore
+            # error_message return value is Optional[str]
+            # but here we know that it is a string
+            result.error_message,
+            r"rule failed: test_rule.py, line [0-9]+, "
+            r"in test_error_message\s+raise TypeError\('rule failed'\)"
+        )
+
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO')
+        self.assertIsNone(result.error_message)
+
+    def test_errored(self) -> None:
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO', rule_exception=TypeError())
+        self.assertTrue(result.errored)
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO', title_exception=TypeError())
+        self.assertTrue(result.errored)
+
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO')
+        self.assertFalse(result.errored)
+
+    def test_rule_evaluation_failed(self) -> None:
+        result = RuleResult(rule_id='failed.rule', rule_severity='INFO')
+        self.assertFalse(result.errored)
+
+        self.assertTrue(RuleResult(rule_id='failed.rule', rule_severity='INFO', rule_exception=TypeError()).rule_evaluation_failed)
+        self.assertTrue(RuleResult(rule_id='failed.rule', rule_severity='INFO', setup_exception=TypeError()).rule_evaluation_failed)
+        self.assertFalse(RuleResult(rule_id='failed.rule', rule_severity='INFO', title_exception=TypeError()).rule_evaluation_failed)


### PR DESCRIPTION
Relates to https://app.asana.com/0/1200441743569436/1200267145879888

### Background

In order to make the changes in https://github.com/panther-labs/panther_analysis_tool/pull/109 easier to review, this PR only copies the files from Panther, without using them anywhere.

### Changes

* Copy rule executor, importer and result aggregator from Engine, along with their unit tests.

### Testing

* No additional tests