### PR TITLE
allow OnePassword log type regex

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -48,9 +48,9 @@ LOG_TYPE_REGEX = Regex(
     r"Lacework\.Events|Microsoft365\.Audit\.AzureActiveDirectory|Microsoft365\.Audit\.Exchange"
     r"|Microsoft365\.Audit\.General|Microsoft365\.Audit\.SharePoint|Microsoft365\.DLP\.All|"
     r"Nginx\.Access|Okta\.SystemLog|OneLogin\.Events|Osquery\.Batch|Osquery\.Differential|"
-    r"Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\."
-    r"LoginAs|Salesforce\.Logout|Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|"
-    r"Slack\.IntegrationLogs|Sophos\.Central|Suricata\.Anomaly|Suricata\.DNS|Syslog\."
+    r"Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|Salesforce\.Login|Salesforce\.LoginAs|"
+    r"Salesforce\.Logout|Salesforce\.URI|OnePassword\.ItemUsage|OnePassword\.SignInAttempt|"
+    r"Slack\.AccessLogs|Slack\.AuditLogs|Slack\.IntegrationLogs|Sophos\.Central|Suricata\.Anomaly|Suricata\.DNS|Syslog\."
     r"RFC3164|Syslog\.RFC5424|Zeek\.DNS|Zendesk\.Audit|Zendesk\.AuditLog|Custom\.[A-Za-z0-9-\.]+)$"
 )
 


### PR DESCRIPTION
### Background

v1.25.0 introduced OnePassword log types, so I added them to the allowed regex validation so `panther_analysis_tool test` can pass for rules that use those log types.

### Changes

* updated the `LOG_TYPE_REGEX` regex in `schema.py`

### Testing

* `make test`
