### PR TITLE
adds async bulk upload support for api users

### DIFF
--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -32,6 +32,7 @@ class BackendError(Exception):
 class PermanentBackendError(BackendError):
     permanent: bool = True
 
+
 @dataclass(frozen=True)
 class BulkUploadPayload:
     data: bytes
@@ -159,6 +160,7 @@ class Client(ABC):
     @abstractmethod
     def async_bulk_upload(self, params: BulkUploadParams) -> BackendResponse[BulkUploadResponse]:
         pass
+
     @abstractmethod
     def bulk_upload(self, params: BulkUploadParams) -> BackendResponse[BulkUploadResponse]:
         pass

--- a/panther_analysis_tool/backend/errors.py
+++ b/panther_analysis_tool/backend/errors.py
@@ -5,9 +5,9 @@ UPLOAD_IN_PROGRESS_SUBSTR = "another upload"
 
 def is_retryable_error(err: Optional[Dict[str, Any]]) -> bool:
     if err:
-        if is_retryable_error_str(err.get(
-            "message", ""
-        )) or is_retryable_error_str(err.get("body", "")):
+        if is_retryable_error_str(err.get("message", "")) or is_retryable_error_str(
+            err.get("body", "")
+        ):
             return True
     return False
 
@@ -17,9 +17,9 @@ def is_retryable_error_str(err: str) -> bool:
         return False
 
     return (
-            UPLOAD_IN_PROGRESS_SUBSTR in err or
-            err == "upload failed" or
-            "unknown error occurred" in err or
-            "ddb lock" in err or
-            "pload does not exist" in err
+        UPLOAD_IN_PROGRESS_SUBSTR in err
+        or err == "upload failed"
+        or "unknown error occurred" in err
+        or "ddb lock" in err
+        or "pload does not exist" in err
     )

--- a/panther_analysis_tool/backend/errors.py
+++ b/panther_analysis_tool/backend/errors.py
@@ -3,10 +3,23 @@ from typing import Any, Dict, Optional
 UPLOAD_IN_PROGRESS_SUBSTR = "another upload"
 
 
-def is_upload_in_progress_error(err: Optional[Dict[str, Any]]) -> bool:
+def is_retryable_error(err: Optional[Dict[str, Any]]) -> bool:
     if err:
-        if UPLOAD_IN_PROGRESS_SUBSTR in err.get(
+        if is_retryable_error_str(err.get(
             "message", ""
-        ) or UPLOAD_IN_PROGRESS_SUBSTR in err.get("body", ""):
+        )) or is_retryable_error_str(err.get("body", "")):
             return True
     return False
+
+
+def is_retryable_error_str(err: str) -> bool:
+    if not err:
+        return False
+
+    return (
+            UPLOAD_IN_PROGRESS_SUBSTR in err or
+            err == "upload failed" or
+            "unknown error occurred" in err or
+            "ddb lock" in err or
+            "pload does not exist" in err
+    )

--- a/panther_analysis_tool/backend/graphql/async_bulk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/async_bulk_upload.graphql
@@ -1,0 +1,5 @@
+mutation uploadDetectionEntitiesAsync($input: UploadDetectionEntitiesAsyncInput!) {
+    uploadDetectionEntitiesAsync(input: $input) {
+        receiptId
+    }
+}

--- a/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
+++ b/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
@@ -1,0 +1,32 @@
+query status($input: ID!) {
+    detectionEntitiesUploadStatus(receiptId: $input) {
+        status
+        error
+        result {
+            dataModels {
+                ...UploadStatisticDetails
+                }
+                globalHelpers {
+                ...UploadStatisticDetails
+                }
+                lookupTables {
+                ...UploadStatisticDetails
+                }
+                policies {
+                ...UploadStatisticDetails
+                }
+                rules {
+                ...UploadStatisticDetails
+                }
+                queries {
+                ...UploadStatisticDetails
+                }
+        }
+    }
+}
+
+fragment UploadStatisticDetails on UploadStatistics {
+  modified
+  new
+  total
+}

