### PR TITLE
Path specification fix for PAT tool

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -351,7 +351,7 @@ def zip_analysis(args: argparse.Namespace) -> Tuple[int, str]:
         files: Set[str] = set()
         for (file_name, f_path, spec, _) in list(
                 load_analysis_specs(
-                    [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION, LUTS_LOCATION], args.ignore_files
+                    [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION], args.ignore_files
                 )
         ):
             if file_name not in files:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1479,7 +1479,7 @@ def setup_parser() -> argparse.ArgumentParser:
                     + "managing Panther policies and rules.",
         prog="panther_analysis_tool",
     )
-    parser.add_argument("--version", action="version", version="panther_analysis_tool 0.16.1")
+    parser.add_argument("--version", action="version", version="panther_analysis_tool 0.16.2")
     parser.add_argument("--debug", action="store_true", dest="debug")
     subparsers = parser.add_subparsers()
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='panther_analysis_tool',
-    version='0.16.1',
+    version='0.16.2',
     packages=find_packages(),
     license='AGPL-3.0',
     description=
@@ -33,7 +33,7 @@ setup(
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url='https://github.com/panther-labs/panther_analysis_tool/archive/v0.16.1.tar.gz',
+    download_url='https://github.com/panther-labs/panther_analysis_tool/archive/v0.16.2.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=install_requires,


### PR DESCRIPTION
### Background

https://app.asana.com/0/1200908948600035/1202486395033678/f

### Changes

* Remove LUTS_LOCATION option when zipping file

### Testing

* Specifying path - selects only the files in that path 
* Specifying all - includes all files 
* Specifying luts - includes only luts file path
