### PR TITLE
Split ci and fmt into separate workflows with different targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,23 +23,3 @@ jobs:
       - name: Run CLI Tests
         run: make ci
 
-  fmt:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3.1.0
-      - name: Setup Python
-        uses: actions/setup-python@v4.3.0
-        with:
-          python-version: 3.9.15
-      - name: Install pipenv
-        run: make install-pipenv
-      - name: Install
-        run: make install
-      - name: Format
-        run: make fmt
-      - name: Commit formatting
-        uses: stefanzweifel/git-auto-commit-action@v4
-        with:
-          commit_message: Automatically commit format changes
-

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,0 +1,23 @@
+on: [push, pull_request, pull_request_target]
+
+jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3.1.0
+      - name: Setup Python
+        uses: actions/setup-python@v4.3.0
+        with:
+          python-version: 3.9.15
+      - name: Install pipenv
+        run: make install-pipenv
+      - name: Install
+        run: make install
+      - name: Format
+        run: make fmt
+      - name: Commit formatting
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Automatically commit format changes
+


### PR DESCRIPTION
### Background

We want fmt to operate on pull_request_target to allow fmt changes to be committed to forked PRs, but we do not want ci to operate on pull_request_target because this requires that tests pass on the tip of master which is not guaranteed because the tests depend on changing resources.

### Changes

* Move fmt job from ci.yml to fmt.yml
* Add pull_request_target to fmt.yml

### Testing

* Testing will be GitHub CI
