### PR TITLE
Improve error messages for bad file cases

### DIFF
--- a/panther_analysis_tool/command/benchmark.py
+++ b/panther_analysis_tool/command/benchmark.py
@@ -104,14 +104,16 @@ def run(  # pylint: disable=too-many-locals
 def validate_rule_count(analyses: List[ClassifiedAnalysis]) -> (Union[ClassifiedAnalysis, str]):
     if len(analyses) != 1:
         return (
-            f"Only 1 detection must be specified for benchmarking, {len(analyses)} were specified:"
-            f" {[a.file_name for a in analyses]}"
+            f"Only 1 detection must be specified for benchmarking, but {len(analyses)} were specified. The rule must"
+            f" be the only item in the working directory or specified by --path, --ignore-files, and/or --filter. The"
+            f" following files were provided (up to 10 shown):"
+            f" {[a.file_name for a in analyses[:10]]}"
         )
     analysis = analyses[0]
     if analysis.analysis_spec["AnalysisType"] != AnalysisTypes.RULE:
         return (
             f"Only rules are supported for performance testing, but {analysis.analysis_spec['AnalysisType']}"
-            f" was provided"
+            f" was provided in {analysis.file_name}"
         )
     return analysis
 


### PR DESCRIPTION
### Background

It was pointed out that listing all of the files in the dir was unwieldy for large file counts and that advice on how to use the method would be preferable
closes: https://app.asana.com/0/1200908948600035/1205226048539595/f

### Changes

* Cleaned up error text for too many detections and wrong type

### Testing

* Ran manually and observed error
* Ensured existing unit tests pass
