### PR TITLE
update naming

### DIFF
--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -229,7 +229,7 @@ class LambdaClient(Client):
         )
 
     def configsdk_bulk_upload(self, params: ConfigSDKBulkUploadParams) -> BackendResponse[ConfigSDKBulkUploadResponse]:
-        raise NotImplementedError("Lambda API client does not support ConfigSDK bulk upload")
+        raise NotImplementedError("Lambda API client does not support bulk upload of panther_config content")
 
     @staticmethod
     def _serialize_request(data: Dict[str, Any]) -> str:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1676,11 +1676,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     check_conn_parser.set_defaults(func=func_with_backend(check_connection.run))
 
-    # -- configsdk command
+    # -- config command
 
     configsdk_parser = subparsers.add_parser(
-        "configsdk", help="Perform operations using the new Config SDK exclusively "
-                          "(pass configsdk --help for more)"
+        "config", help="Perform operations using the new Config SDK exclusively "
+                          "(pass config --help for more)"
     )
     standard_args.for_public_api(configsdk_parser, required=True)
     configsdk_subparsers = configsdk_parser.add_subparsers()


### PR DESCRIPTION
Semantic updates to keep user facing terminology consistent.

- updates the `panther_config`-only bulk upload command from `pat configsdk upload` to `pat config upload`
- updates the error message to use "panther_config content" instead of "ConfigSDK"