### PR TITLE
Add Rule Setup Exception Setter Method

### DIFF
--- a/panther_analysis_tool/rule.py
+++ b/panther_analysis_tool/rule.py
@@ -370,6 +370,11 @@ class Rule:
         """Used to expose the setup exception to the engine"""
         return self._setup_exception
 
+    @setup_exception.setter
+    def setup_exception(self, val: Any) -> Any:
+        """Used to set the setup_exception to the engine"""
+        self._setup_exception = val
+
     def run(
         self, event: PantherEvent, outputs: dict, outputs_names: dict, batch_mode: bool = True
     ) -> RuleResult:


### PR DESCRIPTION
### Background

Changes required for mocking json objects in unit tests necessitate the ability to set the setup exception for a rule

### Changes

* Added a setter method to the rule setup exception

### Testing

* `make test`
