### PR TITLE
adds upload chunking support via the --batch parameter

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -2,14 +2,21 @@ import json
 import logging
 import os
 from fnmatch import fnmatch
-from typing import List, Iterator, Tuple, Any, Dict
+from typing import Any, Dict, Iterator, List, Tuple
 
 from ruamel.yaml import YAML
 from ruamel.yaml import parser as YAMLParser
 from ruamel.yaml import scanner as YAMLScanner
 
-from panther_analysis_tool.constants import DATA_MODEL_PATH_PATTERN, HELPERS_PATH_PATTERN, LUTS_PATH_PATTERN, \
-    PACKS_PATH_PATTERN, POLICIES_PATH_PATTERN, RULES_PATH_PATTERN, QUERIES_PATH_PATTERN
+from panther_analysis_tool.constants import (
+    DATA_MODEL_PATH_PATTERN,
+    HELPERS_PATH_PATTERN,
+    LUTS_PATH_PATTERN,
+    PACKS_PATH_PATTERN,
+    POLICIES_PATH_PATTERN,
+    QUERIES_PATH_PATTERN,
+    RULES_PATH_PATTERN,
+)
 
 
 def filter_analysis(
@@ -46,6 +53,7 @@ def filter_analysis(
             filtered_analysis.append((file_name, dir_name, analysis_spec))
 
     return filtered_analysis
+
 
 def load_analysis_specs(
     directories: List[str], ignore_files: List[str]

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -126,3 +126,8 @@ def load_analysis_specs(
                             yield spec_filename, relative_path, json.load(spec_file_obj), None
                         except ValueError as err:
                             yield spec_filename, relative_path, None, err
+
+
+def to_relative_path(filename: str) -> str:
+    cwd = os.getcwd()
+    return os.path.relpath(filename, cwd)

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -1,0 +1,128 @@
+import json
+import logging
+import os
+from fnmatch import fnmatch
+from typing import List, Iterator, Tuple, Any, Dict
+
+from ruamel.yaml import YAML
+from ruamel.yaml import parser as YAMLParser
+from ruamel.yaml import scanner as YAMLScanner
+
+from panther_analysis_tool.constants import DATA_MODEL_PATH_PATTERN, HELPERS_PATH_PATTERN, LUTS_PATH_PATTERN, \
+    PACKS_PATH_PATTERN, POLICIES_PATH_PATTERN, RULES_PATH_PATTERN, QUERIES_PATH_PATTERN
+
+
+def filter_analysis(
+    analysis: List[Any], filters: Dict[str, List], filters_inverted: Dict[str, List]
+) -> List[Any]:
+    if filters is None:
+        return analysis
+
+    filtered_analysis = []
+    for file_name, dir_name, analysis_spec in analysis:
+        if fnmatch(dir_name, HELPERS_PATH_PATTERN):
+            logging.debug("auto-adding helpers file %s", os.path.join(file_name))
+            filtered_analysis.append((file_name, dir_name, analysis_spec))
+            continue
+        if fnmatch(dir_name, DATA_MODEL_PATH_PATTERN):
+            logging.debug("auto-adding data model file %s", os.path.join(file_name))
+            filtered_analysis.append((file_name, dir_name, analysis_spec))
+            continue
+        match = True
+        for key, values in filters.items():
+            spec_value = analysis_spec.get(key, "")
+            spec_value = spec_value if isinstance(spec_value, list) else [spec_value]
+            if not set(spec_value).intersection(values):
+                match = False
+                break
+        for key, values in filters_inverted.items():
+            spec_value = analysis_spec.get(key, "")
+            spec_value = spec_value if isinstance(spec_value, list) else [spec_value]
+            if set(spec_value).intersection(values):
+                match = False
+                break
+
+        if match:
+            filtered_analysis.append((file_name, dir_name, analysis_spec))
+
+    return filtered_analysis
+
+def load_analysis_specs(
+    directories: List[str], ignore_files: List[str]
+) -> Iterator[Tuple[str, str, Any, Any]]:
+    """Loads the analysis specifications from a file.
+
+    Args:
+        directories: The relative path to Panther policies or rules.
+        ignore_files: Files that Panther Analysis Tool should not process
+
+    Yields:
+        A tuple of the relative filepath, directory name, and loaded analysis specification dict.
+    """
+    # setup a list of paths to ensure we do not import the same files
+    # multiple times, which can happen when testing from root directory without filters
+    ignored_normalized = []
+    for file in ignore_files:
+        ignored_normalized.append(os.path.normpath(file))
+
+    loaded_specs: List[Any] = []
+    for directory in directories:
+        for relative_path, _, file_list in os.walk(directory):
+            # Skip hidden folders
+            if (
+                relative_path.split("/")[-1].startswith(".")
+                and relative_path != "./"
+                and relative_path != "."
+            ):
+                continue
+            # setup yaml object
+            yaml = YAML(typ="safe")
+            # If the user runs with no path args, filter to make sure
+            # we only run folders with valid analysis files. Ensure we test
+            # files in the current directory by not skipping this iteration
+            # when relative_path is the current dir
+            if directory in [".", "./"] and relative_path not in [".", "./"]:
+                if not any(
+                    (
+                        fnmatch(relative_path, path_pattern)
+                        for path_pattern in (
+                            DATA_MODEL_PATH_PATTERN,
+                            HELPERS_PATH_PATTERN,
+                            LUTS_PATH_PATTERN,
+                            RULES_PATH_PATTERN,
+                            PACKS_PATH_PATTERN,
+                            POLICIES_PATH_PATTERN,
+                            QUERIES_PATH_PATTERN,
+                        )
+                    )
+                ):
+                    logging.debug("Skipping path %s", relative_path)
+                    continue
+            for filename in sorted(file_list):
+                # Skip hidden files
+                if filename.startswith("."):
+                    continue
+                spec_filename = os.path.abspath(os.path.join(relative_path, filename))
+                # skip loading files that have already been imported
+                if spec_filename in loaded_specs:
+                    continue
+                # Dont load files that are explictly ignored
+                relative_name = os.path.normpath(os.path.join(relative_path, filename))
+                if relative_name in ignored_normalized:
+                    logging.info("ignoring file %s", relative_name)
+                    continue
+                loaded_specs.append(spec_filename)
+                if fnmatch(filename, "*.y*ml"):
+                    with open(spec_filename, "r") as spec_file_obj:
+                        try:
+                            yield spec_filename, relative_path, yaml.load(spec_file_obj), None
+                        except (YAMLParser.ParserError, YAMLScanner.ScannerError) as err:
+                            # recreate the yaml object and yield the error
+                            yaml = YAML(typ="safe")
+                            yield spec_filename, relative_path, None, err
+                if fnmatch(filename, "*.json"):
+                    with open(spec_filename, "r") as spec_file_obj:
+                        try:
+                            yield spec_filename, relative_path, json.load(spec_file_obj), None
+                        except ValueError as err:
+                            yield spec_filename, relative_path, None, err

--- a/panther_analysis_tool/constants.py
+++ b/panther_analysis_tool/constants.py
@@ -1,10 +1,8 @@
 import os
 import tempfile
-from typing import Final, Dict
+from typing import Dict, Final
 
-from schema import (
-    Schema,
-)
+from schema import Schema
 
 from panther_analysis_tool.schemas import (
     DATA_MODEL_SCHEMA,

--- a/panther_analysis_tool/constants.py
+++ b/panther_analysis_tool/constants.py
@@ -1,0 +1,75 @@
+import os
+import tempfile
+from typing import Final, Dict
+
+from schema import (
+    Schema,
+)
+
+from panther_analysis_tool.schemas import (
+    DATA_MODEL_SCHEMA,
+    GLOBAL_SCHEMA,
+    LOOKUP_TABLE_SCHEMA,
+    PACK_SCHEMA,
+    POLICY_SCHEMA,
+    RULE_SCHEMA,
+    SCHEDULED_QUERY_SCHEMA,
+)
+
+VERSION_STRING: Final = "panther_analysis_tool 0.18.0"
+
+CONFIG_FILE = ".panther_settings.yml"
+DATA_MODEL_LOCATION = "./data_models"
+HELPERS_LOCATION = "./global_helpers"
+LUTS_LOCATION = "./lookup_tables"
+DATA_MODEL_PATH_PATTERN = "*data_models*"
+LUTS_PATH_PATTERN = "*lookup_tables*"
+HELPERS_PATH_PATTERN = "*/global_helpers"
+PACKS_PATH_PATTERN = "*/packs"
+POLICIES_PATH_PATTERN = "*policies*"
+QUERIES_PATH_PATTERN = "*queries*"
+RULES_PATH_PATTERN = "*rules*"
+TMP_HELPER_MODULE_LOCATION = os.path.join(tempfile.gettempdir(), "panther-path", "globals")
+
+DATAMODEL = "datamodel"
+DETECTION = "detection"
+GLOBAL = "global"
+LOOKUP_TABLE = "lookup_table"
+PACK = "pack"
+POLICY = "policy"
+QUERY = "scheduled_query"
+RULE = "rule"
+SCHEDULED_RULE = "scheduled_rule"
+
+RESERVED_FUNCTIONS = (
+    "alert_context",
+    "dedup",
+    "description",
+    "destinations",
+    "reference",
+    "runbook",
+    "severity",
+    "title",
+)
+
+VALID_SEVERITIES = ["INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"]
+
+SCHEMAS: Dict[str, Schema] = {
+    DATAMODEL: DATA_MODEL_SCHEMA,
+    GLOBAL: GLOBAL_SCHEMA,
+    LOOKUP_TABLE: LOOKUP_TABLE_SCHEMA,
+    PACK: PACK_SCHEMA,
+    POLICY: POLICY_SCHEMA,
+    QUERY: SCHEDULED_QUERY_SCHEMA,
+    RULE: RULE_SCHEMA,
+    SCHEDULED_RULE: RULE_SCHEMA,
+}
+
+SET_FIELDS = [
+    "LogTypes",
+    "PackIDs",
+    "OutputIds",
+    "SummaryAttributes",
+    "Suppressions",
+    "Tags",
+]

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -82,11 +82,10 @@ from panther_analysis_tool.cmd import (
     panthersdk_upload,
     standard_args,
 )
-from panther_analysis_tool.destination import FakeDestination
-from panther_analysis_tool.constants import LOOKUP_TABLE, LUTS_PATH_PATTERN, QUERY, SCHEDULED_RULE, DATAMODEL, RULE, \
-    POLICY, PACK, DATA_MODEL_PATH_PATTERN, HELPERS_PATH_PATTERN, RULES_PATH_PATTERN, POLICIES_PATH_PATTERN, \
-    PACKS_PATH_PATTERN, QUERIES_PATH_PATTERN, DETECTION, GLOBAL, SCHEMAS, HELPERS_LOCATION, DATA_MODEL_LOCATION, \
+from panther_analysis_tool.constants import LOOKUP_TABLE, QUERY, SCHEDULED_RULE, DATAMODEL, RULE, \
+    POLICY, PACK, DETECTION, GLOBAL, SCHEMAS, HELPERS_LOCATION, DATA_MODEL_LOCATION, \
     TMP_HELPER_MODULE_LOCATION, SET_FIELDS, VERSION_STRING, CONFIG_FILE
+from panther_analysis_tool.destination import FakeDestination
 from panther_analysis_tool.log_schemas import user_defined
 from panther_analysis_tool.schemas import TYPE_SCHEMA, GLOBAL_SCHEMA, POLICY_SCHEMA, RULE_SCHEMA, LOOKUP_TABLE_SCHEMA
 from panther_analysis_tool.util import func_with_backend, get_client
@@ -175,20 +174,19 @@ def zip_analysis_chunks(args: argparse.Namespace) -> List[str]:
 
     current_time = datetime.now().isoformat(timespec="seconds").replace(":", "-")
     zip_chunks = [
+        # note: all the files we care about have an AnalysisType field in their yml
+        # so we can ignore file patterns and leave them empty
         ZipChunk(
-            patterns=[
-                DATA_MODEL_PATH_PATTERN, HELPERS_PATH_PATTERN, RULES_PATH_PATTERN,
-                POLICIES_PATH_PATTERN, PACKS_PATH_PATTERN
-            ],
+            patterns=[],
             types=(DATAMODEL, RULE, POLICY, PACK, GLOBAL)  # type: ignore
         ),
         ZipChunk(
-            patterns=[QUERIES_PATH_PATTERN, RULES_PATH_PATTERN],
+            patterns=[],
             types=(QUERY, SCHEDULED_RULE)  # type: ignore
         ),
         ZipChunk(
-            patterns=[LUTS_PATH_PATTERN],
-            types=(LOOKUP_TABLE)  # type: ignore
+            patterns=[],
+            types=LOOKUP_TABLE  # type: ignore
         )
     ]
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -227,7 +227,7 @@ def add_path_to_filename(output_path: str, filename: str) -> str:
                 output_path,
             )
             os.makedirs(output_path)
-        filename = output_path.rstrip("/") + "/" + filename
+        filename = f"{output_path.rstrip('/')}/{filename}"
 
     return filename
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -35,12 +35,13 @@ from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import asdict
 from datetime import datetime
+
 # Comment below disabling pylint checks is due to a bug in the CircleCi image with Pylint
 # It seems to be unable to import the distutils module, however the module is present and importable
 # in the Python Repl.
 from distutils.util import strtobool  # pylint: disable=E0611, E0401
 from importlib.abc import Loader
-from typing import DefaultDict, Type, List, Dict, Any, Tuple
+from typing import Any, DefaultDict, Dict, List, Tuple, Type
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
@@ -72,7 +73,7 @@ from schema import (
     SchemaWrongKeyError,
 )
 
-from panther_analysis_tool.analysis_utils import load_analysis_specs, filter_analysis
+from panther_analysis_tool.analysis_utils import filter_analysis, load_analysis_specs
 from panther_analysis_tool.backend.client import BackendError, BulkUploadParams
 from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.cmd import (
@@ -82,14 +83,35 @@ from panther_analysis_tool.cmd import (
     panthersdk_upload,
     standard_args,
 )
-from panther_analysis_tool.constants import LOOKUP_TABLE, QUERY, SCHEDULED_RULE, DATAMODEL, RULE, \
-    POLICY, PACK, DETECTION, GLOBAL, SCHEMAS, HELPERS_LOCATION, DATA_MODEL_LOCATION, \
-    TMP_HELPER_MODULE_LOCATION, SET_FIELDS, VERSION_STRING, CONFIG_FILE
+from panther_analysis_tool.constants import (
+    CONFIG_FILE,
+    DATA_MODEL_LOCATION,
+    DATAMODEL,
+    DETECTION,
+    GLOBAL,
+    HELPERS_LOCATION,
+    LOOKUP_TABLE,
+    PACK,
+    POLICY,
+    QUERY,
+    RULE,
+    SCHEDULED_RULE,
+    SCHEMAS,
+    SET_FIELDS,
+    TMP_HELPER_MODULE_LOCATION,
+    VERSION_STRING,
+)
 from panther_analysis_tool.destination import FakeDestination
 from panther_analysis_tool.log_schemas import user_defined
-from panther_analysis_tool.schemas import TYPE_SCHEMA, GLOBAL_SCHEMA, POLICY_SCHEMA, RULE_SCHEMA, LOOKUP_TABLE_SCHEMA
+from panther_analysis_tool.schemas import (
+    GLOBAL_SCHEMA,
+    LOOKUP_TABLE_SCHEMA,
+    POLICY_SCHEMA,
+    RULE_SCHEMA,
+    TYPE_SCHEMA,
+)
 from panther_analysis_tool.util import func_with_backend, get_client
-from panther_analysis_tool.zip_chunker import ZipArgs, analysis_chunks, ZipChunk
+from panther_analysis_tool.zip_chunker import ZipArgs, ZipChunk, analysis_chunks
 
 # interpret datetime as str, the backend uses the default behavior for json.loads, which
 # interprets these as str.  This sets global config for ruamel SafeConstructor
@@ -176,18 +198,9 @@ def zip_analysis_chunks(args: argparse.Namespace) -> List[str]:
     zip_chunks = [
         # note: all the files we care about have an AnalysisType field in their yml
         # so we can ignore file patterns and leave them empty
-        ZipChunk(
-            patterns=[],
-            types=(DATAMODEL, RULE, POLICY, PACK, GLOBAL)  # type: ignore
-        ),
-        ZipChunk(
-            patterns=[],
-            types=(QUERY, SCHEDULED_RULE)  # type: ignore
-        ),
-        ZipChunk(
-            patterns=[],
-            types=LOOKUP_TABLE  # type: ignore
-        )
+        ZipChunk(patterns=[], types=(DATAMODEL, RULE, POLICY, PACK, GLOBAL)),  # type: ignore
+        ZipChunk(patterns=[], types=(QUERY, SCHEDULED_RULE)),  # type: ignore
+        ZipChunk(patterns=[], types=LOOKUP_TABLE),  # type: ignore
     ]
 
     filenames = []
@@ -378,12 +391,12 @@ def parse_lookup_table(args: argparse.Namespace) -> dict:
             LOOKUP_TABLE_SCHEMA.validate(lookup_spec)
             logging.info("Successfully validated the Lookup Table file %s", args.path)
         except (
-                schema.SchemaError,
-                schema.SchemaMissingKeyError,
-                schema.SchemaWrongKeyError,
-                schema.SchemaForbiddenKeyError,
-                schema.SchemaUnexpectedTypeError,
-                schema.SchemaOnlyOneAllowedError,
+            schema.SchemaError,
+            schema.SchemaMissingKeyError,
+            schema.SchemaWrongKeyError,
+            schema.SchemaForbiddenKeyError,
+            schema.SchemaUnexpectedTypeError,
+            schema.SchemaOnlyOneAllowedError,
         ) as err:
             logging.error("Invalid schema in the Lookup Table spec file %s", input_file)
             logging.error(err)
@@ -590,7 +603,7 @@ def publish_release(args: argparse.Namespace) -> Tuple[int, str]:
 
 
 def clone_github(
-        owner: str, repo: str, branch: str, path: str, access_token: str
+    owner: str, repo: str, branch: str, path: str, access_token: str
 ) -> Tuple[int, str]:
     repo_url = (
         f"https://{access_token}@github.com/{owner}/{repo}"
@@ -696,10 +709,10 @@ def test_analysis(args: argparse.Namespace) -> Tuple[int, list]:
 
     # Try the parent directory as well
     for directory in (
-            HELPERS_LOCATION,
-            "." + HELPERS_LOCATION,
-            DATA_MODEL_LOCATION,
-            "." + DATA_MODEL_LOCATION,
+        HELPERS_LOCATION,
+        "." + HELPERS_LOCATION,
+        DATA_MODEL_LOCATION,
+        "." + DATA_MODEL_LOCATION,
     ):
         absolute_dir_path = os.path.abspath(os.path.join(args.path, directory))
         absolute_helper_path = os.path.abspath(directory)
@@ -864,12 +877,12 @@ def setup_data_models(data_models: List[Any]) -> Tuple[Dict[str, DataModel], Lis
 
 
 def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
-        log_type_to_data_model: Dict[str, DataModel],
-        analysis: List[Any],
-        minimum_tests: int,
-        skip_disabled_tests: bool,
-        destinations_by_name: Dict[str, FakeDestination],
-        ignore_exception_types: List[Type[Exception]],
+    log_type_to_data_model: Dict[str, DataModel],
+    analysis: List[Any],
+    minimum_tests: int,
+    skip_disabled_tests: bool,
+    destinations_by_name: Dict[str, FakeDestination],
+    ignore_exception_types: List[Type[Exception]],
 ) -> Tuple[DefaultDict[str, List[Any]], List[Any]]:
     invalid_specs = []
     failed_tests: DefaultDict[str, list] = defaultdict(list)
@@ -925,13 +938,13 @@ def validate_packs(analysis_specs: Dict[str, List[Any]]) -> List[Any]:
     for analysis_type in analysis_specs:
         for analysis_spec_filename, _, analysis_spec in analysis_specs[analysis_type]:
             analysis_id = (
-                    analysis_spec.get("PolicyID")
-                    or analysis_spec.get("RuleID")
-                    or analysis_spec.get("DataModelID")
-                    or analysis_spec.get("GlobalID")
-                    or analysis_spec.get("PackID")
-                    or analysis_spec.get("QueryName")
-                    or analysis_spec["LookupName"]
+                analysis_spec.get("PolicyID")
+                or analysis_spec.get("RuleID")
+                or analysis_spec.get("DataModelID")
+                or analysis_spec.get("GlobalID")
+                or analysis_spec.get("PackID")
+                or analysis_spec.get("QueryName")
+                or analysis_spec["LookupName"]
             )
             id_to_detection[analysis_id] = analysis_spec
     for analysis_spec_filename, _, analysis_spec in analysis_specs[PACK]:
@@ -952,7 +965,7 @@ def validate_packs(analysis_specs: Dict[str, List[Any]]) -> List[Any]:
 
 
 def print_summary(
-        test_path: str, num_tests: int, failed_tests: Dict[str, list], invalid_specs: List[Any]
+    test_path: str, num_tests: int, failed_tests: Dict[str, list], invalid_specs: List[Any]
 ) -> None:
     """Print a summary of passed, failed, and invalid specs"""
     print("--------------------------")
@@ -979,7 +992,7 @@ def print_summary(
 
 # pylint: disable=too-many-locals,too-many-statements
 def classify_analysis(
-        specs: List[Tuple[str, str, Any, Any]]
+    specs: List[Tuple[str, str, Any, Any]]
 ) -> Tuple[Dict[str, List[Any]], List[Any]]:
     # First setup return dict containing different
     # types of detections, meta types that can be zipped
@@ -1039,9 +1052,9 @@ def classify_analysis(
         except SchemaWrongKeyError as err:
             invalid_specs.append((analysis_spec_filename, handle_wrong_key_error(err, keys)))
         except (
-                SchemaMissingKeyError,
-                SchemaForbiddenKeyError,
-                SchemaUnexpectedTypeError,
+            SchemaMissingKeyError,
+            SchemaForbiddenKeyError,
+            SchemaUnexpectedTypeError,
         ) as err:
             invalid_specs.append((analysis_spec_filename, err))
             continue
@@ -1119,13 +1132,13 @@ def handle_wrong_key_error(err: SchemaWrongKeyError, keys: list) -> Exception:
 
 
 def run_tests(  # pylint: disable=too-many-arguments
-        analysis: Dict[str, Any],
-        analysis_data_models: Dict[str, DataModel],
-        detection: Detection,
-        failed_tests: DefaultDict[str, list],
-        minimum_tests: int,
-        destinations_by_name: Dict[str, FakeDestination],
-        ignore_exception_types: List[Type[Exception]],
+    analysis: Dict[str, Any],
+    analysis_data_models: Dict[str, DataModel],
+    detection: Detection,
+    failed_tests: DefaultDict[str, list],
+    minimum_tests: int,
+    destinations_by_name: Dict[str, FakeDestination],
+    ignore_exception_types: List[Type[Exception]],
 ) -> DefaultDict[str, list]:
     if len(analysis.get("Tests", [])) < minimum_tests:
         failed_tests[detection.detection_id].append(
@@ -1149,8 +1162,8 @@ def run_tests(  # pylint: disable=too-many-arguments
     )
 
     if minimum_tests > 1 and not (
-            [x for x in analysis["Tests"] if x["ExpectedResult"]]
-            and [x for x in analysis["Tests"] if not x["ExpectedResult"]]
+        [x for x in analysis["Tests"] if x["ExpectedResult"]]
+        and [x for x in analysis["Tests"] if not x["ExpectedResult"]]
     ):
         failed_tests[detection.detection_id].append(
             "Insufficient test coverage: expected at least one positive and one negative test"
@@ -1160,12 +1173,12 @@ def run_tests(  # pylint: disable=too-many-arguments
 
 
 def _run_tests(  # pylint: disable=too-many-arguments
-        analysis_data_models: Dict[str, DataModel],
-        detection: Detection,
-        tests: List[Dict[str, Any]],
-        failed_tests: DefaultDict[str, list],
-        destinations_by_name: Dict[str, FakeDestination],
-        ignore_exception_types: List[Type[Exception]],
+    analysis_data_models: Dict[str, DataModel],
+    detection: Detection,
+    tests: List[Dict[str, Any]],
+    failed_tests: DefaultDict[str, list],
+    destinations_by_name: Dict[str, FakeDestination],
+    ignore_exception_types: List[Type[Exception]],
 ) -> DefaultDict[str, list]:
     for unit_test in tests:
         try:
@@ -1218,7 +1231,7 @@ def _run_tests(  # pylint: disable=too-many-arguments
 
 
 def _print_test_result(
-        detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]
+    detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]
 ) -> None:
     status_pass = "PASS"  # nosec
     status_fail = "FAIL"
@@ -1269,7 +1282,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "action": "store_true",
         "default": False,
         "required": False,
-        "help": "When set your upload will be broken down into multiple zip files"
+        "help": "When set your upload will be broken down into multiple zip files",
     }
     filter_name = "--filter"
     filter_arg: Dict[str, Any] = {"required": False, "metavar": "KEY=VALUE", "nargs": "+"}
@@ -1284,8 +1297,8 @@ def setup_parser() -> argparse.ArgumentParser:
         "default": 0,
         "type": int,
         "help": "The minimum number of tests in order for a detection to be considered passing. "
-                + "If a number greater than 1 is specified, at least one True and one False test is "
-                + "required.",
+        + "If a number greater than 1 is specified, at least one True and one False test is "
+        + "required.",
         "required": False,
     }
     out_name = "--out"
@@ -1329,7 +1342,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "dest": "ignore_files",
         "nargs": "+",
         "help": "Relative path to files in this project to be ignored by panther-analysis tool, "
-                + "space separated. Example ./foo.yaml ./bar/baz.yaml",
+        + "space separated. Example ./foo.yaml ./bar/baz.yaml",
         "type": str,
         "default": [],
     }
@@ -1340,14 +1353,14 @@ def setup_parser() -> argparse.ArgumentParser:
         "type": str,
         "action": "append",
         "help": "A destination name that may be returned by the destinations function. "
-                "Repeat the argument to define more than one name.",
+        "Repeat the argument to define more than one name.",
     }
 
     # -- root parser
 
     parser = argparse.ArgumentParser(
         description="Panther Analysis Tool: A command line tool for "
-                    + "managing Panther policies and rules.",
+        + "managing Panther policies and rules.",
         prog="panther_analysis_tool",
     )
     parser.add_argument("--version", action="version", version=VERSION_STRING)
@@ -1359,8 +1372,8 @@ def setup_parser() -> argparse.ArgumentParser:
     release_parser = subparsers.add_parser(
         "release",
         help="Create release assets for repository containing panther detections. "
-             + "Generates a file called panther-analysis-all.zip and optionally generates "
-             + "panther-analysis-all.sig",
+        + "Generates a file called panther-analysis-all.zip and optionally generates "
+        + "panther-analysis-all.sig",
     )
 
     standard_args.for_public_api(release_parser, required=False)
@@ -1396,8 +1409,8 @@ def setup_parser() -> argparse.ArgumentParser:
     publish_parser = subparsers.add_parser(
         "publish",
         help="Publishes a new release, generates the release assets, and uploads them. "
-             + "Generates a file called panther-analysis-all.zip and optionally generates "
-             + "panther-analysis-all.sig",
+        + "Generates a file called panther-analysis-all.zip and optionally generates "
+        + "panther-analysis-all.sig",
     )
     publish_parser.add_argument(
         "--body",
@@ -1625,7 +1638,7 @@ def setup_dynaconf() -> Dict[str, Any]:
 
 
 def dynaconf_argparse_merge(
-        argparse_dict: Dict[str, Any], config_file_settings: Dict[str, Any]
+    argparse_dict: Dict[str, Any], config_file_settings: Dict[str, Any]
 ) -> None:
     # Set up another parser w/ no defaults
     aux_parser = argparse.ArgumentParser(argument_default=argparse.SUPPRESS)
@@ -1657,15 +1670,15 @@ def parse_filter(filters: List[str]) -> Tuple[Dict[str, Any], Dict[str, Any]]:
             split[0] = split[0][:-1]  # Remove the trailing "!"
         key = split[0]
         if not any(
-                (
-                        key
-                        in (
-                                list(GLOBAL_SCHEMA.schema.keys())
-                                + list(POLICY_SCHEMA.schema.keys())
-                                + list(RULE_SCHEMA.schema.keys())
-                        )
-                        for key in (key, Optional(key))
+            (
+                key
+                in (
+                    list(GLOBAL_SCHEMA.schema.keys())
+                    + list(POLICY_SCHEMA.schema.keys())
+                    + list(RULE_SCHEMA.schema.keys())
                 )
+                for key in (key, Optional(key))
+            )
         ):
             logging.warning("Filter key %s is not a valid filter field, skipping", key)
             continue

--- a/panther_analysis_tool/zip_chunker.py
+++ b/panther_analysis_tool/zip_chunker.py
@@ -10,12 +10,23 @@ from panther_analysis_tool.constants import HELPERS_LOCATION, DATA_MODEL_LOCATIO
 
 @dataclass
 class ZipChunk:
-    """Patterns are Unix shell style:
+    """
+    ZipChunk allows you to select which files should go into a given chunk
+      - you can set patterns and types; this will match both cases
+      - you can set patterns or types; this will match whichever value is set
+
+
+    Patterns are Unix shell style:
 
         *       matches everything
         ?       matches any single character
         [seq]   matches any character in seq
         [!seq]  matches any char not in seq
+
+        Note: if a pattern such as */folder is used ./folder/hey.txt will not match
+        You will need a pattern that does */folder/* to match
+
+    Types are the types we expect in AnalysisType of a given yaml
     """
     patterns: List[str]
     types: Set[str] = ()  # type: ignore

--- a/panther_analysis_tool/zip_chunker.py
+++ b/panther_analysis_tool/zip_chunker.py
@@ -2,10 +2,14 @@ import argparse
 import os
 from dataclasses import dataclass
 from fnmatch import fnmatch
-from typing import Set, List, Dict, Any
+from typing import Any, Dict, List, Set
 
-from panther_analysis_tool.analysis_utils import filter_analysis, load_analysis_specs, to_relative_path
-from panther_analysis_tool.constants import HELPERS_LOCATION, DATA_MODEL_LOCATION
+from panther_analysis_tool.analysis_utils import (
+    filter_analysis,
+    load_analysis_specs,
+    to_relative_path,
+)
+from panther_analysis_tool.constants import DATA_MODEL_LOCATION, HELPERS_LOCATION
 
 
 @dataclass
@@ -28,6 +32,7 @@ class ZipChunk:
 
     Types are the types we expect in AnalysisType of a given yaml
     """
+
     patterns: List[str]
     types: Set[str] = ()  # type: ignore
 
@@ -62,7 +67,7 @@ class ZipArgs:
             path=args.path,
             ignore_files=args.ignore_files,
             filters=filters,  # type: ignore
-            filters_inverted=filters_inverted
+            filters_inverted=filters_inverted,
         )
 
 
@@ -113,9 +118,7 @@ def analysis_chunks(args: ZipArgs, chunks: List[ZipChunk] = None) -> List[ChunkF
     files: Set[str] = set()
 
     for (file_name, f_path, spec, _) in list(
-            load_analysis_specs(
-                [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION], args.ignore_files
-            )
+        load_analysis_specs([args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION], args.ignore_files)
     ):
         if file_name not in files:
             analysis.append((file_name, f_path, spec))
@@ -128,6 +131,8 @@ def analysis_chunks(args: ZipArgs, chunks: List[ZipChunk] = None) -> List[ChunkF
                 chunk.add_file(to_relative_path(analysis_spec_filename))
                 # datamodels may not have python body
                 if "Filename" in analysis_spec:
-                    chunk.add_file(to_relative_path(os.path.join(dir_name, analysis_spec["Filename"])))
+                    chunk.add_file(
+                        to_relative_path(os.path.join(dir_name, analysis_spec["Filename"]))
+                    )
 
     return chunk_files

--- a/panther_analysis_tool/zip_chunker.py
+++ b/panther_analysis_tool/zip_chunker.py
@@ -1,0 +1,122 @@
+import argparse
+import os
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from typing import Set, List, Dict, Any
+
+from panther_analysis_tool.analysis_utils import filter_analysis, load_analysis_specs
+from panther_analysis_tool.constants import HELPERS_LOCATION, DATA_MODEL_LOCATION
+
+
+@dataclass
+class ZipChunk:
+    """Patterns are Unix shell style:
+
+        *       matches everything
+        ?       matches any single character
+        [seq]   matches any character in seq
+        [!seq]  matches any char not in seq
+    """
+    patterns: List[str]
+    types: Set[str] = ()  # type: ignore
+
+    @classmethod
+    def from_patterns(cls, patterns: List[str]) -> Any:
+        return cls(patterns=patterns)
+
+
+@dataclass
+class ZipArgs:
+    out: Any
+    path: Any
+    ignore_files: List[str]
+    filters: Dict[str, List]
+    filters_inverted: Dict[str, List]
+
+    @classmethod
+    def from_args(cls, args: argparse.Namespace) -> Any:
+        filters = []
+        filters_inverted = {}
+        try:
+            filters = args.filter
+        except:  # pylint: disable=bare-except # nosec
+            pass
+
+        try:
+            filters_inverted = args.filter_inverted
+        except:  # pylint: disable=bare-except # nosec
+            pass
+        return cls(
+            out=args.out,
+            path=args.path,
+            ignore_files=args.ignore_files,
+            filters=filters,  # type: ignore
+            filters_inverted=filters_inverted
+        )
+
+
+class ChunkFiles:
+    chunk: ZipChunk
+    files: List[str]
+    added_files: Dict[str, bool]
+
+    def __init__(self, chunk: ZipChunk):
+        self.chunk = chunk
+        self.files = []
+        self.added_files = {}
+
+    def add_file(self, filename: str) -> None:
+        if self.added_files.get(filename) is None:
+            self.added_files[filename] = True
+            self.files.append(filename)
+
+    def matches_file(self, filename: str, spec: Dict[str, Any] = None) -> bool:
+        if len(self.chunk.types) > 0 and spec is not None and "AnalysisType" in spec:
+            if spec["AnalysisType"] not in self.chunk.types:
+                return False
+
+            if len(self.chunk.patterns) == 0:
+                return True
+
+        for pattern in self.chunk.patterns:
+            if fnmatch(filename, pattern):
+                return True
+
+        return False
+
+
+def analysis_chunks(args: ZipArgs, chunks: List[ZipChunk] = None) -> List[ChunkFiles]:
+    """Generates all files that should be added to a zip file. If no chunks are provided
+    a single chunk will be returned. Note: a file can be in multiple chunks if both chunks
+    matches the file pattern
+    :param args:
+    :param chunks:
+    :return:
+    """
+
+    if chunks is None or len(chunks) == 0:
+        chunks = [ZipChunk(patterns=["*"])]
+
+    chunk_files = [ChunkFiles(f) for f in chunks]
+    analysis = []
+    files: Set[str] = set()
+
+    for (file_name, f_path, spec, _) in list(
+            load_analysis_specs(
+                [args.path, HELPERS_LOCATION, DATA_MODEL_LOCATION], args.ignore_files
+            )
+    ):
+        if file_name not in files:
+            analysis.append((file_name, f_path, spec))
+            files.add(file_name)
+            files.add("./" + file_name)
+    analysis = filter_analysis(analysis, args.filters, args.filters_inverted)
+    for analysis_spec_filename, dir_name, analysis_spec in analysis:
+        for chunk in chunk_files:
+            if chunk.matches_file(analysis_spec_filename, analysis_spec):
+                chunk.add_file(analysis_spec_filename)
+                # datamodels may not have python body
+                if "Filename" in analysis_spec:
+                    chunk.add_file(os.path.join(dir_name, analysis_spec["Filename"]))
+
+    return chunk_files

--- a/panther_analysis_tool/zip_chunker.py
+++ b/panther_analysis_tool/zip_chunker.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from fnmatch import fnmatch
 from typing import Set, List, Dict, Any
 
-from panther_analysis_tool.analysis_utils import filter_analysis, load_analysis_specs
+from panther_analysis_tool.analysis_utils import filter_analysis, load_analysis_specs, to_relative_path
 from panther_analysis_tool.constants import HELPERS_LOCATION, DATA_MODEL_LOCATION
 
 
@@ -125,9 +125,9 @@ def analysis_chunks(args: ZipArgs, chunks: List[ZipChunk] = None) -> List[ChunkF
     for analysis_spec_filename, dir_name, analysis_spec in analysis:
         for chunk in chunk_files:
             if chunk.matches_file(analysis_spec_filename, analysis_spec):
-                chunk.add_file(analysis_spec_filename)
+                chunk.add_file(to_relative_path(analysis_spec_filename))
                 # datamodels may not have python body
                 if "Filename" in analysis_spec:
-                    chunk.add_file(os.path.join(dir_name, analysis_spec["Filename"]))
+                    chunk.add_file(to_relative_path(os.path.join(dir_name, analysis_spec["Filename"])))
 
     return chunk_files

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -361,6 +361,25 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 0)
         assert_true(out_filename.endswith('.zip'))
 
+    def test_zip_analysis_chunks(self):
+        # Note: This is a workaround for CI
+        try:
+            self.fs.create_dir('tmp/')
+        except OSError:
+            pass
+        args = pat.setup_parser(). \
+            parse_args(f'upload --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/ --chunk'.split())
+
+        results = pat.zip_analysis_chunks(args)
+        for out_filename in results:
+            _ = out_filename
+            assert_true(out_filename.startswith("tmp/"))
+            statinfo = os.stat(out_filename)
+            assert_true(statinfo.st_size > 0)
+            assert_true(out_filename.endswith('.zip'))
+
+        assert_equal(3, len(results))
+
     def test_generate_release_assets(self):
         # Note: This is a workaround for CI
         try:

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -368,7 +368,7 @@ class TestPantherAnalysisTool(TestCase):
         except OSError:
             pass
         args = pat.setup_parser(). \
-            parse_args(f'upload --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/ --chunk'.split())
+            parse_args(f'upload --path {DETECTIONS_FIXTURES_PATH}/valid_analysis --out tmp/ --batch'.split())
 
         results = pat.zip_analysis_chunks(args)
         for out_filename in results:


### PR DESCRIPTION
Closes https://app.asana.com/0/1202324455056256/1203717883565327/f

### Background
We need the ability to break our uploads into smaller pieces to avoid timeouts.

### Changes

* Moves some constants in the main.py to its own file
* Moves some functions in main.py to its own file
* Adds new zip chunking capability
* Adds --batch parameter to uploads .. when set will break uploads into chunks of
  - rules, policies, globals, data models, packs
  - queries & scheduled rules
  - look up tables
* Updates zipping logic to use relative paths instead of absolute paths for stored zip files

### Testing

* unit tests
* manual uploads

### Sample Output
**Command:** `panther_analysis_tool upload --skip-tests --batch`

```bash
[INFO]: Zipping analysis items in . to .
[INFO]: Uploading Batch 1...
[INFO]: Uploading items to Panther
[INFO]: Upload success.
[INFO]: API Response:
{
    "rules": {
        "new": 279,
        "total": 279,
        "modified": 0
    },
    "policies": {
        "new": 116,
        "total": 116,
        "modified": 0
    },
    "data_models": {
        "new": 23,
        "total": 23,
        "modified": 0
    },
    "lookup_tables": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "global_helpers": {
        "new": 15,
        "total": 15,
        "modified": 0
    }
}
[INFO]: Uploaded Batch 1
[INFO]: Uploading Batch 2...
[INFO]: Uploading items to Panther
[INFO]: Upload success.
[INFO]: API Response:
{
    "rules": {
        "new": 18,
        "total": 18,
        "modified": 0
    },
    "policies": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "data_models": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "lookup_tables": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "global_helpers": {
        "new": 0,
        "total": 0,
        "modified": 0
    }
}
[INFO]: Uploaded Batch 2
[INFO]: Uploading Batch 3...
[INFO]: Uploading items to Panther
[INFO]: Upload success.
[INFO]: API Response:
{
    "rules": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "policies": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "data_models": {
        "new": 0,
        "total": 0,
        "modified": 0
    },
    "lookup_tables": {
        "new": 0,
        "total": 7,
        "modified": 0
    },
    "global_helpers": {
        "new": 0,
        "total": 0,
        "modified": 0
    }
}
[INFO]: Uploaded Batch 3
```
