### PR TITLE
remove schema check to allow use of protected endpoints.

### DIFF
--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -451,7 +451,7 @@ def _build_client(host: str, token: str) -> GraphQLClient:
 
     transport = AIOHTTPTransport(url=graphql_url, headers={_API_TOKEN_HEADER: token})
 
-    return GraphQLClient(transport=transport, fetch_schema_from_transport=True, execute_timeout=30)
+    return GraphQLClient(transport=transport, fetch_schema_from_transport=False, execute_timeout=30)
 
 
 def is_url(url: str) -> bool:


### PR DESCRIPTION
### Background

We recently introduced a protected api endpoint concept on the graphql endpoint that allows pat to hit public endpoints that aren't necessarily documented. Protected endpoints do now show any information in the introspection query that our current client utilizes before every request.

With this change PAT can talk to protected endpoints without complaining.
* We recently introduced and api endpoint that is now protected (this endpoint will be hit in the next PAT release)

### Testing

* Tested exhaustively in #305
   * back porting since that PR may not make the next release
