### PR TITLE
update policy output

### DIFF
--- a/panther_analysis_tool/detection.py
+++ b/panther_analysis_tool/detection.py
@@ -147,9 +147,7 @@ class DetectionResult:
         """Returns whether the detection function raises an error or an import error occurred"""
         return bool(self.detection_exception or self.setup_exception)
 
-    def ignore_errors(
-        self, ignore_exception_types: Optional[List[Type[Exception]]] = None
-    ) -> None:
+    def ignore_errors(self, ignore_exception_types: Optional[List[Type[Exception]]] = None) -> None:
         """Used to ignore exceptions of particular types, used primarily in testing"""
         for exception_type in ignore_exception_types or []:
             if isinstance(self.detection_exception, exception_type):

--- a/panther_analysis_tool/detection.py
+++ b/panther_analysis_tool/detection.py
@@ -24,7 +24,7 @@ from abc import abstractmethod
 from dataclasses import dataclass
 from pathlib import Path
 from types import ModuleType
-from typing import List, Optional
+from typing import List, Optional, Type
 
 from panther_analysis_tool.util import id_to_path, import_file_as_module, store_modules
 
@@ -146,6 +146,30 @@ class DetectionResult:
     def detection_evaluation_failed(self) -> bool:
         """Returns whether the detection function raises an error or an import error occurred"""
         return bool(self.detection_exception or self.setup_exception)
+
+    def ignore_errors(
+        self, ignore_exception_types: Optional[List[Type[Exception]]] = None
+    ) -> None:
+        """Used to ignore exceptions of particular types, used primarily in testing"""
+        for exception_type in ignore_exception_types or []:
+            if isinstance(self.detection_exception, exception_type):
+                self.detection_exception = None
+            if isinstance(self.title_exception, exception_type):
+                self.title_exception = None
+            if isinstance(self.description_exception, exception_type):
+                self.description_exception = None
+            if isinstance(self.reference_exception, exception_type):
+                self.reference_exception = None
+            if isinstance(self.severity_exception, exception_type):
+                self.severity_exception = None
+            if isinstance(self.runbook_exception, exception_type):
+                self.runbook_exception = None
+            if isinstance(self.destinations_exception, exception_type):
+                self.destinations_exception = None
+            if isinstance(self.dedup_exception, exception_type):
+                self.dedup_exception = None
+            if isinstance(self.alert_context_exception, exception_type):
+                self.alert_context_exception = None
 
 
 class BaseImporter:

--- a/panther_analysis_tool/detection.py
+++ b/panther_analysis_tool/detection.py
@@ -147,9 +147,9 @@ class DetectionResult:
         """Returns whether the detection function raises an error or an import error occurred"""
         return bool(self.detection_exception or self.setup_exception)
 
-    def ignore_errors(self, ignore_exception_types: Optional[List[Type[Exception]]] = None) -> None:
+    def ignore_errors(self, ignore_exception_types: List[Type[Exception]]) -> None:
         """Used to ignore exceptions of particular types, used primarily in testing"""
