### PR TITLE
CI: don't run `make integration` target twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,4 +20,4 @@ jobs:
             command: pipenv run -- pip3 install -e .
         - run:
             name: CLI Tests
-            command: make ci && make integration
+            command: make ci


### PR DESCRIPTION
### Background

Our `make ci` target [already runs the `integration` target](https://github.com/panther-labs/panther_analysis_tool/blob/master/Makefile#L3), so running the `integration` target again via CircleCI just results in running the same target twice.

You can confirm that by searching the full output from [the successful CI run on my last PR](https://app.circleci.com/pipelines/github/panther-labs/panther_analysis_tool/1091/workflows/da316e1c-6dfe-485a-be77-1cbaa683b81f/jobs/1052) for the string `Testing analysis items in tests/fixtures/detections/valid_analysis`, which occurs twice.

### Changes

* CircleCI config does not explicitly run `make integration`

### Testing

* Look at CI output and verify `make integration` target is run once
