### PR TITLE
Supported saved but but not scheduled queries

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -65,9 +65,7 @@ class ClassifiedAnalysisContainer:
     simple_detections: List[ClassifiedAnalysis] = dataclasses.field(
         init=False, default_factory=list
     )
-    scheduled_queries: List[ClassifiedAnalysis] = dataclasses.field(
-        init=False, default_factory=list
-    )
+    queries: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
     lookup_tables: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
     packs: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
 
@@ -77,7 +75,7 @@ class ClassifiedAnalysisContainer:
             self.globals,
             self.detections,
             self.simple_detections,
-            self.scheduled_queries,
+            self.queries,
             self.lookup_tables,
             self.packs,
         ]
@@ -94,7 +92,7 @@ class ClassifiedAnalysisContainer:
         container.globals = func(self.globals)
         container.detections = func(self.detections)
         container.simple_detections = func(self.simple_detections)
-        container.scheduled_queries = func(self.scheduled_queries)
+        container.queries = func(self.queries)
         container.lookup_tables = func(self.lookup_tables)
         container.packs = func(self.packs)
         return container
@@ -123,8 +121,10 @@ class ClassifiedAnalysisContainer:
             self.lookup_tables.append(classified_analysis)
         elif analysis_type == AnalysisTypes.PACK:
             self.packs.append(classified_analysis)
+        elif analysis_type == AnalysisTypes.SAVED_QUERY:
+            self.queries.append(classified_analysis)
         elif analysis_type == AnalysisTypes.SCHEDULED_QUERY:
-            self.scheduled_queries.append(classified_analysis)
+            self.queries.append(classified_analysis)
 
 
 def filter_analysis(

--- a/panther_analysis_tool/constants.py
+++ b/panther_analysis_tool/constants.py
@@ -10,8 +10,8 @@ from panther_analysis_tool.schemas import (
     LOOKUP_TABLE_SCHEMA,
     PACK_SCHEMA,
     POLICY_SCHEMA,
-    QUERY_SCHEMA,
     RULE_SCHEMA,
+    SAVED_QUERY_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
 )
 
@@ -71,7 +71,7 @@ SCHEMAS: Dict[str, Schema] = {
     AnalysisTypes.LOOKUP_TABLE: LOOKUP_TABLE_SCHEMA,
     AnalysisTypes.PACK: PACK_SCHEMA,
     AnalysisTypes.POLICY: POLICY_SCHEMA,
-    AnalysisTypes.SAVED_QUERY: QUERY_SCHEMA,
+    AnalysisTypes.SAVED_QUERY: SAVED_QUERY_SCHEMA,
     AnalysisTypes.SCHEDULED_QUERY: SCHEDULED_QUERY_SCHEMA,
     AnalysisTypes.RULE: RULE_SCHEMA,
     AnalysisTypes.SCHEDULED_RULE: RULE_SCHEMA,

--- a/panther_analysis_tool/constants.py
+++ b/panther_analysis_tool/constants.py
@@ -10,6 +10,7 @@ from panther_analysis_tool.schemas import (
     LOOKUP_TABLE_SCHEMA,
     PACK_SCHEMA,
     POLICY_SCHEMA,
+    QUERY_SCHEMA,
     RULE_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
 )
@@ -39,6 +40,7 @@ class AnalysisTypes:
     LOOKUP_TABLE = "lookup_table"
     PACK = "pack"
     POLICY = "policy"
+    SAVED_QUERY = "saved_query"
     SCHEDULED_QUERY = "scheduled_query"
     RULE = "rule"
     SCHEDULED_RULE = "scheduled_rule"
@@ -69,6 +71,7 @@ SCHEMAS: Dict[str, Schema] = {
     AnalysisTypes.LOOKUP_TABLE: LOOKUP_TABLE_SCHEMA,
     AnalysisTypes.PACK: PACK_SCHEMA,
     AnalysisTypes.POLICY: POLICY_SCHEMA,
+    AnalysisTypes.SAVED_QUERY: QUERY_SCHEMA,
     AnalysisTypes.SCHEDULED_QUERY: SCHEDULED_QUERY_SCHEMA,
     AnalysisTypes.RULE: RULE_SCHEMA,
     AnalysisTypes.SCHEDULED_RULE: RULE_SCHEMA,

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -102,6 +102,7 @@ TYPE_SCHEMA = Schema(
             "pack",
             "policy",
             "rule",
+            "saved_query",
             "scheduled_rule",
             "scheduled_query",
             "lookup_table",
@@ -225,6 +226,17 @@ RULE_SCHEMA = Schema(
                 Optional("Mocks"): [MOCK_SCHEMA],
             }
         ],
+    },
+    ignore_extra_keys=False,
+)  # Prevent user typos on optional fields
+
+QUERY_SCHEMA = Schema(
+    {
+        "AnalysisType": Or("saved_query"),
+        "QueryName": And(str, NAME_ID_VALIDATION_REGEX),
+        Or("Query", "AthenaQuery", "SnowflakeQuery"): str,
+        Optional("Description"): str,
+        Optional("Tags"): [str],
     },
     ignore_extra_keys=False,
 )  # Prevent user typos on optional fields

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -230,7 +230,7 @@ RULE_SCHEMA = Schema(
     ignore_extra_keys=False,
 )  # Prevent user typos on optional fields
 
-QUERY_SCHEMA = Schema(
+SAVED_QUERY_SCHEMA = Schema(
     {
         "AnalysisType": Or("saved_query"),
         "QueryName": And(str, NAME_ID_VALIDATION_REGEX),

--- a/tests/fixtures/detections/valid_analysis/queries/query_three.yml
+++ b/tests/fixtures/detections/valid_analysis/queries/query_three.yml
@@ -1,12 +1,8 @@
-AnalysisType: scheduled_query
+AnalysisType: saved_query
 QueryName: A Third Test Query
-Enabled: true
 AthenaQuery: 'SELECT * FROM panther_logs.aws_cloudtrail LIMIT 10'
 SnowflakeQuery: 'SELECT * FROM panther_logs.public.aws_cloudtrail LIMIT 10'
-Description: Some meme query
+Description: Some saved (not scheduled) query
 Tags:
   - some
   - meme
-Schedule:
-  CronExpression: '0 8 * * *'
-  TimeoutMinutes: 1

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -415,7 +415,7 @@ class TestPantherAnalysisTool(TestCase):
                 assert_equal(logging_mocks['warning'].call_count, 1)
                 # test + zip + upload messages, + 3 messages about sqlfluff loading improperly,
                 # which can be removed by pausing the fake file system
-                assert_equal(logging_mocks['info'].call_count, 6)
+                assert_equal(logging_mocks['info'].call_count, 5)
                 assert_equal(time_mock.call_count, 10)
 
         # invalid retry count, default to 0
@@ -428,7 +428,7 @@ class TestPantherAnalysisTool(TestCase):
                 assert_equal(return_code, 1)
                 assert_equal(logging_mocks['debug'].call_count, 1)
                 assert_equal(logging_mocks['warning'].call_count, 2)
-                assert_equal(logging_mocks['info'].call_count, 6)
+                assert_equal(logging_mocks['info'].call_count, 5)
                 assert_equal(time_mock.call_count, 0)
 
         # invalid retry count, default to 10
@@ -442,7 +442,7 @@ class TestPantherAnalysisTool(TestCase):
                 assert_equal(logging_mocks['debug'].call_count, 21)
                 # warning about max and final error
                 assert_equal(logging_mocks['warning'].call_count, 2)
-                assert_equal(logging_mocks['info'].call_count, 6)
+                assert_equal(logging_mocks['info'].call_count, 5)
                 assert_equal(time_mock.call_count, 10)
 
     def test_available_destination_names_invalid_name_returned(self):

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -9,6 +9,7 @@ from panther_analysis_tool.schemas import (
     POLICY_SCHEMA,
     LOG_TYPE_REGEX,
     MOCK_SCHEMA,
+    SAVED_QUERY_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
     RULE_SCHEMA,
     SIMPLE_DETECTION_SCHEMA,
@@ -67,7 +68,78 @@ class TestPATSchemas(unittest.TestCase):
             sample_datamodel["Mappings"] = [{"Name": "hello", "Path": "world", "Method": "foo"}]
             DATA_MODEL_SCHEMA.validate(sample_datamodel)
 
-    def test_query_rateminutes(self):
+    def test_scheduled_query_validate_schema(self):
+        # has required fields
+        SCHEDULED_QUERY_SCHEMA.validate({
+            "QueryName": "my.query.id",
+            "AnalysisType": "scheduled_query",
+            "Query": "select 1",
+            "Enabled": False,
+            "Schedule": {"RateMinutes": 10, "TimeoutMinutes": 5}
+        })
+        # missing Enabled
+        with self.assertRaises(SchemaError):
+            SCHEDULED_QUERY_SCHEMA.validate({
+                "QueryName": "my.query.id",
+                "AnalysisType": "scheduled_query",
+                "Query": "select 1",
+                "Schedule": {"RateMinutes": 10, "TimeoutMinutes": 5}
+        })
+        # missing Schedule
+        with self.assertRaises(SchemaError):
+            SCHEDULED_QUERY_SCHEMA.validate({
+                "QueryName": "my.query.id",
+                "AnalysisType": "scheduled_query",
+                "Query": "select 1",
+                "Enabled": False,
+        })
+        #  unknown field
+        with self.assertRaises(SchemaError):
+            SCHEDULED_QUERY_SCHEMA.validate({
+                "QueryName": "my.query.id",
+                "AnalysisType": "scheduled_query",
+                "Query": "select 1",
+                "Enabled": False,
+                "Schedule": {"RateMinutes": 10, "TimeoutMinutes": 5},
+                "Unknown field": 1
+        })
+
+    def test_saved_query_validate_schema(self):
+        # has required fields
+        SAVED_QUERY_SCHEMA.validate({
+            "QueryName": "my.query.id",
+            "AnalysisType": "saved_query",
+            "Query": "select 1",
+        })
+        # missing QueryName
+        with self.assertRaises(SchemaError):
+            SAVED_QUERY_SCHEMA.validate({
+                "AnalysisType": "saved_query",
+                "Query": "select 1",
+                "Schedule": {"RateMinutes": 10, "TimeoutMinutes": 5}
+        })
+        #  schedule query
+        with self.assertRaises(SchemaError):
+            SAVED_QUERY_SCHEMA.validate({
+            "QueryName": "my.query.id",
+            "AnalysisType": "saved_query",
+            "Query": "select 1",
+            "Enabled": False,
+            "Schedule": {"RateMinutes": 10, "TimeoutMinutes": 5}
+        })        
+        #  unknown field
+        with self.assertRaises(SchemaError):
+            SAVED_QUERY_SCHEMA.validate({
+                "QueryName": "my.query.id",
+                "AnalysisType": "saved_query",
+                "Query": "select 1",
+                "Enabled": False,
+                "Schedule": {"RateMinutes": 10, "TimeoutMinutes": 5},
+                "Unknown field": 1
+        })
+            
+        
+    def test_query_rateminutes(self):        
         sample_query = {
             "QueryName": "my.query.id",
             "AnalysisType": "scheduled_query",


### PR DESCRIPTION
### Background

We currently support `scheduled_query` as an AnalysisType but `saved_query` was never finished.

This PR finishes supporting `saved_query`.

[Another PR ](https://github.com/panther-labs/panther-enterprise/pull/13357) addresses the `panther-analysis-api`.

### Changes

Added schema for saved queries.


### Testing

Added test fixture for saved query.