-        for exception_type in ignore_exception_types or []:
+        for exception_type in ignore_exception_types:
             if isinstance(self.detection_exception, exception_type):
                 self.detection_exception = None
             if isinstance(self.title_exception, exception_type):

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -802,7 +802,7 @@ def setup_data_models(data_models: List[Any]) -> Tuple[Dict[str, DataModel], Lis
     return log_type_to_data_model, invalid_specs
 
 
-def setup_run_tests( # pylint: disable=too-many-locals,too-many-arguments
+def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
     log_type_to_data_model: Dict[str, DataModel],
     analysis: List[Any],
     minimum_tests: int,
@@ -1101,7 +1101,7 @@ def run_tests(  # pylint: disable=too-many-arguments
     return failed_tests
 
 
-def _run_tests( # pylint: disable=too-many-arguments
+def _run_tests(  # pylint: disable=too-many-arguments
     analysis_data_models: Dict[str, DataModel],
     detection: Detection,
     tests: List[Dict[str, Any]],

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1165,7 +1165,9 @@ def _check_destinations(test_result: TestResult, destination_by_name: Dict[str, 
     return test_result
 
 
-def _print_test_result(detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]) -> None:
+def _print_test_result(
+    detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]
+) -> None:
     status_pass = "PASS"  # nosec
     status_fail = "FAIL"
     if test_result.passed:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1145,19 +1145,24 @@ def _check_destinations(test_result: TestResult, destination_by_name: Dict[str, 
     # For backwards compatibility we can accept invalid destination names,
     # as long as a string is returned. Strict check is enabled when users
     # pass destination names explicitly through command-line parameters.
-    if test_result.functions.destinationsFunction:
-        if test_result.functions.destinationsFunction.error and not bool(destination_by_name):
-            error_message = test_result.functions.destinationsFunction.error.message or ""
-            if "UnknownDestinationError" in error_message:
-                test_result.functions.destinationsFunction.output = error_message.split(" ")[-1]
-                test_result.functions.destinationsFunction.error = None
-                test_result.passed = True
-                # reset test_result as necessary
-                for function_name in vars(test_result.functions):
-                    function_result = vars(test_result.functions)[function_name]
-                    if function_result:
-                        if function_result.error:
-                            test_result.passed = False
+    if (
+        test_result.functions.destinationsFunction
+        and test_result.functions.destinationsFunction.error
+        and not bool(destination_by_name)
+    ):
+
+        error_message = test_result.functions.destinationsFunction.error.message or ""
+        if "UnknownDestinationError" in error_message:
+            # reset the output and error
+            test_result.functions.destinationsFunction.output = error_message.split(" ")[-1]
+            test_result.functions.destinationsFunction.error = None
+            test_result.passed = True
+            # reset test_result as necessary
+            for function_name in vars(test_result.functions):
+                function_result = vars(test_result.functions)[function_name]
+                if function_result:
+                    if function_result.error:
+                        test_result.passed = False
     return test_result
 
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1161,7 +1161,7 @@ def _run_tests(  # pylint: disable=too-many-arguments
 def _print_test_result(
     detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]
 ) -> None:
-    status_pass = "PASS"  # nosec
+    status_pass = "PASS" # nosec
     status_fail = "FAIL"
     if test_result.passed:
         outcome = status_pass
@@ -1186,7 +1186,7 @@ def _print_test_result(
                         status_fail, printable_name, function_result.get("error", {}).get("message")
                     )
                 )
-            # if it didn't error, we simiply need to check if the output was as expected
+            # if it didn't error, we simply need to check if the output was as expected
             elif not function_result.get("matched", True):
                 failed_tests[detection.detection_id].append(f"{test_result.name}:{printable_name}")
                 print(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -36,7 +36,7 @@ from datetime import datetime
 from distutils.util import strtobool
 from fnmatch import fnmatch
 from importlib.abc import Loader
-from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple
+from typing import Any, DefaultDict, Dict, Iterator, List, Optional, Set, Tuple
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -65,7 +65,8 @@ from panther_analysis_tool.exceptions import (
     UnknownDestinationError,
 )
 from panther_analysis_tool.log_schemas import user_defined
-from panther_analysis_tool.rule import Rule
+from panther_analysis_tool.policy import Policy
+from panther_analysis_tool.rule import Detection, Rule
 from panther_analysis_tool.schemas import (
     DATA_MODEL_SCHEMA,
     GLOBAL_SCHEMA,
@@ -74,6 +75,12 @@ from panther_analysis_tool.schemas import (
     RULE_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
     TYPE_SCHEMA,
+)
+from panther_analysis_tool.testing import (
+    TestCaseEvaluator,
+    TestExpectations,
+    TestResult,
+    TestSpecification,
 )
 from panther_analysis_tool.util import get_client
 
@@ -808,20 +815,10 @@ def setup_run_tests(
             continue
         analysis_type = analysis_spec["AnalysisType"]
         analysis_id = analysis_spec.get("PolicyID") or analysis_spec["RuleID"]
-        print(analysis_id)
-
         module_code_path = os.path.join(dir_name, analysis_spec["Filename"])
-        module, load_err = load_module(module_code_path)
-        # If the module could not be loaded, continue to the next
-        if load_err:
-            invalid_specs.append((analysis_spec_filename, load_err))
-            continue
-
-        analysis_funcs = {"module": module}
+        detection = None
         if analysis_type == POLICY:
-            analysis_funcs["run"] = module.policy
-        elif analysis_type in [RULE, SCHEDULED_RULE]:
-            rule = Rule(
+            detection = Policy(
                 dict(
                     id=analysis_id,
                     analysisType=analysis_type,
@@ -829,18 +826,31 @@ def setup_run_tests(
                     versionId="0000-0000-0000",
                 )
             )
-            analysis_funcs["run"] = functools.partial(
-                rule.run, outputs={}, outputs_names=destinations_by_name, batch_mode=False
+        elif analysis_type in [RULE, SCHEDULED_RULE]:
+            detection = Rule(
+                dict(
+                    id=analysis_id,
+                    analysisType=analysis_type,
+                    path=module_code_path,
+                    versionId="0000-0000-0000",
+                )
             )
-            analysis_funcs["module"] = rule.module
+
+        # if there is a setup exception, no need to run tets
+        if detection.setup_exception:
+            invalid_specs.append((analysis_spec_filename, detection.setup_exception))
+            print("\n")
+            continue
+
+        print(detection.detection_id)
 
         failed_tests = run_tests(
             analysis_spec,
-            analysis_funcs,
             log_type_to_data_model,
+            detection,
             failed_tests,
             minimum_tests,
-            bool(destinations_by_name),
+            destinations_by_name,
         )
         print("")
     return failed_tests, invalid_specs
@@ -1050,15 +1060,15 @@ def handle_wrong_key_error(err: SchemaWrongKeyError, keys: list) -> Exception:
 
 def run_tests(  # pylint: disable=too-many-arguments
     analysis: Dict[str, Any],
-    analysis_funcs: Dict[str, Any],
     analysis_data_models: Dict[str, DataModel],
+    detection: Detection,
     failed_tests: DefaultDict[str, list],
     minimum_tests: int,
-    destination_names_strict_check: bool,
+    destinations_by_name: Dict[str, FakeDestination],
 ) -> DefaultDict[str, list]:
 
     if len(analysis.get("Tests", [])) < minimum_tests:
-        failed_tests[analysis.get("PolicyID") or analysis["RuleID"]].append(
+        failed_tests[detection.detection_id].append(
             "Insufficient test coverage: {} tests required but only {} found".format(
                 minimum_tests, len(analysis.get("Tests", []))
             )
@@ -1066,19 +1076,18 @@ def run_tests(  # pylint: disable=too-many-arguments
 
     # First check if any tests exist, so we can print a helpful message if not
     if "Tests" not in analysis:
-        analysis_id = analysis.get("PolicyID") or analysis["RuleID"]
-        print("\tNo tests configured for {}".format(analysis_id))
+        print("\tNo tests configured for {}".format(detection.detection_id))
         return failed_tests
 
     failed_tests = _run_tests(
-        analysis, analysis_funcs, analysis_data_models, failed_tests, destination_names_strict_check
+        analysis_data_models, detection, analysis["Tests"], failed_tests, destinations_by_name
     )
 
     if minimum_tests > 1 and not (
         [x for x in analysis["Tests"] if x["ExpectedResult"]]
         and [x for x in analysis["Tests"] if not x["ExpectedResult"]]
     ):
-        failed_tests[analysis.get("PolicyID") or analysis["RuleID"]].append(
+        failed_tests[detection.detection_id].append(
             "Insufficient test coverage: expected at least one positive and one negative test"
         )
 
@@ -1086,15 +1095,14 @@ def run_tests(  # pylint: disable=too-many-arguments
 
 
 def _run_tests(
-    analysis: Dict[str, Any],
-    analysis_funcs: Dict[str, Any],
     analysis_data_models: Dict[str, DataModel],
+    detection: Detection,
+    tests: List[Dict[str, Any]],
     failed_tests: DefaultDict[str, list],
-    destination_names_strict_check: bool,
+    destination_by_name: Dict[str, FakeDestination],
 ) -> DefaultDict[str, list]:
-    is_policy = analysis.get("PolicyID") is not None
-    analysis_id = analysis.get("PolicyID") or analysis["RuleID"]
-    for unit_test in analysis["Tests"]:
+
+    for unit_test in tests:
         try:
             entry = unit_test.get("Resource") or unit_test["Log"]
             log_type = entry.get("p_log_type", "")
@@ -1106,124 +1114,89 @@ def _run_tests(
                     for each_mock in mocks
                     if "objectName" in each_mock and "returnValue" in each_mock
                 }
-            if is_policy:
-                # Policies use plain dict objects as input
-                test_case = entry
-            else:
-                # Set up each test case, including any relevant data models
-                test_case = PantherEvent(entry, analysis_data_models.get(log_type))
+            test_case = PantherEvent(entry, analysis_data_models.get(log_type))
             if mock_methods:
-                with patch.multiple(analysis_funcs["module"], **mock_methods):
-                    result = analysis_funcs["run"](test_case)
+                with patch.multiple(detection.module, **mock_methods):
+                    result = detection.run(test_case, {}, destination_by_name, batch_mode=False)
             else:
-                result = analysis_funcs["run"](test_case)
+                result = detection.run(test_case, {}, destination_by_name, batch_mode=False)
         except (AttributeError, KeyError) as err:
             logging.warning("AttributeError: {%s}", err)
             logging.debug(str(err), exc_info=err)
-            failed_tests[analysis.get("PolicyID") or analysis["RuleID"]].append(unit_test["Name"])
+            failed_tests[detection.detection_id].append(unit_test["Name"])
             continue
         except Exception as err:  # pylint: disable=broad-except
             # Catch arbitrary exceptions raised by user code
             logging.warning("Unexpected exception: {%s}", err)
             logging.debug(str(err), exc_info=err)
-            failed_tests[analysis.get("PolicyID") or analysis["RuleID"]].append(unit_test["Name"])
+            failed_tests[detection.detection_id].append(unit_test["Name"])
             continue
-
-        # using a dictionary to map between the tests and their outcomes
-        # assume the test passes (default "PASS")
-        # until failure condition is found (set to "FAIL")
-        test_result: Dict[Any, str] = defaultdict(lambda: "PASS")
-
-        # check expected result
-        auxiliary_functions_result_message = ""
-        if is_policy:
-            if result != unit_test["ExpectedResult"]:
-                test_result["outcome"] = "FAIL"
-                failed_tests[analysis_id].append(unit_test["Name"])
-        else:
-            rule_result: DetectionResult = result
-            if rule_result.matched is not unit_test["ExpectedResult"]:
-                test_result["outcome"] = "FAIL"
-                failed_tests[analysis_id].append(unit_test["Name"])
-
-            # validate reserved function return types and values
-            # Only applies to rules which match an incoming event
-            if unit_test["ExpectedResult"]:
-                for function_name in RESERVED_FUNCTIONS:
-                    strict_check = (
-                        function_name == "destinations" and destination_names_strict_check
-                    )
-                    aux_function_result = _evaluate_auxiliary_function_result(
-                        function_name, rule_result, strict_check
-                    )
-
-                    # The function has not been executed, nothing to display
-                    if aux_function_result["display"] is None:
-                        continue
-
-                    if aux_function_result["failed"]:
-                        # Mark the test as failed if an auxiliary function fails
-                        test_result[function_name] = test_result["outcome"] = "FAIL"
-                        failed_tests[analysis_id].append(f"{unit_test['Name']}:{function_name}")
-
-                    auxiliary_functions_result_message += f"\t\t[{test_result[function_name]}] "
-                    if aux_function_result["has_invalid_type"]:
-                        auxiliary_functions_result_message += "[INVALID TYPE] "
-                    auxiliary_functions_result_message += (
-                        f"[{function_name}] {aux_function_result['display']}\n"
-                    )
-                auxiliary_functions_result_message = auxiliary_functions_result_message.rstrip()
-
         # print results
-        print("\t[{}] {}".format(test_result["outcome"], unit_test["Name"]))
-        if auxiliary_functions_result_message:
-            print(auxiliary_functions_result_message)
+        spec = TestSpecification(
+            id=unit_test["Name"],
+            name=unit_test["Name"],
+            data=unit_test.get("Resource") or unit_test["Log"],
+            mocks=unit_test.get("Mocks", {}),
+            expectations=TestExpectations(detection=unit_test["ExpectedResult"]),
+        )
+        test_result = TestCaseEvaluator(spec, result).interpret()
+        test_result = _check_destinations(test_result, destination_by_name)
+        _print_test_result(test_result)
+        # add failed tests as necessary
+        if not test_result.passed:
+            failed_tests[detection.detection_id].append(unit_test["Name"])
 
     return failed_tests
 
 
-def _evaluate_auxiliary_function_result(
-    function_name: str, detection_result: DetectionResult, strict_check: bool
-) -> Dict[str, Any]:
-    """Determine whether an auxiliary function for a rule raised an error"""
-    function_error = getattr(detection_result, f"{function_name}_exception")
-    output = getattr(detection_result, f"{function_name}_output")
-    is_defined = getattr(detection_result, f"{function_name}_defined")
-    failed = function_error is not None
-
+def _check_destinations(test_result: TestResult, destination_by_name: Dict[str, Any]) -> TestResult:
     # For backwards compatibility we can accept invalid destination names,
     # as long as a string is returned. Strict check is enabled when users
     # pass destination names explicitly through command-line parameters.
-    if function_name == "destinations" and failed and not strict_check:
-        # Otherwise we fall back to a best-effort check of the return type only
-        if isinstance(function_error, UnknownDestinationError):
-            exc: UnknownDestinationError = function_error
-            failed = not _check_destinations_type(exc.result())
+    if test_result.functions.destinationsFunction:
+        if test_result.functions.destinationsFunction.error and not bool(destination_by_name):
+            error_message = test_result.functions.destinationsFunction.error.message or ""
+            if "UnknownDestinationError" in error_message:
+                test_result.functions.destinationsFunction.output = error_message.split(" ")[-1]
+                test_result.functions.destinationsFunction.error = None
+                test_result.passed = True
+                # reset test_result as necessary
+                for function_name in vars(test_result.functions):
+                    function_result = vars(test_result.functions)[function_name]
+                    if function_result:
+                        if function_result.error:
+                            test_result.passed = False
+    return test_result
 
-    # The function has not been executed
-    if not is_defined:
-        display = None
+
+def _print_test_result(test_result: TestResult) -> None:
+    status_pass = "PASS"  # nosec
+    status_fail = "FAIL"
+    if test_result.passed:
+        outcome = status_pass
     else:
-        display = function_error if failed else output
+        outcome = status_fail
+    # print overall status for this test
+    print("\t[{}] {}".format(outcome, test_result.name))
 
-    return {
-        "error": function_error,
-        "output": output,
-        "failed": failed,
-        "has_invalid_type": isinstance(function_error, FunctionReturnTypeError),
-        "display": display,
-    }
-
-
-def _check_destinations_type(obj: Any) -> bool:
-    """Checks that the return value of the `destinations` function is a list of strings"""
-    if obj is None:
-        return True
-
-    if not isinstance(obj, list):
-        return False
-
-    return all(isinstance(destination_name, str) for destination_name in obj)
+    # print aux function status as necessary
+    for function_name in vars(test_result.functions):
+        if function_name == "detectionFunction":
+            # we are already printing the overall status for the detection
+            continue
+        printable_name = function_name.replace("Function", "")
+        function_result = vars(test_result.functions)[function_name]
+        if function_result:
+            if function_result.error:
+                print(
+                    "\t\t[{}] [{}] {}".format(
+                        status_fail, printable_name, function_result.error.message
+                    )
+                )
+            else:
+                print(
+                    "\t\t[{}] [{}] {}".format(status_pass, printable_name, function_result.output)
+                )
 
 
 def setup_parser() -> argparse.ArgumentParser:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1193,6 +1193,12 @@ def _print_test_result(
                         status_fail, printable_name, function_result.error.message
                     )
                 )
+            # if it didn't error, we simiply need to check if the output was as expected
+            elif not function_result.matched:
+                failed_tests[detection.detection_id].append(f"{test_result.name}:{printable_name}")
+                print(
+                    "\t\t[{}] [{}] {}".format(status_fail, printable_name, function_result.output)
+                )
             else:
                 print(
                     "\t\t[{}] [{}] {}".format(status_pass, printable_name, function_result.output)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1177,7 +1177,7 @@ def _print_test_result(
     # print overall status for this test
     print("\t[{}] {}".format(outcome, test_result.name))
 
-    # print aux function status as necessary
+    # print function output and status as necessary
     for function_name in vars(test_result.functions):
         printable_name = function_name.replace("Function", "")
         if printable_name == "detection":

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1137,11 +1137,14 @@ def _run_tests(
         ignore_exception_types = []
         if not bool(destinations_by_name):
             ignore_exception_types.append(UnknownDestinationError)
-        test_result = TestCaseEvaluator(spec, result).interpret(ignore_exception_types=ignore_exception_types)
+        test_result = TestCaseEvaluator(spec, result).interpret(
+            ignore_exception_types=ignore_exception_types
+        )
 
         _print_test_result(detection, test_result, failed_tests)
 
     return failed_tests
+
 
 def _print_test_result(
     detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1187,7 +1187,7 @@ def _print_test_result(
         if function_result:
             if function_result.error:
                 # add this as output to the failed test spec as well
-                failed_tests[test_result.detectionId].append(f"{test_result.name}:{printable_name}")
+                failed_tests[detection.detection_id].append(f"{test_result.name}:{printable_name}")
                 print(
                     "\t\t[{}] [{}] {}".format(
                         status_fail, printable_name, function_result.error.message

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1134,7 +1134,7 @@ def _run_tests(
             mocks=unit_test.get("Mocks", {}),
             expectations=TestExpectations(detection=unit_test["ExpectedResult"]),
         )
-        ignore_exception_types = []
+        ignore_exception_types: List[Exception] = []
         if not bool(destinations_by_name):
             ignore_exception_types.append(UnknownDestinationError)
         test_result = TestCaseEvaluator(spec, result).interpret(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -654,6 +654,7 @@ def upload_assets_github(upload_url: str, headers: dict, release_dir: str) -> in
     return return_code
 
 
+# pylint: disable=too-many-locals
 def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
     """Imports each policy or rule and runs their tests.
 
@@ -801,8 +802,7 @@ def setup_data_models(data_models: List[Any]) -> Tuple[Dict[str, DataModel], Lis
     return log_type_to_data_model, invalid_specs
 
 
-# pylint: disable=too-many-locals
-def setup_run_tests(
+def setup_run_tests( # pylint: disable=too-many-locals,too-many-arguments
     log_type_to_data_model: Dict[str, DataModel],
     analysis: List[Any],
     minimum_tests: int,
@@ -1101,7 +1101,7 @@ def run_tests(  # pylint: disable=too-many-arguments
     return failed_tests
 
 
-def _run_tests(
+def _run_tests( # pylint: disable=too-many-arguments
     analysis_data_models: Dict[str, DataModel],
     detection: Detection,
     tests: List[Dict[str, Any]],

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -165,7 +165,7 @@ class TestCaseEvaluator:
         """Get the test status - passing/failing"""
 
         # Title/dedup functions are executed unconditionally
-        # (regardless if the detection trigger_alert or not) during testing.
+        # (regardless if the detection matched or not) during testing.
         if self._spec.expectations.detection == self._detection_result.detection_output:
             # Any error should mark the test as failing
             return not self._detection_result.errored

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -23,8 +23,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from panther_analysis_tool.detection import DetectionResult
+from panther_analysis_tool.policy import TYPE_POLICY, Policy
 from panther_analysis_tool.rule import Rule
-from panther_analysis_tool.policy import Policy, TYPE_POLICY
+
 
 @dataclass
 class TestError:
@@ -152,7 +153,6 @@ class TestCaseEvaluator:
             return False
         # expectations match the detection output
         return self._spec.expectations.detection == self._detection_result.detection_output
-
 
     def _get_generic_error_details(self) -> Tuple[Optional[Exception], Optional[str]]:
         generic_error = None

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import json
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Type, Union
 
 from panther_analysis_tool.detection import DetectionResult
 
@@ -182,7 +182,9 @@ class TestCaseEvaluator:
             generic_error = self._detection_result.setup_exception
         return generic_error, generic_error_title
 
-    def _check_exception_types(self, ignore_exception_types:Optional[List[Exception]] = None) -> None:
+    def _check_exception_types(
+        self, ignore_exception_types: Optional[List[Type[Exception]]] = None
+    ) -> None:
         for exception_type in ignore_exception_types or []:
             if isinstance(self._detection_result.detection_exception, exception_type):
                 self._detection_result.detection_exception = None
@@ -204,7 +206,9 @@ class TestCaseEvaluator:
                 self._detection_result.alert_context_exception = None
         return
 
-    def interpret(self, ignore_exception_types: Optional[List[Exception]] = None) -> TestResult:
+    def interpret(
+        self, ignore_exception_types: Optional[List[Type[Exception]]] = None
+    ) -> TestResult:
         """Evaluate the detection result taking into account
         the errors raised during evaluation and
         the test specification expectations"""

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -182,27 +182,26 @@ class TestCaseEvaluator:
             generic_error = self._detection_result.setup_exception
         return generic_error, generic_error_title
 
-    def _check_exception_types(self, ignore_exception_types=None) -> None:
-        if ignore_exception_types:
-            for exception_type in ignore_exception_types:
-                if isinstance(self._detection_result.detection_exception, exception_type):
-                    self._detection_result.detection_exception = None
-                if isinstance(self._detection_result.title_exception, exception_type):
-                    self._detection_result.title_exception = None
-                if isinstance(self._detection_result.description_exception, exception_type):
-                    self._detection_result.description_exception = None
-                if isinstance(self._detection_result.reference_exception, exception_type):
-                    self._detection_result.reference_exception = None
-                if isinstance(self._detection_result.severity_exception, exception_type):
-                    self._detection_result.severity_exception = None
-                if isinstance(self._detection_result.runbook_exception, exception_type):
-                    self._detection_result.runbook_exception = None
-                if isinstance(self._detection_result.destinations_exception, exception_type):
-                    self._detection_result.destinations_exception = None
-                if isinstance(self._detection_result.dedup_exception, exception_type):
-                    self._detection_result.dedup_exception = None
-                if isinstance(self._detection_result.alert_context_exception, exception_type):
-                    self._detection_result.alert_context_exception = None
+    def _check_exception_types(self, ignore_exception_types:Optional[List[Exception]] = None) -> None:
+        for exception_type in ignore_exception_types or []:
+            if isinstance(self._detection_result.detection_exception, exception_type):
+                self._detection_result.detection_exception = None
+            if isinstance(self._detection_result.title_exception, exception_type):
+                self._detection_result.title_exception = None
+            if isinstance(self._detection_result.description_exception, exception_type):
+                self._detection_result.description_exception = None
+            if isinstance(self._detection_result.reference_exception, exception_type):
+                self._detection_result.reference_exception = None
+            if isinstance(self._detection_result.severity_exception, exception_type):
+                self._detection_result.severity_exception = None
+            if isinstance(self._detection_result.runbook_exception, exception_type):
+                self._detection_result.runbook_exception = None
+            if isinstance(self._detection_result.destinations_exception, exception_type):
+                self._detection_result.destinations_exception = None
+            if isinstance(self._detection_result.dedup_exception, exception_type):
+                self._detection_result.dedup_exception = None
+            if isinstance(self._detection_result.alert_context_exception, exception_type):
+                self._detection_result.alert_context_exception = None
         return
 
     def interpret(self, ignore_exception_types: Optional[List[Exception]] = None) -> TestResult:

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -164,29 +164,6 @@ class TestCaseEvaluator:
             generic_error = self._detection_result.setup_exception
         return generic_error, generic_error_title
 
-    def _check_exception_types(
-        self, ignore_exception_types: Optional[List[Type[Exception]]] = None
-    ) -> None:
-        for exception_type in ignore_exception_types or []:
-            if isinstance(self._detection_result.detection_exception, exception_type):
-                self._detection_result.detection_exception = None
-            if isinstance(self._detection_result.title_exception, exception_type):
-                self._detection_result.title_exception = None
-            if isinstance(self._detection_result.description_exception, exception_type):
-                self._detection_result.description_exception = None
-            if isinstance(self._detection_result.reference_exception, exception_type):
-                self._detection_result.reference_exception = None
-            if isinstance(self._detection_result.severity_exception, exception_type):
-                self._detection_result.severity_exception = None
-            if isinstance(self._detection_result.runbook_exception, exception_type):
-                self._detection_result.runbook_exception = None
-            if isinstance(self._detection_result.destinations_exception, exception_type):
-                self._detection_result.destinations_exception = None
-            if isinstance(self._detection_result.dedup_exception, exception_type):
-                self._detection_result.dedup_exception = None
-            if isinstance(self._detection_result.alert_context_exception, exception_type):
-                self._detection_result.alert_context_exception = None
-
     def _get_detection_alert_value(self) -> bool:
         if self._detection_result.detection_type.upper() == TYPE_POLICY.upper():
             return Policy.matcher_alert_value
@@ -201,7 +178,7 @@ class TestCaseEvaluator:
 
         # first, we should update the detection result, taking into account any
         # ignored exception types passed into this test
-        self._check_exception_types(ignore_exception_types)
+        self._detection_result.ignore_errors(ignore_exception_types)
 
         function_results = dict(
             detectionFunction=FunctionTestResult.new(

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -163,7 +163,7 @@ class TestCaseEvaluator:
 
         # matched attribute can also be None,
         # coerce to boolean for consistent return values
-        matched = (
+        should_alert = (
             bool(self._detection_result.matched)
             == self._detection_result.detection_match_alert_value
         )
@@ -174,13 +174,13 @@ class TestCaseEvaluator:
         # we want to include errors from other functions in the status.
         if self._spec.expectations.detection == self._detection_result.detection_match_alert_value:
             # Any error should mark the test as failing
-            return matched and not self._detection_result.errored
+            return should_alert and not self._detection_result.errored
 
         # Only detection/setup exceptions and event compatibility (JSON-decodable and JSON object)
         # should be a factor in marking the test as failing
         return (
             self._detection_result.input_exception is None
-            and not matched
+            and not should_alert
             and not self._detection_result.detection_evaluation_failed
         )
 

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -148,7 +148,6 @@ class TestCaseEvaluator:
 
     def _get_result_status(self) -> bool:
         """Get the test status - passing/failing"""
-        
         # Any error should mark the test as failing
         if self._detection_result.errored:
             return False

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -189,7 +189,7 @@ class TestCaseEvaluator:
                 self._detection_result.alert_context_exception = None
 
     def _get_detection_alert_value(self) -> bool:
-        if self._detection_result.detection_type == TYPE_POLICY:
+        if self._detection_result.detection_type.upper() == TYPE_POLICY.upper():
             return Policy.matcher_alert_value
         return Rule.matcher_alert_value
 

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -204,7 +204,6 @@ class TestCaseEvaluator:
                 self._detection_result.dedup_exception = None
             if isinstance(self._detection_result.alert_context_exception, exception_type):
                 self._detection_result.alert_context_exception = None
-        return
 
     def interpret(
         self, ignore_exception_types: Optional[List[Type[Exception]]] = None

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -41,12 +41,15 @@ class FunctionTestResult:
     # error contains a TestError instance with the error message or
     # None if no error was raised
     error: Optional[TestError]
+    # return value matched expectations
+    matched: Optional[bool]
 
     @classmethod
     def new(
         cls,
         output: Optional[Union[bool, str, List[str]]],
         raw_exception: Optional[Exception] = None,
+        matched: Optional[bool] = True,
     ) -> Optional["FunctionTestResult"]:
         """Create a new instance while applying
         the necessary transformations to the parameters"""
@@ -56,7 +59,7 @@ class FunctionTestResult:
         if output is not None and not isinstance(output, str):
             output = json.dumps(output)
 
-        return cls(output=output, error=cls.to_test_error(raw_exception))
+        return cls(output=output, error=cls.to_test_error(raw_exception), matched=matched)
 
     @staticmethod
     def format_exception(exc: Optional[Exception], title: Optional[str] = None) -> Optional[str]:
@@ -201,7 +204,9 @@ class TestCaseEvaluator:
 
         function_results = dict(
             detectionFunction=FunctionTestResult.new(
-                self._detection_result.matched, self._detection_result.detection_exception
+                self._detection_result.matched,
+                self._detection_result.detection_exception,
+                self._spec.expectations.detection==self._detection_result.matched,
             )
         )
 
@@ -213,7 +218,8 @@ class TestCaseEvaluator:
             function_results.update(
                 dict(
                     titleFunction=FunctionTestResult.new(
-                        self._detection_result.title_output, self._detection_result.title_exception
+                        self._detection_result.title_output,
+                        self._detection_result.title_exception,
                     ),
                     descriptionFunction=FunctionTestResult.new(
                         self._detection_result.description_output,
@@ -236,7 +242,8 @@ class TestCaseEvaluator:
                         self._detection_result.destinations_exception,
                     ),
                     dedupFunction=FunctionTestResult.new(
-                        self._detection_result.dedup_output, self._detection_result.dedup_exception
+                        self._detection_result.dedup_output,
+                        self._detection_result.dedup_exception,
                     ),
                     alertContextFunction=FunctionTestResult.new(
                         self._detection_result.alert_context_output,

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -170,7 +170,7 @@ class TestCaseEvaluator:
         return Rule.matcher_alert_value
 
     def interpret(
-        self, ignore_exception_types: Optional[List[Type[Exception]]] = None
+        self, ignore_exception_types: List[Type[Exception]] = None
     ) -> TestResult:
         """Evaluate the detection result taking into account
         the errors raised during evaluation and
@@ -178,7 +178,8 @@ class TestCaseEvaluator:
 
         # first, we should update the detection result, taking into account any
         # ignored exception types passed into this test
-        self._detection_result.ignore_errors(ignore_exception_types)
+        if ignore_exception_types:
+            self._detection_result.ignore_errors(ignore_exception_types)
 
         function_results = dict(
             detectionFunction=FunctionTestResult.new(

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -189,7 +189,7 @@ class TestCaseEvaluator:
             if isinstance(self._detection_result.alert_context_exception, exception_type):
                 self._detection_result.alert_context_exception = None
 
-    def _get_detection_alert_value(self):
+    def _get_detection_alert_value(self) -> bool:
         if self._detection_result.detection_type == TYPE_POLICY:
             return Policy.matcher_alert_value
         return Rule.matcher_alert_value

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -182,7 +182,6 @@ class TestCaseEvaluator:
             generic_error = self._detection_result.setup_exception
         return generic_error, generic_error_title
 
-
     def _check_exception_types(self, ignore_exception_types=None) -> None:
         if ignore_exception_types:
             for exception_type in ignore_exception_types:
@@ -206,7 +205,7 @@ class TestCaseEvaluator:
                     self._detection_result.alert_context_exception = None
         return
 
-    def interpret(self, ignore_exception_types: Optional[List[Exception]]=None) -> TestResult:
+    def interpret(self, ignore_exception_types: Optional[List[Exception]] = None) -> TestResult:
         """Evaluate the detection result taking into account
         the errors raised during evaluation and
         the test specification expectations"""

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -206,7 +206,7 @@ class TestCaseEvaluator:
             detectionFunction=FunctionTestResult.new(
                 self._detection_result.matched,
                 self._detection_result.detection_exception,
-                self._spec.expectations.detection==self._detection_result.matched,
+                self._spec.expectations.detection == self._detection_result.matched,
             )
         )
 

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -188,7 +188,7 @@ class TestCaseEvaluator:
         the test specification expectations"""
         function_results = dict(
             detectionFunction=FunctionTestResult.new(
-                self._detection_result.matched,
+                self._detection_result.detection_output,
                 self._detection_result.detection_exception,
                 self._spec.expectations.detection == self._detection_result.detection_output,
             )

--- a/panther_analysis_tool/testing.py
+++ b/panther_analysis_tool/testing.py
@@ -182,10 +182,39 @@ class TestCaseEvaluator:
             generic_error = self._detection_result.setup_exception
         return generic_error, generic_error_title
 
-    def interpret(self) -> TestResult:
+
+    def _check_exception_types(self, ignore_exception_types=None) -> None:
+        if ignore_exception_types:
+            for exception_type in ignore_exception_types:
+                if isinstance(self._detection_result.detection_exception, exception_type):
+                    self._detection_result.detection_exception = None
+                if isinstance(self._detection_result.title_exception, exception_type):
+                    self._detection_result.title_exception = None
+                if isinstance(self._detection_result.description_exception, exception_type):
+                    self._detection_result.description_exception = None
+                if isinstance(self._detection_result.reference_exception, exception_type):
+                    self._detection_result.reference_exception = None
+                if isinstance(self._detection_result.severity_exception, exception_type):
+                    self._detection_result.severity_exception = None
+                if isinstance(self._detection_result.runbook_exception, exception_type):
+                    self._detection_result.runbook_exception = None
+                if isinstance(self._detection_result.destinations_exception, exception_type):
+                    self._detection_result.destinations_exception = None
+                if isinstance(self._detection_result.dedup_exception, exception_type):
+                    self._detection_result.dedup_exception = None
+                if isinstance(self._detection_result.alert_context_exception, exception_type):
+                    self._detection_result.alert_context_exception = None
+        return
+
+    def interpret(self, ignore_exception_types: Optional[List[Exception]]=None) -> TestResult:
         """Evaluate the detection result taking into account
         the errors raised during evaluation and
         the test specification expectations"""
+
+        # first, we should update the detection result, taking into account any
+        # ignored exception types passed into this test
+        self._check_exception_types(ignore_exception_types)
+
         function_results = dict(
             detectionFunction=FunctionTestResult.new(
                 self._detection_result.detection_output,

--- a/tests/fixtures/detections/example_set_duplicates.yml
+++ b/tests/fixtures/detections/example_set_duplicates.yml
@@ -17,8 +17,8 @@ SummaryAttributes:
   - example_dupe
   - example_dupe
 OutputIds:
-  - 1234
-  - 1234
+  - "1234"
+  - "1234"
 Suppressions:
   - asdf
   - asdf

--- a/tests/fixtures/detections/valid_analysis/policies/example_policy_generated_functions.py
+++ b/tests/fixtures/detections/valid_analysis/policies/example_policy_generated_functions.py
@@ -30,4 +30,4 @@ def reference(resource):
     return 'THIS IS AN EXAMPLE REFERENCE.'
 
 def severity(resource):
-    return 'CRITICAL'
+    return 'CrItIcAl'

--- a/tests/fixtures/detections/valid_analysis/policies/example_policy_generated_functions.py
+++ b/tests/fixtures/detections/valid_analysis/policies/example_policy_generated_functions.py
@@ -1,0 +1,33 @@
+IGNORED_USERS = {}
+
+def policy(resource):
+    if resource['UserName'] in IGNORED_USERS:
+        return False
+
+    cred_report = resource.get('CredentialReport', {})
+    if not cred_report:
+        return True
+
+    return cred_report.get('PasswordEnabled', False) and cred_report.get(
+        'MfaActive', False)
+
+def title(resource):
+    return 'THIS IS AN EXAMPLE TITLE'
+
+def alert_context(resource):
+    return {'ip': '1.1.1.1'}
+
+def description(resource):
+    return 'THIS IS AN EXAMPLE DESCRIPTION.'
+
+def destinations(resource):
+    return ["ExampleDestinationName"]
+
+def runbook(resource):
+    return 'THIS IS AN EXAMPLE RUNBOOK VALUE.'
+
+def reference(resource):
+    return 'THIS IS AN EXAMPLE REFERENCE.'
+
+def severity(resource):
+    return 'CRITICAL'

--- a/tests/fixtures/detections/valid_analysis/policies/example_policy_generated_functions.yml
+++ b/tests/fixtures/detections/valid_analysis/policies/example_policy_generated_functions.yml
@@ -1,9 +1,9 @@
 AnalysisType: policy
-Filename: example_policy_beta.py
-DisplayName: MFA Is Enabled For User
+Filename: example_policy_generated_functions.py
+DisplayName: MFA Is Enabled For User Generated Fields
 Description: Another valid policy.
 Severity: High
-PolicyID: AWS.IAM.BetaTest
+PolicyID: AWS.IAM.MFAEnabledGenerated
 Enabled: true
 ResourceTypes:
   - AWS.IAM.RootUser

--- a/tests/unit/panther_analysis_tool/test_rule.py
+++ b/tests/unit/panther_analysis_tool/test_rule.py
@@ -755,7 +755,7 @@ class TestDetectionResult(TestCase):
         self.assertTrue(DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, setup_exception=TypeError(), trigger_alert=False).detection_evaluation_failed)
         self.assertFalse(DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, title_exception=TypeError(), trigger_alert=False).detection_evaluation_failed)
 
-    def test_ignore_errores(self) -> None:
+    def test_ignore_errors(self) -> None:
         # type error should be ignored, and there are no other exceptions
         result = DetectionResult(
             detection_id='failed.rule',
@@ -768,7 +768,7 @@ class TestDetectionResult(TestCase):
         self.assertFalse(result.errored)
         self.assertIsNone(result.detection_exception)
 
-        # type error should be ignored, but the ZeroDivisonError should not
+        # type error should be ignored, but the ZeroDivisionError should not
         result = DetectionResult(
             detection_id='failed.rule',
             detection_severity='INFO',

--- a/tests/unit/panther_analysis_tool/test_rule.py
+++ b/tests/unit/panther_analysis_tool/test_rule.py
@@ -757,20 +757,40 @@ class TestDetectionResult(TestCase):
 
     def test_ignore_errores(self) -> None:
         # type error should be ignored, and there are no other exceptions
-        result = DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, detection_exception=TypeError(), trigger_alert=False)
+        result = DetectionResult(
+            detection_id='failed.rule',
+            detection_severity='INFO',
+            detection_type=TYPE_RULE,
+            detection_exception=TypeError(),
+            trigger_alert=False,
+        )
         result.ignore_errors([TypeError])
         self.assertFalse(result.errored)
         self.assertIsNone(result.detection_exception)
 
         # type error should be ignored, but the ZeroDivisonError should not
-        result = DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, detection_exception=ZeroDivisionError(), trigger_alert=False, title_exception=TypeError())
+        result = DetectionResult(
+            detection_id='failed.rule',
+            detection_severity='INFO',
+            detection_type=TYPE_RULE,
+            detection_exception=ZeroDivisionError(),
+            trigger_alert=False,
+            title_exception=TypeError(),
+        )
         result.ignore_errors([TypeError])
         self.assertTrue(result.errored)
         self.assertIsInstance(result.detection_exception, ZeroDivisionError)
         self.assertIsNone(result.title_exception)
 
         # UnknownDestinationError should be ignored, and there are no other exceptions
-        result = DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, detection_exception=None, trigger_alert=False, destinations_exception=UnknownDestinationError())
+        result = DetectionResult(
+            detection_id='failed.rule',
+            detection_severity='INFO',
+            detection_type=TYPE_RULE,
+            detection_exception=None,
+            trigger_alert=False,
+            destinations_exception=UnknownDestinationError(),
+        )
         result.ignore_errors([UnknownDestinationError])
         self.assertFalse(result.errored)
         self.assertIsNone(result.destinations_exception)

--- a/tests/unit/panther_analysis_tool/test_rule.py
+++ b/tests/unit/panther_analysis_tool/test_rule.py
@@ -31,7 +31,7 @@ from panther_analysis_tool.detection import DetectionResult, FilesystemImporter,
 from panther_analysis_tool.rule import Rule, MAX_DEDUP_STRING_SIZE, \
     MAX_GENERATED_FIELD_SIZE, TRUNCATED_STRING_SUFFIX, TYPE_RULE
 from panther_analysis_tool.enriched_event import PantherEvent
-from panther_analysis_tool.exceptions import FunctionReturnTypeError
+from panther_analysis_tool.exceptions import FunctionReturnTypeError, UnknownDestinationError
 
 
 class TestRule(TestCase):  # pylint: disable=too-many-public-methods
@@ -755,6 +755,25 @@ class TestDetectionResult(TestCase):
         self.assertTrue(DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, setup_exception=TypeError(), trigger_alert=False).detection_evaluation_failed)
         self.assertFalse(DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, title_exception=TypeError(), trigger_alert=False).detection_evaluation_failed)
 
+    def test_ignore_errores(self) -> None:
+        # type error should be ignored, and there are no other exceptions
+        result = DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, detection_exception=TypeError(), trigger_alert=False)
+        result.ignore_errors([TypeError])
+        self.assertFalse(result.errored)
+        self.assertIsNone(result.detection_exception)
+
+        # type error should be ignored, but the ZeroDivisonError should not
+        result = DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, detection_exception=ZeroDivisionError(), trigger_alert=False, title_exception=TypeError())
+        result.ignore_errors([TypeError])
+        self.assertTrue(result.errored)
+        self.assertIsInstance(result.detection_exception, ZeroDivisionError)
+        self.assertIsNone(result.title_exception)
+
+        # UnknownDestinationError should be ignored, and there are no other exceptions
+        result = DetectionResult(detection_id='failed.rule', detection_severity='INFO', detection_type=TYPE_RULE, detection_exception=None, trigger_alert=False, destinations_exception=UnknownDestinationError())
+        result.ignore_errors([UnknownDestinationError])
+        self.assertFalse(result.errored)
+        self.assertIsNone(result.destinations_exception)
 
 class TestRawStringImporter(TestCase):
     def setUp(self) -> None:

--- a/tests/unit/panther_analysis_tool/test_testing.py
+++ b/tests/unit/panther_analysis_tool/test_testing.py
@@ -39,11 +39,11 @@ class TestFunctionTestResult(unittest.TestCase):
     def test_new(self) -> None:
         # If output is boolean
         result = FunctionTestResult.new(output=True)
-        self.assertEqual(result, FunctionTestResult(output='true', error=None))
+        self.assertEqual(result, FunctionTestResult(output='true', error=None, matched=True))
 
         # If output is string
         result = FunctionTestResult.new(output='some output')
-        self.assertEqual(result, FunctionTestResult(output='some output', error=None))
+        self.assertEqual(result, FunctionTestResult(output='some output', error=None, matched=True))
 
         # If both parameters are None
         result = FunctionTestResult.new(output=None, raw_exception=None)
@@ -51,8 +51,8 @@ class TestFunctionTestResult(unittest.TestCase):
 
         # When an exception is given
         exception = TypeError('wrong type')
-        result = FunctionTestResult.new(output='some output', raw_exception=exception)
-        expected = FunctionTestResult(output='some output', error=TestError(message='TypeError: wrong type'))
+        result = FunctionTestResult.new(output='some output', raw_exception=exception, matched=True)
+        expected = FunctionTestResult(output='some output', error=TestError(message='TypeError: wrong type'), matched=True)
         self.assertEqual(result, expected)
 
     def test_format_exception(self) -> None:
@@ -94,7 +94,7 @@ class TestTestCaseEvaluator(unittest.TestCase):
             passed=True,
             matched=False,
             functions=TestResultsPerFunction(
-                detectionFunction=FunctionTestResult(output='false', error=None),
+                detectionFunction=FunctionTestResult(output='false', error=None, matched=True),
                 titleFunction=None,
                 dedupFunction=None,
                 alertContextFunction=None,
@@ -122,7 +122,7 @@ class TestTestCaseEvaluator(unittest.TestCase):
             passed=True,
             matched=True,
             functions=TestResultsPerFunction(
-                detectionFunction=FunctionTestResult(output='true', error=None),
+                detectionFunction=FunctionTestResult(output='true', error=None, matched=True),
                 titleFunction=None,
                 dedupFunction=None,
                 alertContextFunction=None,
@@ -157,7 +157,7 @@ class TestTestCaseEvaluator(unittest.TestCase):
             passed=False,
             matched=None,
             functions=TestResultsPerFunction(
-                detectionFunction=FunctionTestResult(output=None, error=TestError(message='TypeError: wrong type')),
+                detectionFunction=FunctionTestResult(output=None, error=TestError(message='TypeError: wrong type'), matched=False),
                 titleFunction=None,
                 dedupFunction=None,
                 alertContextFunction=None,
@@ -192,7 +192,7 @@ class TestTestCaseEvaluator(unittest.TestCase):
             passed=False,
             matched=None,
             functions=TestResultsPerFunction(
-                detectionFunction=FunctionTestResult(output=None, error=TestError(message='TypeError: wrong type')),
+                detectionFunction=FunctionTestResult(output=None, error=TestError(message='TypeError: wrong type'), matched=False),
                 titleFunction=None,
                 dedupFunction=None,
                 alertContextFunction=None,


### PR DESCRIPTION
### Background

Closes: https://app.asana.com/0/1199961856165998/1201003028086559/f

With dynamic field output in policies, we should show the output for them when running `pat`.  Also, we should use the testing module to be consistent with the BE.

### Changes

* unify the way we call the run and aux methods between rules and policies
* update output: 
   * show dynamic fields for policies
   * print rule/policy output or error as well
* Update `FunctionTestResult` to have a per-function `matched` value
   * can be used to determine if we should print the detection status/output. (see "example rule / aux function throws error" below for difference in output)
   * can be used in the future for output checking on a per function basis
   

### Testing

* `make test`
* `make integration`

<details>
<summary> example policy output </summary>

```
 % panther_analysis_tool test --path ./tests/fixtures/detections/valid_analysis/policies
[INFO]: Testing analysis packs in ./tests/fixtures/detections/valid_analysis/policies

AWS.IAM.MFAEnabled
	[PASS] Root MFA not enabled fails compliance
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.IAM.MFAEnabled
	[PASS] User MFA not enabled fails compliance
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.IAM.MFAEnabled

AWS.IAM.BetaTest
	[PASS] Root MFA not enabled fails compliance
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.IAM.BetaTest
	[PASS] User MFA not enabled fails compliance
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:AWS.IAM.BetaTest

IAM.MFAEnabled Extra Fields
	[PASS] Root MFA not enabled triggers a violation.
		[PASS] [policy] false
		[PASS] [dedup] defaultDedupString:IAM.MFAEnabled Extra Fields

AWS.IAM.MFAEnabledGenerated
	[PASS] Root MFA not enabled fails compliance
		[PASS] [policy] false
		[PASS] [title] THIS IS AN EXAMPLE TITLE
		[PASS] [dedup] THIS IS AN EXAMPLE TITLE
		[PASS] [alertContext] {"ip": "1.1.1.1"}
		[PASS] [description] THIS IS AN EXAMPLE DESCRIPTION.
		[PASS] [reference] THIS IS AN EXAMPLE REFERENCE.
		[PASS] [severity] CRITICAL
		[PASS] [runbook] THIS IS AN EXAMPLE RUNBOOK VALUE.
		[PASS] [destinations] ['ExampleDestinationName']
	[PASS] User MFA not enabled fails compliance
		[PASS] [policy] false
		[PASS] [title] THIS IS AN EXAMPLE TITLE
		[PASS] [dedup] THIS IS AN EXAMPLE TITLE
		[PASS] [alertContext] {"ip": "1.1.1.1"}
		[PASS] [description] THIS IS AN EXAMPLE DESCRIPTION.
		[PASS] [reference] THIS IS AN EXAMPLE REFERENCE.
		[PASS] [severity] CRITICAL
		[PASS] [runbook] THIS IS AN EXAMPLE RUNBOOK VALUE.
		[PASS] [destinations] ['ExampleDestinationName']

--------------------------
Panther CLI Test Summary
	Path: ./tests/fixtures/detections/valid_analysis/policies
	Passed: 4
	Failed: 0
	Invalid: 0
```

</details>

<details>

<summary> example rule / aux function throws error </summary>

Before:

```
% panther_analysis_tool test --path ./panther_analysis_tool/tmp
[INFO]: Testing analysis packs in ./panther_analysis_tool/tmp

AWS.CloudTrail.ResourceMadePublic
	[FAIL] ECR Made Public
		[FAIL] [alert_context] division by zero
		[FAIL] [description] division by zero

--------------------------
Panther CLI Test Summary
	Path: ./panther_analysis_tool/tmp
	Passed: 1
	Failed: 1
	Invalid: 0

--------------------------
Failed Tests Summary
	AWS.CloudTrail.ResourceMadePublic
		['ECR Made Public', 'ECR Made Public:alert_context', 'ECR Made Public:description']
```

After:

```
% panther_analysis_tool --debug test --path ./tmp
[INFO]: Testing analysis packs in ./tmp

AWS.CloudTrail.ResourceMadePublic
	[FAIL] ECR Made Public
		[FAIL] [rule] ZeroDivisionError: division by zero
		[PASS] [dedup] defaultDedupString:AWS.CloudTrail.ResourceMadePublic
		[FAIL] [alertContext] ZeroDivisionError: division by zero
		[FAIL] [description] ZeroDivisionError: division by zero

--------------------------
Panther CLI Test Summary
	Path: ./tmp
	Passed: 1
	Failed: 1
	Invalid: 0

--------------------------
Failed Tests Summary
	AWS.CloudTrail.ResourceMadePublic
		['ECR Made Public:rule', 'ECR Made Public:alertContext', 'ECR Made Public:description']
```

</details>