### PR TITLE
expand regex for allowed Custom schema names

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -51,7 +51,7 @@ LOG_TYPE_REGEX = Regex(
     r"Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\."
     r"LoginAs|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|"
     r"Slack\.IntegrationLogs|Sophos\.Central|Suricata\.Anomaly|Suricata\.DNS|Syslog\."
-    r"RFC3164|Syslog\.RFC5424|Zeek\.DNS|Zendesk\.Audit|Zendesk\.AuditLog|Custom\.[A-Za-z0-9-]+)$"
+    r"RFC3164|Syslog\.RFC5424|Zeek\.DNS|Zendesk\.Audit|Zendesk\.AuditLog|Custom\.[A-Za-z0-9-\.]+)$"
 )
 
 TYPE_SCHEMA = Schema(

--- a/tests/fixtures/custom-schemas/valid/schema-3.yml
+++ b/tests/fixtures/custom-schemas/valid/schema-3.yml
@@ -1,0 +1,14 @@
+schema: Custom.Sample.Schema3
+description: "Sample Schema 3"
+referenceURL: "https://runpanther.io"
+version: 0
+fields:
+  - name: time
+    description: Event timestamp
+    required: true
+    type: timestamp
+    timeFormat: rfc3339
+    isEventTime: true
+  - name: method
+    description: The HTTP method used for the request
+    type: string

--- a/tests/unit/panther_analysis_tool/log_schemas/test_user_defined.py
+++ b/tests/unit/panther_analysis_tool/log_schemas/test_user_defined.py
@@ -28,11 +28,12 @@ class TestUtilities(unittest.TestCase):
         files = user_defined.discover_files(path, user_defined.Uploader._SCHEMA_FILE_GLOB_PATTERNS)
         self.assertListEqual(files, [os.path.join(path, 'schema-1.yml'),
                                      os.path.join(path, 'schema-2.yaml'),
+                                     os.path.join(path, 'schema-3.yml'),
                                      os.path.join(path, 'schema_1_tests.yml')])
 
     def test_ignore_schema_test_files(self):
         base_path = os.path.join(FIXTURES_PATH, 'custom-schemas', 'valid')
-        schema_files = ['schema-1.yml', 'schema-2.yml']
+        schema_files = ['schema-1.yml', 'schema-2.yml', 'schema-3.yml']
         schema_test_files = ['schema_1_tests.yml']
 
         all_files = [os.path.join(base_path, filename) for filename in schema_files + schema_test_files]
@@ -56,6 +57,9 @@ class TestUploader(unittest.TestCase):
 
         with open(os.path.join(self.valid_schema_path, 'schema-2.yaml')) as f:
             self.valid_schema2 = f.read()
+
+        with open(os.path.join(self.valid_schema_path, 'schema-3.yml')) as f:
+            self.valid_schema3 = f.read()
 
         self.list_schemas_response = {
             'results': [
@@ -82,6 +86,19 @@ class TestUploader(unittest.TestCase):
                     'description': 'A verbose description',
                     'referenceURL': 'https://example.com',
                     'spec': self.valid_schema2,
+                    'active': False,
+                    'native': False
+                },
+                {
+                    'name': 'Custom.Sample.Schema3',
+                    'revision': 17,
+                    'updatedAt': '2021-05-14T12:05:13.928862479Z',
+                    'createdAt': '2021-05-11T14:08:08.42627193Z',
+                    'managed': False,
+                    'disabled': False,
+                    'description': 'A verbose description',
+                    'referenceURL': 'https://example.com',
+                    'spec': self.valid_schema3,
                     'active': False,
                     'native': False
                 }
@@ -135,7 +152,8 @@ class TestUploader(unittest.TestCase):
         self.assertListEqual(
             uploader.files,
             [os.path.join(self.valid_schema_path, 'schema-1.yml'),
-             os.path.join(self.valid_schema_path, 'schema-2.yaml')]
+             os.path.join(self.valid_schema_path, 'schema-2.yaml'),
+             os.path.join(self.valid_schema_path, 'schema-3.yml')]
         )
 
     def test_process(self):
@@ -160,11 +178,11 @@ class TestUploader(unittest.TestCase):
             )
             uploader = user_defined.Uploader(self.valid_schema_path, None)
             results = uploader.process()
