### PR TITLE
adds reference to api docs and makes minor modification to public api host logic.

### DIFF
--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -23,6 +23,7 @@ import logging
 from typing import Dict
 from pathlib import Path
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from gql import Client as GraphQLClient, gql
 from gql.transport.aiohttp import AIOHTTPTransport
@@ -137,7 +138,18 @@ def _build_client(host: str, token: str) -> GraphQLClient:
     return GraphQLClient(transport=transport, fetch_schema_from_transport=True)
 
 
+def is_url(url: str) -> bool:
+    try:
+        result = urlparse(url)
+        return all([result.scheme, result.netloc])
+    except ValueError:
+        return False
+
+
 def _build_api_url(host: str) -> str:
+    if is_url(host):
+        return host
+
     return f"https://{_API_DOMAIN_PREFIX}.{host}/{_API_URL_PATH}"
 
 

--- a/panther_analysis_tool/cmd/standard_args.py
+++ b/panther_analysis_tool/cmd/standard_args.py
@@ -1,15 +1,17 @@
 import argparse
 
+API_DOCUMENTATION = "https://docs.panther.com/api-beta"
+
 
 def for_public_api(parser: argparse.ArgumentParser, required: bool) -> None:
     parser.add_argument("--api-token",
                         type=str,
-                        help="The Panther API token to use.",
+                        help="The Panther API token to use. See: " + API_DOCUMENTATION,
                         required=required)
 
     parser.add_argument("--api-host",
                         type=str,
-                        help="The Panther API token to use.",
+                        help="The Panther API host to use. See: " + API_DOCUMENTATION,
                         required=required)
 
 


### PR DESCRIPTION
### Background

We had the wrong text for one of our commands and also did not have the ability to provide the full url to an endpoint for the public api

### Changes

* updates help text around api-host to include references to api documentation
* updates host logic to use raw host if it is a valid url

