### PR TITLE
Add bulk upload for Config-SDK-based analysis modules

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ integration:
 	cd panther-analysis && pipenv lock
 	cd panther-analysis && pipenv requirements | grep -v 'panther-analysis-tool==' > requirements.ci.txt
 	cd panther-analysis && pipenv install -r requirements.ci.txt
+	cd panther-analysis && pipenv install -e ..
 	cd panther-analysis && pipenv run panther_analysis_tool --version && pipenv run panther_analysis_tool test --path .
 
 pypi:

--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,7 @@ integration:
 	cd panther-analysis && pipenv install -r requirements.ci.txt
 	cd panther-analysis && pipenv install -e ..
 	cd panther-analysis && pipenv run panther_analysis_tool --version && pipenv run panther_analysis_tool test --path .
+	rm -rf panther-analysis
 
 pypi:
 	pipenv run python3 setup.py sdist

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,8 @@ integration:
 	pipenv run panther_analysis_tool test --path tests/fixtures/detections/valid_analysis
 	rm -rf panther-analysis
 	git clone https://github.com/panther-labs/panther-analysis.git
-	cd panther-analysis && pipenv lock -r  | grep -v 'panther-analysis-tool==' > requirements.ci.txt
+	cd panther-analysis && pipenv lock
+	cd panther-analysis && pipenv requirements | grep -v 'panther-analysis-tool==' > requirements.ci.txt
 	cd panther-analysis && pipenv install -r requirements.ci.txt
 	cd panther-analysis && pipenv run panther_analysis_tool --version && pipenv run panther_analysis_tool test --path .
 

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -142,6 +142,8 @@ class ConfigSDKBulkUploadParams:
 @dataclass(frozen=True)
 class ConfigSDKBulkUploadResponse:
     rules: BulkUploadStatistics
+    policies: BulkUploadStatistics
+    queries: BulkUploadStatistics
 
 
 class Client(ABC):

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -127,6 +127,17 @@ class ListManagedSchemasResponse:
 class UpdateManagedSchemaResponse:
     schema: ManagedSchema
 
+
+@dataclass(frozen=True)
+class ConfigSDKBulkUploadParams:
+    content: str
+
+
+@dataclass(frozen=True)
+class ConfigSDKBulkUploadResponse:
+    queries: BulkUploadStatistics
+
+
 class Client(ABC):
 
     @abstractmethod
@@ -151,4 +162,8 @@ class Client(ABC):
 
     @abstractmethod
     def update_managed_schema(self, params: UpdateManagedSchemaParams) -> BackendResponse[Any]:
+        pass
+
+    @abstractmethod
+    def configsdk_bulk_upload(self, params: ConfigSDKBulkUploadParams) -> BackendResponse[ConfigSDKBulkUploadResponse]:
         pass

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -68,9 +68,11 @@ class DeleteDetectionsParams:
     dry_run: bool
     include_saved_queries: bool
 
+
 @dataclass(frozen=True)
 class ListSchemasParams:
     is_managed: bool
+
 
 @dataclass(frozen=True)
 class UpdateManagedSchemaParams:
@@ -79,6 +81,7 @@ class UpdateManagedSchemaParams:
     reference_url: str
     revision: int
     spec: str
+
 
 @dataclass(frozen=True)
 class BulkUploadStatistics:
@@ -107,6 +110,7 @@ class DeleteDetectionsResponse:
     ids: List[str]
     saved_query_names: List[str]
 
+
 # pylint: disable=too-many-instance-attributes
 @dataclass(frozen=True)
 class ManagedSchema:
@@ -119,9 +123,11 @@ class ManagedSchema:
     spec: str
     updated_at: str
 
+
 @dataclass(frozen=True)
 class ListManagedSchemasResponse:
     schemas: List[ManagedSchema]
+
 
 @dataclass(frozen=True)
 class UpdateManagedSchemaResponse:

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -141,7 +141,7 @@ class ConfigSDKBulkUploadParams:
 
 @dataclass(frozen=True)
 class ConfigSDKBulkUploadResponse:
-    queries: BulkUploadStatistics
+    rules: BulkUploadStatistics
 
 
 class Client(ABC):

--- a/panther_analysis_tool/backend/graphql/sdk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/sdk_upload.graphql
@@ -5,5 +5,15 @@ mutation SDKUpload($input: UploadDetectionEntitiesInput!) {
             new
             total
         }
+        policies {
+            modified
+            new
+            total
+        }
+        queries {
+            modified
+            new
+            total
+        }
     }
 }

