### PR TITLE
Detect and ignore schema test case files

### DIFF
--- a/tests/fixtures/custom-schemas/valid/schema_1_tests.yml
+++ b/tests/fixtures/custom-schemas/valid/schema_1_tests.yml
@@ -1,0 +1,31 @@
+name: test1
+logType: Custom.Schema1
+input: |
+  {
+    "ip": "10.0.0.1",
+    "timestamp":"2021-03-26T21:40:41Z"
+  }
+result: |
+  {
+    "ip": "10.0.0.1",
+    "timestamp":"2021-03-26T21:40:41Z",
+    "p_log_type":"Custom.Schema1",
+    "p_event_time":"2021-03-26T21:40:41Z",
+    "p_any_ip_addresses":["10.0.0.1"]
+  }
+---
+name: test2
+logType: Custom.Schema1
+input: |
+  {
+    "ip": "10.0.0.2",
+    "timestamp":"2021-03-26T21:40:41Z"
+  }
+result: |
+  {
+    "ip": "10.0.0.2",
+    "timestamp":"2021-03-26T21:40:41Z",
+    "p_log_type":"Custom.Schema1",
+    "p_event_time":"2021-03-26T21:40:41Z",
+    "p_any_ip_addresses":["10.0.0.1"]
+  }

--- a/tests/unit/panther_analysis_tool/log_schemas/test_user_defined.py
+++ b/tests/unit/panther_analysis_tool/log_schemas/test_user_defined.py
@@ -27,7 +27,17 @@ class TestUtilities(unittest.TestCase):
         path = os.path.join(FIXTURES_PATH, 'custom-schemas', 'valid')
         files = user_defined.discover_files(path, user_defined.Uploader._SCHEMA_FILE_GLOB_PATTERNS)
         self.assertListEqual(files, [os.path.join(path, 'schema-1.yml'),
-                                     os.path.join(path, 'schema-2.yaml')])
+                                     os.path.join(path, 'schema-2.yaml'),
+                                     os.path.join(path, 'schema_1_tests.yml')])
+
+    def test_ignore_schema_test_files(self):
+        base_path = os.path.join(FIXTURES_PATH, 'custom-schemas', 'valid')
+        schema_files = ['schema-1.yml', 'schema-2.yml']
+        schema_test_files = ['schema_1_tests.yml']
+
+        all_files = [os.path.join(base_path, filename) for filename in schema_files + schema_test_files]
+        self.assertListEqual(user_defined.ignore_schema_test_files(all_files),
+                             all_files[:len(schema_files)])
 
     def test_normalize_path(self):
         # If path does not exist


### PR DESCRIPTION
Closes https://app.asana.com/0/1200693863324520/1200791354082308

### Background

Schema tests would be reported as malformed schema definitions, and were skipped but the error reporting results in a non zero exit code.

### Changes

* Filter discovered files by detecting test case files and omitting them from the path list of files to be examined as possible schema definitions.

### Testing

* Reproduced the error by adding a test file containing a single document, since YAML parsing would break either way for multidocument YAML files.
* Tested the changes end-to-end to verify that no error is reported.