### PR TITLE
[config sdk] adds support for direct lambda invocations.

### DIFF
--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -28,7 +28,6 @@ ResponseData = TypeVar('ResponseData')
 class BackendError(Exception):
     pass
 
-
 @dataclass(frozen=True)
 class BulkUploadPayload:
     data:    bytes

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -16,10 +16,11 @@ GNU Affero General Public License for more details.
 You should have received a copy of the GNU Affero General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
-
+import base64
 import os
 import json
 import logging
+import typing
 
 from typing import Dict, Any, Optional
 from dataclasses import dataclass
@@ -42,21 +43,27 @@ from .client import (
     UpdateManagedSchemaResponse, ConfigSDKBulkUploadParams, ConfigSDKBulkUploadResponse,
 )
 
-
 LAMBDA_CLIENT_NAME = "lambda"
 AWS_PROFILE_ENV_KEY = "AWS_PROFILE"
 
 
+def decode_body(res: BackendResponse) -> typing.Any:
+    try:
+        return json.loads(res.data['body'])
+    except json.decoder.JSONDecodeError as decode_error:
+        raise Exception(res.data['body']) from decode_error
+
+
 @dataclass(frozen=True)
 class LambdaClientOpts:
-    user_id:         str
-    aws_profile:     Optional[str]
+    user_id: str
+    aws_profile: Optional[str]
     datalake_lambda: str
 
 
 class LambdaClient(Client):
-    _user_id:         str
-    _lambda_client:   boto3.client
+    _user_id: str
+    _lambda_client: boto3.client
     _datalake_lambda: str
 
     def __init__(self, opts: LambdaClientOpts):
@@ -92,7 +99,7 @@ class LambdaClient(Client):
             }),
         ))
 
-        body = json.loads(res.data['body'])
+        body = decode_body(res)
 
         default_stats = dict(total=0, new=0, modified=0)
 
@@ -126,7 +133,7 @@ class LambdaClient(Client):
             }),
         ))
 
-        body = json.loads(res.data['body'])
+        body = decode_body(res)
 
         return BackendResponse(
             status_code=res.status_code,
@@ -151,7 +158,7 @@ class LambdaClient(Client):
             }),
         ))
 
-        body = json.loads(res.data['body'])
+        body = decode_body(res)
 
         return BackendResponse(
             status_code=res.status_code,
@@ -188,11 +195,11 @@ class LambdaClient(Client):
             ))
 
         return BackendResponse(
-                status_code=200,
-                data=ListManagedSchemasResponse(
-                    schemas=schemas
-                )
+            status_code=200,
+            data=ListManagedSchemasResponse(
+                schemas=schemas
             )
+        )
 
     def update_managed_schema(self, params: UpdateManagedSchemaParams) -> BackendResponse:
         res = self._parse_response(self._lambda_client.invoke(
@@ -211,7 +218,7 @@ class LambdaClient(Client):
         if res.data.get("error") is not None:
             raise BackendError(res.data.get("error"))
 
-        schema=res.data.get('result', {})
+        schema = res.data.get('result', {})
         return BackendResponse(
             status_code=200,
             data=UpdateManagedSchemaResponse(
@@ -229,7 +236,28 @@ class LambdaClient(Client):
         )
 
     def configsdk_bulk_upload(self, params: ConfigSDKBulkUploadParams) -> BackendResponse[ConfigSDKBulkUploadResponse]:
-        raise NotImplementedError("Lambda API client does not support bulk upload of panther_config content")
+        res = self._parse_response(self._lambda_client.invoke(
+            FunctionName="panther-analysis-api",
+            InvocationType="RequestResponse",
+            LogType="None",
+            Payload=self._serialize_request({
+                "sdkUpload": {
+                    "data": base64.b64encode(params.content.encode('utf-8')).decode('utf-8'),
+                    "userId": self._user_id,
+                },
+            }),
+        ))
+        body = decode_body(res)
+        default_stats = dict(total=0, new=0, modified=0)
+
+        return BackendResponse(
+            status_code=res.status_code,
+            data=ConfigSDKBulkUploadResponse(
+                rules=BulkUploadStatistics(**body.get('rules', default_stats)),
+                policies=BulkUploadStatistics(**body.get('policies', default_stats)),
+                queries=BulkUploadStatistics(**body.get('queries', default_stats)),
+            )
+        )
 
     @staticmethod
     def _serialize_request(data: Dict[str, Any]) -> str:

--- a/panther_analysis_tool/cmd/configsdk_upload.py
+++ b/panther_analysis_tool/cmd/configsdk_upload.py
@@ -11,7 +11,7 @@ from panther_analysis_tool.backend.client import Client as BackendClient, \
 
 def run(
         backend: BackendClient,
-        args: argparse.Namespace,
+        args: argparse.Namespace,  # pylint: disable=unused-argument
         indirect_invocation: bool = False
 ) -> Tuple[int, str]:
     """Packages and uploads all policies and rules from the Config SDK-based module at
@@ -37,10 +37,6 @@ def run(
             logging.debug(err_message)
             return 0, ""
         logging.error(err_message)
-        return 1, ""
-
-    if not args.api_token:
-        logging.error("Config SDK based uploads are only possible using the public API")
         return 1, ""
 
     panther_config_cache_path: Final = os.path.join(".panther", "panther-config-cache")

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1682,7 +1682,8 @@ def setup_parser() -> argparse.ArgumentParser:
         "config", help="Perform operations using the new Config SDK exclusively "
                           "(pass config --help for more)"
     )
-    standard_args.for_public_api(configsdk_parser, required=True)
+    standard_args.for_public_api(configsdk_parser, required=False)
+    standard_args.using_aws_profile(configsdk_parser)
     configsdk_subparsers = configsdk_parser.add_subparsers()
 
     configsdk_upload_parser = configsdk_subparsers.add_parser(


### PR DESCRIPTION
### Background

Config sdk uploads only work with the public-api this adds support for direct lambda invocations. 


### Changes

* updates lambda client to support config uploads
* updates lambda client to handle json decode better ... just presents the response to the user now .. which will be way more actionable than a cryptic json exception message we were showing before
* adds aws-profile arg to the config upload command
* removes checks around config-sdk that forced api only usage

### Testing

* manual uploads
* unit tests
