### PR TITLE
Hide internal sub-commands for managed schemas from help message

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -127,6 +127,10 @@ SET_FIELDS = [
     "Tags",
 ]
 
+# Environment Variables
+# -- Activates sub-commands that are meant for internal use --
+ENV_VAR_INCLUDE_INTERNAL_SUBCOMMANDS = "PANTHER_PAT_INCLUDE_INTERNAL_SUBCOMMANDS"
+
 
 # exception for conflicting ids
 class AnalysisIDConflictException(Exception):
@@ -1409,33 +1413,6 @@ def setup_parser() -> argparse.ArgumentParser:
     upload_parser.add_argument(available_destination_name, **available_destination_arg)
     upload_parser.set_defaults(func=upload_analysis)
 
-    update_managed_schemas_parser = subparsers.add_parser(
-        "update-schemas", help="Update managed schemas on a Panther deployment."
-    )
-    update_managed_schemas_parser.add_argument(aws_profile_name, **aws_profile_arg)
-    update_managed_schemas_parser.set_defaults(func=update_schemas)
-
-    zip_parser = subparsers.add_parser(
-        "zip", help="Create an archive of local policies and rules for uploading to Panther."
-    )
-    zip_parser.add_argument(filter_name, **filter_arg)
-    zip_parser.add_argument(min_test_name, **min_test_arg)
-    zip_parser.add_argument(out_name, **out_arg)
-    zip_parser.add_argument(path_name, **path_arg)
-    zip_parser.add_argument(skip_test_name, **skip_test_arg)
-    zip_parser.add_argument(skip_disabled_test_name, **skip_disabled_test_arg)
-    zip_parser.add_argument(available_destination_name, **available_destination_arg)
-    zip_parser.set_defaults(func=zip_analysis)
-
-    zip_schemas_parser = subparsers.add_parser(
-        "zip-schemas", help="Create a release asset archive of managed schemas."
-    )
-    zip_schemas_parser.add_argument(
-        "--release", type=str, help="The release tag this asset is for", required=True
-    )
-    zip_schemas_parser.add_argument(out_name, **out_arg)
-    zip_schemas_parser.set_defaults(func=zip_managed_schemas)
-
     update_custom_schemas_parser = subparsers.add_parser(
         "update-custom-schemas", help="Update or create custom schemas on a Panther deployment."
     )
@@ -1444,6 +1421,34 @@ def setup_parser() -> argparse.ArgumentParser:
     custom_schemas_path_arg["help"] = "The relative or absolute path to Panther custom schemas."
     update_custom_schemas_parser.add_argument(path_name, **custom_schemas_path_arg)
     update_custom_schemas_parser.set_defaults(func=update_custom_schemas)
+
+    if os.environ.get(ENV_VAR_INCLUDE_INTERNAL_SUBCOMMANDS):
+        update_managed_schemas_parser = subparsers.add_parser(
+            "update-schemas", help="Update managed schemas on a Panther deployment."
+        )
+        update_managed_schemas_parser.add_argument(aws_profile_name, **aws_profile_arg)
+        update_managed_schemas_parser.set_defaults(func=update_schemas)
+
+        zip_parser = subparsers.add_parser(
+            "zip", help="Create an archive of local policies and rules for uploading to Panther."
+        )
+        zip_parser.add_argument(filter_name, **filter_arg)
+        zip_parser.add_argument(min_test_name, **min_test_arg)
+        zip_parser.add_argument(out_name, **out_arg)
+        zip_parser.add_argument(path_name, **path_arg)
+        zip_parser.add_argument(skip_test_name, **skip_test_arg)
+        zip_parser.add_argument(skip_disabled_test_name, **skip_disabled_test_arg)
+        zip_parser.add_argument(available_destination_name, **available_destination_arg)
+        zip_parser.set_defaults(func=zip_analysis)
+
+        zip_schemas_parser = subparsers.add_parser(
+            "zip-schemas", help="Create a release asset archive of managed schemas."
+        )
+        zip_schemas_parser.add_argument(
+            "--release", type=str, help="The release tag this asset is for", required=True
+        )
+        zip_schemas_parser.add_argument(out_name, **out_arg)
+        zip_schemas_parser.set_defaults(func=zip_managed_schemas)
 
     return parser
 

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -22,6 +22,7 @@ import os
 import shutil
 
 from pyfakefs.fake_filesystem_unittest import TestCase, Pause