--- a/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
+++ b/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
@@ -5,22 +5,22 @@ query status($input: ID!) {
         result {
             dataModels {
                 ...UploadStatisticDetails
-                }
-                globalHelpers {
+            }
+            globalHelpers {
                 ...UploadStatisticDetails
-                }
-                lookupTables {
+            }
+            lookupTables {
                 ...UploadStatisticDetails
-                }
-                policies {
+            }
+            policies {
                 ...UploadStatisticDetails
-                }
-                rules {
+            }
+            rules {
                 ...UploadStatisticDetails
-                }
-                queries {
+            }
+            queries {
                 ...UploadStatisticDetails
-                }
+            }
         }
     }
 }

--- a/panther_analysis_tool/backend/graphql/introspection_query.graphql
+++ b/panther_analysis_tool/backend/graphql/introspection_query.graphql
@@ -1,0 +1,88 @@
+query IntrospectionQuery {
+    __schema {
+      queryType { name }
+      mutationType { name }
+      subscriptionType { name }
+      types {
+        ...FullType
+      }
+      directives {
+        name
+        description
+        locations
+        args {
+          ...InputValue
+        }
+      }
+    }
+  }
+  fragment FullType on __Type {
+    kind
+    name
+    description
+    fields(includeDeprecated: true) {
+      name
+      description
+      args {
+        ...InputValue
+      }
+      type {
+        ...TypeRef
+      }
+      isDeprecated
+      deprecationReason
+    }
+    inputFields {
+      ...InputValue
+    }
+    interfaces {
+      ...TypeRef
+    }
+    enumValues(includeDeprecated: true) {
+      name
+      description
+      isDeprecated
+      deprecationReason
+    }
+    possibleTypes {
+      ...TypeRef
+    }
+  }
+  fragment InputValue on __InputValue {
+    name
+    description
+    type { ...TypeRef }
+    defaultValue
+  }
+  fragment TypeRef on __Type {
+    kind
+    name
+    ofType {
+      kind
+      name
+      ofType {
+        kind
+        name
+        ofType {
+          kind
+          name
+          ofType {
+            kind
+            name
+            ofType {
+              kind
+              name
+              ofType {
+                kind
+                name
+                ofType {
+                  kind
+                  name
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -43,9 +43,11 @@ from .client import (
     ManagedSchema,
     PantherSDKBulkUploadParams,
     PantherSDKBulkUploadResponse,
+    PermanentBackendError,
     UpdateManagedSchemaParams,
     UpdateManagedSchemaResponse,
-    backend_response_failed, to_bulk_upload_response, PermanentBackendError,
+    backend_response_failed,
+    to_bulk_upload_response,
 )
 from .errors import is_retryable_error
 
@@ -120,7 +122,6 @@ class LambdaClient(Client):
 
         body = decode_body(resp)
         return to_bulk_upload_response(body)
-
 
     def delete_detections(
         self, params: DeleteDetectionsParams

--- a/panther_analysis_tool/backend/mocks.py
+++ b/panther_analysis_tool/backend/mocks.py
@@ -17,6 +17,9 @@ from panther_analysis_tool.backend.client import (
 
 
 class MockBackend(BackendClient):
+    def async_bulk_upload(self, params: BulkUploadParams) -> BackendResponse[BulkUploadResponse]:
+        pass
+
     def bulk_upload(self, params: BulkUploadParams) -> BackendResponse[BulkUploadResponse]:
         pass
 
@@ -36,4 +39,7 @@ class MockBackend(BackendClient):
         pass
 
     def panthersdk_bulk_upload(self, params: PantherSDKBulkUploadParams) -> BackendResponse[Any]:
+        pass
+
+    def supports_async_uploads(self) -> bool:
         pass


### PR DESCRIPTION
### Background

When using the api token upload requests are limited to 30seconds. Since they are cases where an upload can take more than 30 seconds we need a way to allow users to continue to upload without any timeout issues.

### Changes
* Updates upload requests that are using the api token to use async uploads
* Adds new --no-async flag to the upload command
* Add logic to detect if panther instance supports async bulk uploads
* Fixes bug where we would always retry uploads vs only retrying when needed

### Testing

* Lots of manual tests
