### PR TITLE
feat: add Zeek schemas to LOG_TYPES_REGEX

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -79,10 +79,11 @@ LOG_TYPE_REGEX = Regex(
     r"Osquery\.Snapshot|Osquery\.Status|OSSEC\.EventInfo|OnePassword\.ItemUsage|OnePassword"
     r"\.SignInAttempt|Panther\.Audit|Salesforce\.Login|Salesforce\.LoginAs|Salesforce\.Logout|"
     r"Salesforce\.URI|Slack\.AccessLogs|Slack\.AuditLogs|Slack\.IntegrationLogs|Snyk\.OrgAudit|Snyk\.GroupAudit|Sophos\.Central|Suricata"
-    r"\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog\.RFC5424|Zeek\.DNS|Zendesk\.Audit|Zendesk"
+    r"\.Anomaly|Suricata\.DNS|Syslog\.RFC3164|Syslog\.RFC5424|Zendesk\.Audit|Zendesk"
     r"\.AuditLog|Zoom\.Activity|Zoom\.Operation"
     r"|SentinelOne\.Activity|SentinelOne\.DeepVisibility|SentinelOne\.DeepVisibilityV2"
     r"|Tines\.Audit"
+    r"|Zeek\.CaptureLoss|Zeek\.Conn|Zeek\.DHCP|Zeek\.DNS|Zeek\.DPD|Zeek\.Files|Zeek\.HTTP|Zeek\.Notice|Zeek\.NTP|Zeek\.OCSP|Zeek\.Reporter|Zeek\.SIP|Zeek\.Software|Zeek\.Ssh|Zeek\.Ssl|Zeek\.Stats|Zeek\.Tunnel|Zeek\.Weird|Zeek\.X509"
     r"|Custom\.([A-Z][A-Za-z0-9]*)(\.[A-Z][A-Za-z0-9]*){0,5})$"
 )
 

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -20,6 +20,28 @@ class TestPATSchemas(unittest.TestCase):
         with self.assertRaises(SchemaError):
             LOG_TYPE_REGEX.validate("Amazon.EKS.Foo")
 
+    def test_logtypes_regex_zeek(self):
+        LOG_TYPE_REGEX.validate("Zeek.CaptureLoss")
+        LOG_TYPE_REGEX.validate("Zeek.Conn")
+        LOG_TYPE_REGEX.validate("Zeek.DHCP")
+        LOG_TYPE_REGEX.validate("Zeek.DNS")
+        LOG_TYPE_REGEX.validate("Zeek.DPD")
+        LOG_TYPE_REGEX.validate("Zeek.Files")
+        LOG_TYPE_REGEX.validate("Zeek.HTTP")
+        LOG_TYPE_REGEX.validate("Zeek.Notice")
+        LOG_TYPE_REGEX.validate("Zeek.NTP")
+        LOG_TYPE_REGEX.validate("Zeek.OCSP")
+        LOG_TYPE_REGEX.validate("Zeek.Reporter")
+        LOG_TYPE_REGEX.validate("Zeek.SIP")
+        LOG_TYPE_REGEX.validate("Zeek.Software")
+        LOG_TYPE_REGEX.validate("Zeek.Ssh")
+        LOG_TYPE_REGEX.validate("Zeek.Ssl")
+        LOG_TYPE_REGEX.validate("Zeek.Stats")
+        LOG_TYPE_REGEX.validate("Zeek.Tunnel")
+        LOG_TYPE_REGEX.validate("Zeek.Weird")
+        LOG_TYPE_REGEX.validate("Zeek.X509")
+
+
     def test_mocks_are_str(self):
         MOCK_SCHEMA.validate({"objectName": "hello", "returnValue": "Testing a string"})
         MOCK_SCHEMA.validate({"objectName": "hello", "returnValue": "False"})


### PR DESCRIPTION
### Background

Adds Zeek Schemas to `LOG_TYPES_REGEX`.

Following up comment from [this PR](https://github.com/panther-labs/panther-enterprise/pull/12291).

Relates to https://app.asana.com/0/1203154630469853/1204484925017214/f

### Testing

* Added unit test to validate all Zeek schemas.
