### PR TITLE
correctly parse saved query names when deleting detections

### DIFF
--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -196,7 +196,7 @@ class PublicAPIClient(Client):
             status_code=200,
             data=DeleteDetectionsResponse(
                 ids=res.data.get('deleteDetections', {}).get('ids', []),
-                saved_query_names=res.data.get('deleteDetections', {}).get('saved_query_names', [])
+                saved_query_names=res.data.get('deleteDetections', {}).get('savedQueryNames', [])
             )
         )
 

--- a/panther_analysis_tool/cmd/bulk_delete.py
+++ b/panther_analysis_tool/cmd/bulk_delete.py
@@ -98,7 +98,7 @@ def _delete_detections_dry_run(backend: BackendClient, ids: List[str]) -> Tuple[
 
     for detection_id in ids:
         if detection_id in found_ids:
-            logging.info("Detection '%s' will be delreted", detection_id)
+            logging.info("Detection '%s' will be deleted", detection_id)
         else:
             logging.info("Detection '%s' was not found.", detection_id)
 

--- a/panther_analysis_tool/cmd/bulk_delete.py
+++ b/panther_analysis_tool/cmd/bulk_delete.py
@@ -98,7 +98,7 @@ def _delete_detections_dry_run(backend: BackendClient, ids: List[str]) -> Tuple[
 
     for detection_id in ids:
         if detection_id in found_ids:
-            logging.info("Detection '%s' will be deleted", detection_id)
+            logging.info("Detection '%s' will be delreted", detection_id)
         else:
             logging.info("Detection '%s' was not found.", detection_id)
 


### PR DESCRIPTION
### Background

Was parsing incorrect field from GraphQL response

### Changes

* parse correct field from GraphQL response body

