### PR TITLE
Adding a sample scheduled query to the PAT tests

### DIFF
--- a/tests/fixtures/queries/example-scheduled-query.yml
+++ b/tests/fixtures/queries/example-scheduled-query.yml
@@ -1,0 +1,33 @@
+AnalysisType: scheduled_query
+QueryName: ScheduledQuery_Example
+Description: Example for a scheduled query for PAT
+Enabled: true
+Query:
+  "SELECT 
+   user_name,
+   reported_client_type,
+   COUNT(event_id) AS counts
+   FROM snowflake.account_usage.login_history
+   WHERE
+    DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24 
+   AND
+   error_code IS NOT NULL
+   GROUP BY reported_client_type, user_name
+   HAVING counts >= 3"
+SnowflakeQuery:
+  "SELECT 
+   user_name,
+   reported_client_type,
+   COUNT(event_id) AS counts
+   FROM snowflake.account_usage.login_history
+   WHERE
+    DATEDIFF(HOUR, event_timestamp, CURRENT_TIMESTAMP) < 24 
+   AND
+   error_code IS NOT NULL
+   GROUP BY reported_client_type, user_name
+   HAVING counts >= 3"
+Schedule:
+  CronExpression: "0 0 29 2 *"
+  RateMinutes: 0
+  TimeoutMinutes: 2
+


### PR DESCRIPTION
### Background

PAT can support uploading the schedule queries but it is missing the sample. This PR is adding a new sample for the scheduled queries. 

### Changes

* A scheduled_query sample for PAT under fixtures/queries folder.