+from unittest import mock
 
 from schema import SchemaWrongKeyError
 from nose.tools import assert_equal, assert_is_instance, assert_true
@@ -294,8 +295,10 @@ class TestPantherAnalysisTool(TestCase):
         except OSError:
             pass
 
-        args = pat.setup_parser().parse_args(
-            f'zip --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/'.split())
+        with mock.patch.dict(os.environ, {pat.ENV_VAR_INCLUDE_INTERNAL_SUBCOMMANDS: 'true'}):
+            args = pat.setup_parser().parse_args(
+                f'zip --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/'.split())
+
         return_code, out_filename = pat.zip_analysis(args)
         assert_true(out_filename.startswith("tmp/"))
         statinfo = os.stat(out_filename)


### PR DESCRIPTION
Closes https://app.asana.com/0/1200543078196176/1200629761291101

### Background

The managed schemas sub-commands may confuse users since it is not easy to differentiate between
custom schemas handling and managed schemas operations.

Since they still might be useful in the near future for internally-issued upgrades,
we optionally include the sub-commands only when the `PANTHER_PAT_INCLUDE_INTERNAL_SUBCOMMANDS` variable is present.

### Changes

* Include `update-schemas` and `zip-schemas` sub-parsers only when a special environment variable is present.

### Testing

```
$ PANTHER_PAT_INCLUDE_INTERNAL_SUBCOMMANDS=true panther_analysis_tool --help
usage: panther_analysis_tool [-h] [--version] [--debug]
                             {release,test,publish,upload,update-custom-schemas,update-schemas,zip,zip-schemas}
                             ...

Panther Analysis Tool: A command line tool for managing Panther policies and
rules.

positional arguments:
  {release,test,publish,upload,update-custom-schemas,update-schemas,zip,zip-schemas}
    release             Create release assets for repository containing
                        panther detections. Generates a file called panther-
                        analysis-all.zip and optionally generates panther-
                        analysis-all.sig
    test                Validate analysis specifications and run policy and
                        rule tests.
    publish             Publishes a new release, generates the release assets,
                        and uploads themGenerates a file called panther-
                        analysis-all.zip and optionally generates panther-
                        analysis-all.sig
    upload              Upload specified policies and rules to a Panther
                        deployment.
    update-custom-schemas
                        Update or create custom schemas on a Panther
                        deployment.
    update-schemas      Update managed schemas on a Panther deployment.
    zip                 Create an archive of local policies and rules for
                        uploading to Panther.
    zip-schemas         Create a release asset archive of managed schemas.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --debug
```

```
$ panther_analysis_tool --help                                  
usage: panther_analysis_tool [-h] [--version] [--debug]
                             {release,test,publish,upload,update-custom-schemas}
                             ...

Panther Analysis Tool: A command line tool for managing Panther policies and
rules.

positional arguments:
  {release,test,publish,upload,update-custom-schemas}
    release             Create release assets for repository containing
                        panther detections. Generates a file called panther-
                        analysis-all.zip and optionally generates panther-
                        analysis-all.sig
    test                Validate analysis specifications and run policy and
                        rule tests.
    publish             Publishes a new release, generates the release assets,
                        and uploads themGenerates a file called panther-
                        analysis-all.zip and optionally generates panther-
                        analysis-all.sig
    upload              Upload specified policies and rules to a Panther
                        deployment.
    update-custom-schemas
                        Update or create custom schemas on a Panther
                        deployment.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --debug
```
