### PR TITLE
Fixing README to make it easier to copy/paste commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,14 @@
 Install simply with pip:
 
 ```bash
-$ pip3 install panther_analysis_tool
+pip3 install panther_analysis_tool
 ```
 
 If you would rather use the `panther_analysis_tool` outside of the virtual environment, install it  directly:
 
 ```bash
-$ make deps
-$ pip3 install -e .
+make deps
+pip3 install -e .
 ```
 
 ## Build From Source
@@ -33,8 +33,8 @@ $ pip3 install -e .
 If you'd prefer instead to run from source for development reasons, first setup your environment:
 
 ```bash
-$ make install
-$ pipenv run -- pip3 install -e .
+make install
+pipenv run -- pip3 install -e .
 ```
 
 # Commands and Usage


### PR DESCRIPTION
### Background

Github README markdown allows to easily copy bash commands to execute in local env. 

The problem was that the commands we have listed include `$` which gets copied as well... I had to click on copy, then paste on terminal, then move the curson backwards to delete the extra `$`. I think it's easier to just... remove it all together. 

### Changes

* Removing `$` from the beginning of commands that are meant to be copy/pasted. 

### Testing

none. README changes. 
