### PR TITLE
Replace 'timeformat' with 'timeFormats' on a sample-schema which is being displayed in our docs

### DIFF
--- a/tests/fixtures/custom-schemas/valid/schema-1.yml
+++ b/tests/fixtures/custom-schemas/valid/schema-1.yml
@@ -7,7 +7,8 @@ fields:
     description: Event timestamp
     required: true
     type: timestamp
-    timeFormat: rfc3339
+    timeFormats: 
+     - rfc3339
     isEventTime: true
   - name: method
     description: The HTTP method used for the request


### PR DESCRIPTION

### Background

- As part of [this](https://app.asana.com/0/1203758566181983/1203771576975528/f) task, all 'timeFormat' occurrences have to to be replaced with the 'timeFormats' key.
 

### Changes

### Testing
