### PR TITLE
Run CI Workflow on PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,4 @@
-on:
-  push
+on: [push, pull_request]
 
 jobs:
   ci:


### PR DESCRIPTION
### Background

The CI check needs to run on PRs. This should unblock PRs created via forks.

### Changes

* Sets `on` to `[push, pull_request]`

### Testing

* Check runs successfully after PR is opened
