### PR TITLE
json_path does not always exist

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1078,7 +1078,7 @@ def classify_analysis(
                 error = SchemaError(f"{first_half}: RESOURCE_TYPE_REGEX{second_half}")
             invalid_specs.append((analysis_spec_filename, error))
         except jsonschema.exceptions.ValidationError as err:
-            error_message = f"{err.json_path}: {err.message}"
+            error_message = f"{getattr(err, 'json_path', 'error')}: {err.message}"
             invalid_specs.append(
                 (analysis_spec_filename, jsonschema.exceptions.ValidationError(error_message))
             )


### PR DESCRIPTION
### Background

only use json_path in the error message when it is present

### Changes

* check for existence prior to use

### Testing

* ran against test files in p-e 
