### PR TITLE
Remove managed schemas sub-command

### DIFF
--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -304,9 +304,8 @@ class TestPantherAnalysisTool(TestCase):
         except OSError:
             pass
 
-        with mock.patch.dict(os.environ, {pat.ENV_VAR_INCLUDE_INTERNAL_SUBCOMMANDS: 'true'}):
-            args = pat.setup_parser().parse_args(
-                f'zip --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/'.split())
+        args = pat.setup_parser().\
+            parse_args(f'zip --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/'.split())
 
         return_code, out_filename = pat.zip_analysis(args)
         assert_true(out_filename.startswith("tmp/"))


### PR DESCRIPTION
### Background

Relates to https://app.asana.com/0/1201101223107402/1200818057929173

### Changes

- Remove code related to generating a managed schemas release archive.
- Restore visibility to the `zip` sub-command, which was erroneously
  hidden with https://github.com/panther-labs/panther_analysis_tool/pull/116.

### Testing

```
$ panther_analysis_tool --help
usage: panther_analysis_tool [-h] [--version] [--debug]
                             {release,test,publish,upload,update-custom-schemas,zip}
                             ...

Panther Analysis Tool: A command line tool for managing Panther policies and
rules.

positional arguments:
  {release,test,publish,upload,update-custom-schemas,zip}
    release             Create release assets for repository containing
                        panther detections. Generates a file called panther-
                        analysis-all.zip and optionally generates panther-
                        analysis-all.sig
    test                Validate analysis specifications and run policy and
                        rule tests.
    publish             Publishes a new release, generates the release assets,
                        and uploads them. Generates a file called panther-
                        analysis-all.zip and optionally generates panther-
                        analysis-all.sig
    upload              Upload specified policies and rules to a Panther
                        deployment.
    update-custom-schemas
                        Update or create custom schemas on a Panther
                        deployment.
    zip                 Create an archive of local policies and rules for
                        uploading to Panther.

optional arguments:
  -h, --help            show this help message and exit
  --version             show program's version number and exit
  --debug
```