### PR TITLE
Revert "Add pull_request_target (#256)"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request, pull_request_target]
+on: [push, pull_request]
 
 jobs:
   ci:


### PR DESCRIPTION
This reverts commit df3475e18efb4a0622fdd1b465335da577feaafe.

### Background

Needed because this requires that the tests pass against the pull request target (tip of master branch) which is not guaranteed because PAT uses panther-analysis in tests, which can change between PAT commits.

### Changes

* Remove pull_request_target from github ci workflow

### Testing

* If the tests pass and this can merge, we should be good
