### PR TITLE
Do not always include LUTS

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -794,8 +794,6 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
             "." + HELPERS_LOCATION,
             DATA_MODEL_LOCATION,
             "." + DATA_MODEL_LOCATION,
-            LUTS_LOCATION,
-            "." + LUTS_LOCATION,
     ):
         absolute_dir_path = os.path.abspath(os.path.join(args.path, directory))
         absolute_helper_path = os.path.abspath(directory)
@@ -1087,10 +1085,6 @@ def filter_analysis(
             continue
         if fnmatch(dir_name, DATA_MODEL_PATH_PATTERN):
             logging.debug("auto-adding data model file %s", os.path.join(file_name))
-            filtered_analysis.append((file_name, dir_name, analysis_spec))
-            continue
-        if fnmatch(dir_name, LUTS_PATH_PATTERN):
-            logging.debug("auto-adding lookup table file %s", os.path.join(file_name))
             filtered_analysis.append((file_name, dir_name, analysis_spec))
             continue
         match = True

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1473,7 +1473,7 @@ def setup_parser() -> argparse.ArgumentParser:
                     + "managing Panther policies and rules.",
         prog="panther_analysis_tool",
     )
-    parser.add_argument("--version", action="version", version="panther_analysis_tool 0.16.2")
+    parser.add_argument("--version", action="version", version="panther_analysis_tool 0.16.3")
     parser.add_argument("--debug", action="store_true", dest="debug")
     subparsers = parser.add_subparsers()
 

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setup(
     name='panther_analysis_tool',
-    version='0.16.2',
+    version='0.16.3',
     packages=find_packages(),
     license='AGPL-3.0',
     description=
@@ -33,7 +33,7 @@ setup(
     author='Panther Labs Inc',
     author_email='pypi@runpanther.io',
     url='https://github.com/panther-labs/panther_analysis_tool',
-    download_url='https://github.com/panther-labs/panther_analysis_tool/archive/v0.16.2.tar.gz',
+    download_url='https://github.com/panther-labs/panther_analysis_tool/archive/v0.16.3.tar.gz',
     keywords=['Security', 'CLI'],
     scripts=['bin/panther_analysis_tool'],
     install_requires=install_requires,


### PR DESCRIPTION
LUTS are never excluded by filters, so setting a filter like `--filter AnalysisType=policy,rule` will still include LUTS. Also, the LUTS file paths are always included as part of `search_directories` in `test_analysis`.

This change removes them from the list of always included paths for `test_analysis` and prevents filter_analysis from always returning `True` when dir_name matches `*lookup_tables*`