### PR TITLE
Add pull_request_target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: [push, pull_request, pull_request_target]
 
 jobs:
   ci:


### PR DESCRIPTION
### Background

Adds the `pull_request_target` trigger to allow formatted files to be committed to a target branch (including forks).

https://github.com/stefanzweifel/git-auto-commit-action/blob/master/README.md#workflow-should-run-in-forked-repository

### Changes

* Adds `pull_request_target` to the CI Workflow triggers