-            self.assertEqual(len(results), 2)
+            self.assertEqual(len(results), 3)
             self.assertListEqual([r.name for r in results],
-                                 ['Custom.SampleSchema1', 'Custom.SampleSchema2'])
-            self.assertListEqual([r.existed for r in results], [True, True])
-            self.assertEqual(mock_uploader_client.put_schema.call_count, 2)
+                                 ['Custom.SampleSchema1', 'Custom.SampleSchema2', 'Custom.Sample.Schema3'])
+            self.assertListEqual([r.existed for r in results], [True, True, True])
+            self.assertEqual(mock_uploader_client.put_schema.call_count, 3)
             mock_uploader_client.put_schema.assert_has_calls(
               [
                   mock.call(
@@ -178,6 +196,13 @@ class TestUploader(unittest.TestCase):
                       name="Custom.SampleSchema2",
                       definition=self.valid_schema2,
                       description='Sample Schema 2',
+                      reference_url='https://runpanther.io',
+                      revision=17
+                  ),
+                  mock.call(
+                      name="Custom.Sample.Schema3",
+                      definition=self.valid_schema3,
+                      description='Sample Schema 3',
                       reference_url='https://runpanther.io',
                       revision=17
                   ),

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -394,6 +394,19 @@ class TestPantherAnalysisTool(TestCase):
                                     'spec': schema2,
                                     'active': False,
                                     'native': False
+                                },
+                                {
+                                    'name': 'Custom.Sample.Schema3',
+                                    'revision': 17,
+                                    'updatedAt': '2021-05-14T12:05:13.928862479Z',
+                                    'createdAt': '2021-05-11T14:08:08.42627193Z',
+                                    'managed': False,
+                                    'disabled': False,
+                                    'description': 'A verbose description',
+                                    'referenceURL': 'https://example.com',
+                                    'spec': schema2,
+                                    'active': False,
+                                    'native': False
                                 }
                             ]
                         }
@@ -403,7 +416,7 @@ class TestPantherAnalysisTool(TestCase):
                 return_code, _ = pat.update_custom_schemas(args)
                 assert_equal(return_code, 0)
                 mocks['error'].assert_not_called()
-                assert_equal(mocks['info'].call_count, 2)
+                assert_equal(mocks['info'].call_count, 3)
 
         with mock.patch.multiple(logging, error=mock.DEFAULT, info=mock.DEFAULT) as mocks:
             with mock.patch('panther_analysis_tool.log_schemas.user_defined.Uploader.api_client', autospec=Client) \


### PR DESCRIPTION
### Background

We have a schema named `Custom.AWS.EKS.Audit` that cannot be used with the PAT test tool. The unit tests will throw an error:

```
[ERROR]: [('./kubernetes_rules/kubectl_exec.yml', SchemaError("Key 'LogTypes' error: LOG_TYPE_REGEX does not match 'Custom.AWS.EKS.Audit'"))]
```

Due to this regex: https://github.com/panther-labs/panther_analysis_tool/blob/fe7fc735b6d62dc585e47349ff58a3dda30961ed/panther_analysis_tool/schemas.py#L54

The rest of the Panther tooling allowed for a schema with this naming scheme to be created and there appears to be precedence for schema names with multiple `.`'s: `Microsoft365\.Audit\.SharePoint`, `Microsoft365\.Audit\.Exchange`.

### Changes

* expand the allowed regex for custom schemas in the test tool to support schema names with multiple separators.

### Testing

* Write a test case .yml file where the `LogTypes` list contains a custom schema name with multiple `.` separators, and then run `panther_analysis_tool test` against it.
