### PR TITLE
Logging Updates

### DIFF
--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -20,7 +20,7 @@ along with this program.  If not, see <https://www.gnu.org/licenses/>.
 import base64
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any, List, TypeVar, Generic, Optional
+from typing import Any, List, TypeVar, Generic
 
 ResponseData = TypeVar('ResponseData')
 

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -94,8 +94,6 @@ class BulkUploadResponse:
     data_models: BulkUploadStatistics
     lookup_tables: BulkUploadStatistics
     global_helpers: BulkUploadStatistics
-    new_detections: Optional[List[Any]]
-    updated_detections: Optional[List[Any]]
 
 
 @dataclass(frozen=True)

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -103,9 +103,7 @@ class LambdaClient(Client):
                 policies=BulkUploadStatistics(**body.get('policies', default_stats)),
                 data_models=BulkUploadStatistics(**body.get('dataModels', default_stats)),
                 lookup_tables=BulkUploadStatistics(**body.get('lookupTables', default_stats)),
-                global_helpers=BulkUploadStatistics(**body.get('globalHelpers', default_stats)),
-                new_detections=body.get('newDetections'),
-                updated_detections=body.get('updatedDetections'),
+                global_helpers=BulkUploadStatistics(**body.get('globalHelpers', default_stats))
             )
         )
 

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -144,9 +144,7 @@ class PublicAPIClient(Client):
                 policies=BulkUploadStatistics(**data.get('policies', default_stats)),
                 data_models=BulkUploadStatistics(**data.get('dataModels', default_stats)),
                 lookup_tables=BulkUploadStatistics(**data.get('lookupTables', default_stats)),
-                global_helpers=BulkUploadStatistics(**data.get('globalHelpers', default_stats)),
-                new_detections=[],
-                updated_detections=[],
+                global_helpers=BulkUploadStatistics(**data.get('globalHelpers', default_stats))
             ))
 
     def delete_saved_queries(self, params: DeleteSavedQueriesParams) -> BackendResponse[DeleteSavedQueriesResponse]:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -34,7 +34,6 @@ import time
 import zipfile
 from collections import defaultdict
 from collections.abc import Mapping
-from dataclasses import asdict
 from datetime import datetime
 
 # Comment below disabling pylint checks is due to a bug in the CircleCi image with Pylint
@@ -47,6 +46,7 @@ from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple, Type
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 from gql.transport.aiohttp import log as aiohttp_logger
+from dataclasses import asdict
 
 import botocore
 import requests
@@ -404,7 +404,12 @@ def upload_analysis(backend: BackendClient, args: argparse.Namespace) -> Tuple[i
                 response = backend.bulk_upload(upload_params)
 
                 logging.info("Upload success.")
-                logging.info("API Response:\n%s", response.data)
+                logging.info("API Response:\n%s",
+                    json.dumps(
+                        asdict(response.data),
+                        indent=4
+                    )
+                )
 
                 return 0, ""
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -17,6 +17,8 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from gql.transport.aiohttp import log as aiohttp_logger
+
 import argparse
 import base64
 import hashlib
@@ -1746,6 +1748,9 @@ def run() -> None:
         format="[%(levelname)s]: %(message)s",
         level=logging.DEBUG if args.debug else logging.INFO,
     )
+    if not args.debug:
+        aiohttp_logger.setLevel(logging.WARNING)
+
 
     if getattr(args, "filter", None) is not None:
         args.filter, args.filter_inverted = parse_filter(args.filter)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -45,9 +45,9 @@ from importlib.abc import Loader
 from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple, Type
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
-from gql.transport.aiohttp import log as aiohttp_logger
 from dataclasses import asdict
 
+from gql.transport.aiohttp import log as aiohttp_logger
 import botocore
 import requests
 import schema

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -34,6 +34,7 @@ import time
 import zipfile
 from collections import defaultdict
 from collections.abc import Mapping
+from dataclasses import asdict
 from datetime import datetime
 
 # Comment below disabling pylint checks is due to a bug in the CircleCi image with Pylint
@@ -45,7 +46,6 @@ from importlib.abc import Loader
 from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple, Type
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
-from dataclasses import asdict
 
 from gql.transport.aiohttp import log as aiohttp_logger
 import botocore

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -17,8 +17,6 @@ You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from gql.transport.aiohttp import log as aiohttp_logger
-
 import argparse
 import base64
 import hashlib
@@ -48,6 +46,7 @@ from importlib.abc import Loader
 from typing import Any, DefaultDict, Dict, Iterator, List, Set, Tuple, Type
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
+from gql.transport.aiohttp import log as aiohttp_logger
 
 import botocore
 import requests


### PR DESCRIPTION
### Background

The GQL client is very noise at the Info log level.  Raising the log level of the async HTTP transport that it uses.

### Changes

* Increase log level of AIOHTTP transport to WARNING
* Pretty Print bulk upload response