--- a/panther_analysis_tool/backend/graphql/sdk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/sdk_upload.graphql
@@ -1,0 +1,9 @@
+mutation SDKUpload($input: SDKUploadInput!) {
+    uploadDetectionEntities(input: $input) {
+        queries {
+            modified
+            new
+            total
+        }
+    }
+}

--- a/panther_analysis_tool/backend/graphql/sdk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/sdk_upload.graphql
@@ -1,4 +1,4 @@
-mutation SDKUpload($input: SDKUploadInput!) {
+mutation SDKUpload($input: UploadDetectionEntitiesInput!) {
     uploadDetectionEntities(input: $input) {
         queries {
             modified

--- a/panther_analysis_tool/backend/graphql/sdk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/sdk_upload.graphql
@@ -1,6 +1,6 @@
 mutation SDKUpload($input: UploadDetectionEntitiesInput!) {
     uploadDetectionEntities(input: $input) {
-        queries {
+        rules {
             modified
             new
             total

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -39,7 +39,7 @@ from .client import (
     DeleteSavedQueriesParams,
     DeleteSavedQueriesResponse,
     ListManagedSchemasResponse, ListSchemasParams, ManagedSchema, UpdateManagedSchemaParams,
-    UpdateManagedSchemaResponse,
+    UpdateManagedSchemaResponse, ConfigSDKBulkUploadParams, ConfigSDKBulkUploadResponse,
 )
 
 
@@ -227,6 +227,9 @@ class LambdaClient(Client):
                 )
             )
         )
+
+    def configsdk_bulk_upload(self, params: ConfigSDKBulkUploadParams) -> BackendResponse[ConfigSDKBulkUploadResponse]:
+        raise NotImplementedError("Lambda API client does not support ConfigSDK bulk upload")
 
     @staticmethod
     def _serialize_request(data: Dict[str, Any]) -> str:

--- a/panther_analysis_tool/backend/mocks.py
+++ b/panther_analysis_tool/backend/mocks.py
@@ -8,7 +8,9 @@ from panther_analysis_tool.backend.client import (
     BackendCheckResponse,
     DeleteDetectionsParams,
     DeleteSavedQueriesParams,
-    ListSchemasParams, UpdateManagedSchemaParams,
+    ListSchemasParams,
+    UpdateManagedSchemaParams,
+    ConfigSDKBulkUploadParams,
 )
 
 
@@ -29,4 +31,7 @@ class MockBackend(BackendClient):
         pass
 
     def delete_detections(self, params: DeleteDetectionsParams) -> BackendResponse[Any]:
+        pass
+
+    def configsdk_bulk_upload(self, params: ConfigSDKBulkUploadParams) -> BackendResponse[Any]:
         pass

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -293,14 +293,14 @@ class PublicAPIClient(Client):
         if res.data is None:
             raise BackendError("empty data")
 
-        queries = res.data.get('queries', {})
+        rule_upload_stats = res.data.get('uploadDetectionEntities', {}).get('rules', {})
         return BackendResponse(
             status_code=200,
             data=ConfigSDKBulkUploadResponse(
-                queries=BulkUploadStatistics(
-                    modified=queries.get("modified"),
-                    new=queries.get("new"),
-                    total=queries.get("total")
+                rules=BulkUploadStatistics(
+                    modified=rule_upload_stats.get("modified"),
+                    new=rule_upload_stats.get("new"),
+                    total=rule_upload_stats.get("total")
                 )
             )
         )

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -294,6 +294,8 @@ class PublicAPIClient(Client):
             raise BackendError("empty data")
 
         rule_upload_stats = res.data.get('uploadDetectionEntities', {}).get('rules', {})
+        policy_upload_stats = res.data.get('uploadDetectionEntities', {}).get('policies', {})
+        query_upload_stats = res.data.get('uploadDetectionEntities', {}).get('queries', {})
         return BackendResponse(
             status_code=200,
             data=ConfigSDKBulkUploadResponse(
@@ -301,6 +303,16 @@ class PublicAPIClient(Client):
                     modified=rule_upload_stats.get("modified"),
                     new=rule_upload_stats.get("new"),
                     total=rule_upload_stats.get("total")
+                ),
+                policies=BulkUploadStatistics(
+                    modified=policy_upload_stats.get("modified"),
+                    new=policy_upload_stats.get("new"),
+                    total=policy_upload_stats.get("total")
+                ),
+                queries=BulkUploadStatistics(
+                    modified=query_upload_stats.get("modified"),
+                    new=query_upload_stats.get("new"),
+                    total=query_upload_stats.get("total")
                 )
             )
         )

--- a/panther_analysis_tool/cmd/configsdk_upload.py
+++ b/panther_analysis_tool/cmd/configsdk_upload.py
@@ -4,8 +4,8 @@ import os
 import runpy
 from typing import Final
 
-from panther_analysis_tool.backend.client import Client as BackendClient, ConfigSDKBulkUploadParams, \
-    BackendError
+from panther_analysis_tool.backend.client import Client as BackendClient, \
+    ConfigSDKBulkUploadParams, BackendError
 
 
 def run(
@@ -56,18 +56,23 @@ def run(
     runpy.run_path("panther_content")
 
     if not os.path.exists(panther_config_cache_path):
-        logging.error(f"panther_content did not generate {panther_config_cache_path}")
+        logging.error("panther_content did not generate %s", panther_config_cache_path)
         return 1
 
-    with open(panther_config_cache_path) as f:
+    with open(panther_config_cache_path) as config_cache_file:
         try:
             result = backend.configsdk_bulk_upload(params=ConfigSDKBulkUploadParams(
-                content=f.read()
+                content=config_cache_file.read()
             ))
         except BackendError as exc:
             logging.error(exc)
             return 1
 
-    logging.info(f"Config SDK module upload succeeded ({result.data.queries.new} new; "
-                 f"{result.data.queries.modified} modified; "
-                 f"{result.data.queries.total} total)")
+    logging.info(
+        "Config SDK module upload succeeded (%d new; %d modified; %d total)",
+        result.data.queries.new,
+        result.data.queries.modified,
+        result.data.queries.total,
+    )
+
+    return 0

--- a/panther_analysis_tool/cmd/configsdk_upload.py
+++ b/panther_analysis_tool/cmd/configsdk_upload.py
@@ -1,0 +1,73 @@
+import argparse
+import logging
+import os
+import runpy
+from typing import Final
+
+from panther_analysis_tool.backend.client import Client as BackendClient, ConfigSDKBulkUploadParams, \
+    BackendError
+
+
+def run(
+        backend: BackendClient,
+        args: argparse.Namespace,
+        indirect_invocation: bool = False
+) -> int:
+    """Packages and uploads all policies and rules from the Config SDK-based module at
+    ./panther_content, if it exists, into a Panther deployment.
+
+        Returns 1 if the packaging or upload fails.
+
+        Args:
+            backend: Backend API client.
+            args: The populated Argparse namespace with parsed command-line arguments.
+            indirect_invocation: True if this function is being invoked as part of
+                                 another command (probably the legacy bulk upload command)
+
+        Returns:
+            Return code
+        """
+
+    if not os.path.exists(os.path.join("panther_content", "__main__.py")):
+        err_message = "Did not find a Config SDK based module at ./panther_content"
+        if indirect_invocation:
+            # If this is run automatically at the end of the standard upload command,
+            # this isn't an error that should cause the invocation to return 1.
+            logging.debug(err_message)
+            return 0
+        logging.error(err_message)
+        return 1
+
+    if not args.api_token:
+        logging.error("Config SDK based uploads are only possible using the public API")
+        return 1
+
+    if args.out or args.path or args.ignore_files or args.filter or args.filter_inverted:
+        logging.warning("configsdk upload subcommand does not support args, including: "
+                        "filter, filter_inverted, ignore_files, out, path")
+
+    panther_config_cache_path: Final = os.path.join(".panther", "panther-config-cache")
+
+    try:
+        os.remove(panther_config_cache_path)
+    except FileNotFoundError:
+        pass
+
+    runpy.run_path("panther_content")
+
+    if not os.path.exists(panther_config_cache_path):
+        logging.error(f"panther_content did not generate {panther_config_cache_path}")
+        return 1
+
+    with open(panther_config_cache_path) as f:
+        try:
+            result = backend.configsdk_bulk_upload(params=ConfigSDKBulkUploadParams(
+                content=f.read()
+            ))
+        except BackendError as exc:
+            logging.error(exc)
+            return 1
+
+    logging.info(f"Config SDK module upload succeeded ({result.data.queries.new} new; "
+                 f"{result.data.queries.modified} modified; "
+                 f"{result.data.queries.total} total)")

--- a/panther_analysis_tool/cmd/configsdk_upload.py
+++ b/panther_analysis_tool/cmd/configsdk_upload.py
@@ -68,11 +68,12 @@ def run(
             logging.error(exc)
             return 1
 
+    logging.info("Config SDK module upload succeeded")
     logging.info(
-        "Config SDK module upload succeeded (%d new; %d modified; %d total)",
-        result.data.queries.new,
-        result.data.queries.modified,
-        result.data.queries.total,
+        "(Rules: %d new; %d modified; %d total)",
+        result.data.rules.new,
+        result.data.rules.modified,
+        result.data.rules.total,
     )
 
     return 0

--- a/panther_analysis_tool/cmd/configsdk_upload.py
+++ b/panther_analysis_tool/cmd/configsdk_upload.py
@@ -3,6 +3,7 @@ import logging
 import os
 import runpy
 from typing import Final
+import sys
 
 from panther_analysis_tool.backend.client import Client as BackendClient, \
     ConfigSDKBulkUploadParams, BackendError
@@ -53,7 +54,12 @@ def run(
     except FileNotFoundError:
         pass
 
-    runpy.run_path("panther_content")
+    path_had_cwd = os.getcwd() in sys.path
+    if not path_had_cwd:
+        sys.path.append(os.getcwd())
+    runpy.run_module("panther_content")
+    if not path_had_cwd:
+        sys.path.remove(os.getcwd())
 
     if not os.path.exists(panther_config_cache_path):
         logging.error("panther_content did not generate %s", panther_config_cache_path)

--- a/panther_analysis_tool/cmd/configsdk_upload.py
+++ b/panther_analysis_tool/cmd/configsdk_upload.py
@@ -77,5 +77,17 @@ def run(
         result.data.rules.modified,
         result.data.rules.total,
     )
+    logging.info(
+        "(Policies: %d new; %d modified; %d total)",
+        result.data.policies.new,
+        result.data.policies.modified,
+        result.data.policies.total,
+    )
+    logging.info(
+        "(Queries: %d new; %d modified; %d total)",
+        result.data.queries.new,
+        result.data.queries.modified,
+        result.data.queries.total,
+    )
 
     return 0, ""

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -100,7 +100,8 @@ from panther_analysis_tool.util import get_client, func_with_backend
 from panther_analysis_tool.cmd import (
     bulk_delete,
     standard_args,
-    check_connection
+    check_connection,
+    configsdk_upload
 )
 
 CONFIG_FILE = ".panther_settings.yml"
@@ -1659,6 +1660,20 @@ def setup_parser() -> argparse.ArgumentParser:
     standard_args.for_public_api(check_conn_parser, required=False)
 
     check_conn_parser.set_defaults(func=func_with_backend(check_connection.run))
+
+    # -- configsdk command
+
+    configsdk_parser = subparsers.add_parser(
+        "configsdk", help="Perform operations using the new Config SDK exclusively "
+                          "(pass configsdk --help for more)"
+    )
+    standard_args.for_public_api(configsdk_parser, required=True)
+    configsdk_subparsers = configsdk_parser.add_subparsers()
+
+    configsdk_upload_parser = configsdk_subparsers.add_parser(
+        "upload", help="Upload policies and rules from the ./panther_content module"
+    )
+    configsdk_upload_parser.set_defaults(func=func_with_backend(configsdk_upload.run))
 
     return parser
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -444,7 +444,7 @@ def upload_analysis(backend: BackendClient, args: argparse.Namespace) -> Tuple[i
     if return_code != 0:
         return return_code, return_archive_fname
 
-    return_code = configsdk_upload.run(backend=backend, args=args, indirect_invocation=True)
+    return_code, _ = configsdk_upload.run(backend=backend, args=args, indirect_invocation=True)
 
     return return_code, return_archive_fname
 


### PR DESCRIPTION
### Background

This PR implements bulk upload for Config-SDK-based analysis modules. This function is accessible via the `configsdk upload` subcommand, also also runs at the end of the normal `upload` subcommand.

### Changes

* Initial implemention of the `configsdk upload` command
* Run `configsdk upload` automatically after the normal `upload` process if a `panther_content/__main__.py` file is detected

### Caveats

This initial implementation comes with a few caveats:

* We look at `CWD/panther_content/__main__.py` to discover the user's Config-DK-based analysis module. Other paths are not supported.
* The lambda-based API doesn't currently support this feature, so this new function only supports usage via the public API via API token.

### Testing

* [X] Was able to successfully upload our test Config SDK rules repo to staging via `panther_analysis_tool configsdk --api-token XXX --api-host "YYY" upload`, as long as `panther_analysis_tool` is installed in the Config SDK content's virtualenv
