### PR TITLE
Handle empty results response for existing schemas request

### DIFF
--- a/panther_analysis_tool/log_schemas/user_defined.py
+++ b/panther_analysis_tool/log_schemas/user_defined.py
@@ -182,7 +182,10 @@ class Uploader:
             success, response = self.api_client.list_schemas()
             if not success:
                 raise RuntimeError("unable to retrieve custom schemas")
-            self._existing_schemas = response["results"]
+            if 'results' in response:
+                self._existing_schemas = response['results']
+            else:
+                self._existing_schemas = []
         return self._existing_schemas
 
     def find_schema(self, name: str) -> Optional[Dict[str, Any]]:

--- a/tests/unit/panther_analysis_tool/log_schemas/test_user_defined.py
+++ b/tests/unit/panther_analysis_tool/log_schemas/test_user_defined.py
@@ -102,6 +102,16 @@ class TestUploader(unittest.TestCase):
             self.assertListEqual(uploader.existing_schemas, self.list_schemas_response['results'])
             mock_uploader_client.list_schemas.assert_called_once()
 
+    def test_existing_schemas_empty_results_from_backend(self):
+        with mock.patch('panther_analysis_tool.log_schemas.user_defined.Uploader.api_client',
+                        autospec=user_defined.Client) as mock_uploader_client:
+            mock_uploader_client.list_schemas = mock.MagicMock(
+                return_value=(True, {})
+            )
+            uploader = user_defined.Uploader(self.valid_schema_path, None)
+            self.assertListEqual(uploader.existing_schemas, [])
+            mock_uploader_client.list_schemas.assert_called_once()
+
     def test_find_schema(self):
         with mock.patch('panther_analysis_tool.log_schemas.user_defined.Uploader.existing_schemas',
                         self.list_schemas_response['results']):


### PR DESCRIPTION
Closes https://app.asana.com/0/1199906407795548/1200783112556400

### Background

An empty response may be returned if no custom schemas are yet stored in the backend.

### Changes

* Fall back to empty list as a default for existing schema on empty API response.

### Testing

* Tested end-to-end in conditions where an empty JSON object is returned by the API.