### PR TITLE
Display subcommand help text on subcommand help (as description)

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1427,6 +1427,7 @@ def setup_parser() -> argparse.ArgumentParser:
         description="Panther Analysis Tool: A command line tool for "
         + "managing Panther policies and rules.",
         prog="panther_analysis_tool",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     parser.add_argument("--version", action="version", version=VERSION_STRING)
     parser.add_argument("--debug", action="store_true", dest="debug")
@@ -1443,6 +1444,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "release",
         help=release_help_text,
         description=release_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     standard_args.for_public_api(release_parser, required=False)
@@ -1465,7 +1467,12 @@ def setup_parser() -> argparse.ArgumentParser:
     # -- test command
 
     test_help_text = "Validate analysis specifications and run policy and rule tests."
-    test_parser = subparsers.add_parser("test", help=test_help_text, description=test_help_text)
+    test_parser = subparsers.add_parser(
+        "test",
+        help=test_help_text,
+        description=test_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
     standard_args.for_public_api(test_parser, required=False)
     test_parser.add_argument(filter_name, **filter_arg)
     test_parser.add_argument(min_test_name, **min_test_arg)
@@ -1490,6 +1497,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "publish",
         help=publish_help_text,
         description=publish_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     publish_parser.add_argument(
         "--body",
@@ -1542,6 +1550,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "upload",
         help=upload_help_text,
         description=upload_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     upload_parser.add_argument(
         "--max-retries",
@@ -1585,6 +1594,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "delete",
         help=delete_help_text,
         description=delete_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     delete_parser.add_argument(
         "--no-confirm",
@@ -1631,6 +1641,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "update-custom-schemas",
         help=custom_schemas_help_text,
         description=custom_schemas_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     standard_args.for_public_api(update_custom_schemas_parser, required=False)
@@ -1650,6 +1661,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "test-lookup-table",
         help=test_lookup_help_text,
         description=test_lookup_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     standard_args.using_aws_profile(test_lookup_table_parser)
@@ -1667,7 +1679,10 @@ def setup_parser() -> argparse.ArgumentParser:
     # -- validate command
     validate_help_text = "Validate your bulk uploads against your panther instance"
     validate_parser = subparsers.add_parser(
-        "validate", help=validate_help_text, description=validate_help_text
+        "validate",
+        help=validate_help_text,
+        description=validate_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     standard_args.for_public_api(validate_parser, required=False)
     validate_parser.add_argument(filter_name, **filter_arg)
@@ -1682,6 +1697,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "zip",
         help=zip_help_text,
         description=zip_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     standard_args.for_public_api(zip_parser, required=False)
     zip_parser.add_argument(filter_name, **filter_arg)
@@ -1704,6 +1720,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "check-connection",
         help=check_connection_help_text,
         description=check_connection_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
 
     standard_args.for_public_api(check_conn_parser, required=False)
@@ -1719,18 +1736,27 @@ def setup_parser() -> argparse.ArgumentParser:
         "sdk",
         help=sdk_help_text,
         description=sdk_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     standard_args.for_public_api(panthersdk_parser, required=False)
     standard_args.using_aws_profile(panthersdk_parser)
     panthersdk_subparsers = panthersdk_parser.add_subparsers()
 
+    sdk_upload_help_text = "Upload policies and rules generated from your Panther content"
     panthersdk_upload_parser = panthersdk_subparsers.add_parser(
-        "upload", help="Upload policies and rules generated from your Panther content"
+        "upload",
+        help=sdk_upload_help_text,
+        description=sdk_upload_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     panthersdk_upload_parser.set_defaults(func=pat_utils.func_with_backend(panthersdk_upload.run))
 
+    sdk_test_help_text = "Validate analysis specifications and run policy and rule tests."
     panthersdk_test_parser = panthersdk_subparsers.add_parser(
-        "test", help="Validate analysis specifications and run policy and rule tests."
+        "test",
+        help=sdk_test_help_text,
+        description=sdk_test_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     panthersdk_test_parser.add_argument(min_test_name, **min_test_arg)
     panthersdk_test_parser.add_argument(skip_disabled_test_name, **skip_disabled_test_arg)
@@ -1746,6 +1772,7 @@ def setup_parser() -> argparse.ArgumentParser:
         "benchmark",
         help=benchmark_help_text,
         description=benchmark_help_text,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
     )
     standard_args.for_public_api(benchmark_parser, required=False)
     benchmark_parser.add_argument(filter_name, **filter_arg)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1434,11 +1434,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- release command
 
+    release_help_text = "Create release assets for repository containing panther detections. " + "Generates a file called panther-analysis-all.zip and optionally generates " + "panther-analysis-all.sig"
     release_parser = subparsers.add_parser(
         "release",
-        help="Create release assets for repository containing panther detections. "
-        + "Generates a file called panther-analysis-all.zip and optionally generates "
-        + "panther-analysis-all.sig",
+        help=release_help_text,
+        description=release_help_text,
     )
 
     standard_args.for_public_api(release_parser, required=False)
@@ -1460,8 +1460,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- test command
 
+    test_help_text = "Validate analysis specifications and run policy and rule tests."
     test_parser = subparsers.add_parser(
-        "test", help="Validate analysis specifications and run policy and rule tests."
+        "test", help=test_help_text, description=test_help_text
     )
     standard_args.for_public_api(test_parser, required=False)
     test_parser.add_argument(filter_name, **filter_arg)
@@ -1478,11 +1479,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- publish command
 
+    publish_help_text = "Publishes a new release, generates the release assets, and uploads them. " + "Generates a file called panther-analysis-all.zip and optionally generates " + "panther-analysis-all.sig"
     publish_parser = subparsers.add_parser(
         "publish",
-        help="Publishes a new release, generates the release assets, and uploads them. "
-        + "Generates a file called panther-analysis-all.zip and optionally generates "
-        + "panther-analysis-all.sig",
+        help=publish_help_text,
+        description=publish_help_text,
     )
     publish_parser.add_argument(
         "--body",
@@ -1530,8 +1531,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- upload command
 
+    upload_help_text = "Upload specified policies and rules to a Panther deployment."
     upload_parser = subparsers.add_parser(
-        "upload", help="Upload specified policies and rules to a Panther deployment."
+        "upload", help=upload_help_text, description=upload_help_text,
     )
     upload_parser.add_argument(
         "--max-retries",
@@ -1570,9 +1572,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- delete command
 
+    delete_help_text = "Delete policies, rules, or saved queries from a Panther deployment"
     delete_parser = subparsers.add_parser(
         "delete",
-        help="Delete policies, rules, or saved queries from a Panther deployment",
+        help=delete_help_text,
+        description=delete_help_text,
     )
     delete_parser.add_argument(
         "--no-confirm",
@@ -1614,9 +1618,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- update custom schemas command
 
+    custom_schemas_help_text = "Update or create custom schemas on a Panther deployment."
     update_custom_schemas_parser = subparsers.add_parser(
         "update-custom-schemas",
-        help="Update or create custom schemas on a Panther deployment.",
+        help=custom_schemas_help_text,
+        description=custom_schemas_help_text,
     )
 
     standard_args.for_public_api(update_custom_schemas_parser, required=False)
@@ -1631,8 +1637,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- test lookup command
 
+    test_lookup_help_text = "Validate a Lookup Table spec file."
     test_lookup_table_parser = subparsers.add_parser(
-        "test-lookup-table", help="Validate a Lookup Table spec file."
+        "test-lookup-table", help=test_lookup_help_text, description=test_lookup_help_text,
     )
 
     standard_args.using_aws_profile(test_lookup_table_parser)
@@ -1648,8 +1655,9 @@ def setup_parser() -> argparse.ArgumentParser:
     test_lookup_table_parser.set_defaults(func=test_lookup_table)
 
     # -- validate command
+    validate_help_text = "Validate your bulk uploads against your panther instance"
     validate_parser = subparsers.add_parser(
-        "validate", help="Validate your bulk uploads against your panther instance"
+        "validate", help=validate_help_text, description=validate_help_text
     )
     standard_args.for_public_api(validate_parser, required=False)
     validate_parser.add_argument(filter_name, **filter_arg)
@@ -1659,9 +1667,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- zip command
 
+    zip_help_text = "Create an archive of local policies and rules for uploading to Panther."
     zip_parser = subparsers.add_parser(
         "zip",
-        help="Create an archive of local policies and rules for uploading to Panther.",
+        help=zip_help_text,
+        description=zip_help_text,
     )
     standard_args.for_public_api(zip_parser, required=False)
     zip_parser.add_argument(filter_name, **filter_arg)
@@ -1679,8 +1689,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- check-connection command
 
+    check_connection_help_text = "Check your Panther API connection"
     check_conn_parser = subparsers.add_parser(
-        "check-connection", help="Check your Panther API connection"
+        "check-connection", help=check_connection_help_text, description=check_connection_help_text,
     )
 
     standard_args.for_public_api(check_conn_parser, required=False)
@@ -1689,9 +1700,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- sdk command
 
+    sdk_help_text = "Perform operations using the Panther SDK exclusively ""(pass sdk --help for more)"
     panthersdk_parser = subparsers.add_parser(
         "sdk",
-        help="Perform operations using the Panther SDK exclusively " "(pass sdk --help for more)",
+        help=sdk_help_text,
+        description=sdk_help_text,
     )
     standard_args.for_public_api(panthersdk_parser, required=False)
     standard_args.using_aws_profile(panthersdk_parser)
@@ -1710,12 +1723,13 @@ def setup_parser() -> argparse.ArgumentParser:
     panthersdk_test_parser.set_defaults(func=panthersdk_test.run)
 
     # -- benchmark command
+    benchmark_help_text = f"Performance test one rule against one of its log types. The rule must be the only item" \
+        f" in the working directory or specified by {path_name}, {ignore_files_name}, and {filter_name}. This feature" \
+        f" is an extension of Data Replay and is subject to the same limitations."
     benchmark_parser = subparsers.add_parser(
         "benchmark",
-        help=f"Performance test one rule against one of its log types. The rule must be the only item"
-        f" in the working directory or specified by {path_name}, {ignore_files_name}, and"
-        f" {filter_name}. This feature is an extension of Data Replay and is subject to the same"
-        f" limitations.",
+        help=benchmark_help_text,
+        description=benchmark_help_text,
     )
     standard_args.for_public_api(benchmark_parser, required=False)
     benchmark_parser.add_argument(filter_name, **filter_arg)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1434,7 +1434,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- release command
 
-    release_help_text = "Create release assets for repository containing panther detections. " + "Generates a file called panther-analysis-all.zip and optionally generates " + "panther-analysis-all.sig"
+    release_help_text = (
+        "Create release assets for repository containing panther detections. "
+        + "Generates a file called panther-analysis-all.zip and optionally generates "
+        + "panther-analysis-all.sig"
+    )
     release_parser = subparsers.add_parser(
         "release",
         help=release_help_text,
@@ -1461,9 +1465,7 @@ def setup_parser() -> argparse.ArgumentParser:
     # -- test command
 
     test_help_text = "Validate analysis specifications and run policy and rule tests."
-    test_parser = subparsers.add_parser(
-        "test", help=test_help_text, description=test_help_text
-    )
+    test_parser = subparsers.add_parser("test", help=test_help_text, description=test_help_text)
     standard_args.for_public_api(test_parser, required=False)
     test_parser.add_argument(filter_name, **filter_arg)
     test_parser.add_argument(min_test_name, **min_test_arg)
@@ -1479,7 +1481,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- publish command
 
-    publish_help_text = "Publishes a new release, generates the release assets, and uploads them. " + "Generates a file called panther-analysis-all.zip and optionally generates " + "panther-analysis-all.sig"
+    publish_help_text = (
+        "Publishes a new release, generates the release assets, and uploads them. "
+        + "Generates a file called panther-analysis-all.zip and optionally generates "
+        + "panther-analysis-all.sig"
+    )
     publish_parser = subparsers.add_parser(
         "publish",
         help=publish_help_text,
@@ -1533,7 +1539,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     upload_help_text = "Upload specified policies and rules to a Panther deployment."
     upload_parser = subparsers.add_parser(
-        "upload", help=upload_help_text, description=upload_help_text,
+        "upload",
+        help=upload_help_text,
+        description=upload_help_text,
     )
     upload_parser.add_argument(
         "--max-retries",
@@ -1639,7 +1647,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     test_lookup_help_text = "Validate a Lookup Table spec file."
     test_lookup_table_parser = subparsers.add_parser(
-        "test-lookup-table", help=test_lookup_help_text, description=test_lookup_help_text,
+        "test-lookup-table",
+        help=test_lookup_help_text,
+        description=test_lookup_help_text,
     )
 
     standard_args.using_aws_profile(test_lookup_table_parser)
@@ -1691,7 +1701,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     check_connection_help_text = "Check your Panther API connection"
     check_conn_parser = subparsers.add_parser(
-        "check-connection", help=check_connection_help_text, description=check_connection_help_text,
+        "check-connection",
+        help=check_connection_help_text,
+        description=check_connection_help_text,
     )
 
     standard_args.for_public_api(check_conn_parser, required=False)
@@ -1700,7 +1712,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- sdk command
 
-    sdk_help_text = "Perform operations using the Panther SDK exclusively ""(pass sdk --help for more)"
+    sdk_help_text = (
+        "Perform operations using the Panther SDK exclusively " "(pass sdk --help for more)"
+    )
     panthersdk_parser = subparsers.add_parser(
         "sdk",
         help=sdk_help_text,
@@ -1723,9 +1737,11 @@ def setup_parser() -> argparse.ArgumentParser:
     panthersdk_test_parser.set_defaults(func=panthersdk_test.run)
 
     # -- benchmark command
-    benchmark_help_text = f"Performance test one rule against one of its log types. The rule must be the only item" \
-        f" in the working directory or specified by {path_name}, {ignore_files_name}, and {filter_name}. This feature" \
+    benchmark_help_text = (
+        f"Performance test one rule against one of its log types. The rule must be the only item"
+        f" in the working directory or specified by {path_name}, {ignore_files_name}, and {filter_name}. This feature"
         f" is an extension of Data Replay and is subject to the same limitations."
+    )
     benchmark_parser = subparsers.add_parser(
         "benchmark",
         help=benchmark_help_text,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1434,17 +1434,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- release command
 
-<<<<<<< Updated upstream
     release_help_text = (
         "Create release assets for repository containing panther detections. "
         + "Generates a file called panther-analysis-all.zip and optionally generates "
         + "panther-analysis-all.sig"
     )
-=======
-    release_help_text = "Create release assets for repository containing panther detections. " \
-                        + "Generates a file called panther-analysis-all.zip and optionally generates " \
-                        + "panther-analysis-all.sig"
->>>>>>> Stashed changes
     release_parser = subparsers.add_parser(
         "release",
         help=release_help_text,
@@ -1487,17 +1481,11 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- publish command
 
-<<<<<<< Updated upstream
     publish_help_text = (
         "Publishes a new release, generates the release assets, and uploads them. "
         + "Generates a file called panther-analysis-all.zip and optionally generates "
         + "panther-analysis-all.sig"
     )
-=======
-    publish_help_text = "Publishes a new release, generates the release assets, and uploads them. "\
-                        + "Generates a file called panther-analysis-all.zip and optionally generates "\
-                        + "panther-analysis-all.sig"
->>>>>>> Stashed changes
     publish_parser = subparsers.add_parser(
         "publish",
         help=publish_help_text,
@@ -1724,13 +1712,9 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- sdk command
 
-<<<<<<< Updated upstream
     sdk_help_text = (
-        "Perform operations using the Panther SDK exclusively " "(pass sdk --help for more)"
+        "Perform operations using the Panther SDK exclusively (pass sdk --help for more)"
     )
-=======
-    sdk_help_text = "Perform operations using the Panther SDK exclusively (pass sdk --help for more)"
->>>>>>> Stashed changes
     panthersdk_parser = subparsers.add_parser(
         "sdk",
         help=sdk_help_text,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1434,11 +1434,17 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- release command
 
+<<<<<<< Updated upstream
     release_help_text = (
         "Create release assets for repository containing panther detections. "
         + "Generates a file called panther-analysis-all.zip and optionally generates "
         + "panther-analysis-all.sig"
     )
+=======
+    release_help_text = "Create release assets for repository containing panther detections. " \
+                        + "Generates a file called panther-analysis-all.zip and optionally generates " \
+                        + "panther-analysis-all.sig"
+>>>>>>> Stashed changes
     release_parser = subparsers.add_parser(
         "release",
         help=release_help_text,
@@ -1481,11 +1487,17 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- publish command
 
+<<<<<<< Updated upstream
     publish_help_text = (
         "Publishes a new release, generates the release assets, and uploads them. "
         + "Generates a file called panther-analysis-all.zip and optionally generates "
         + "panther-analysis-all.sig"
     )
+=======
+    publish_help_text = "Publishes a new release, generates the release assets, and uploads them. "\
+                        + "Generates a file called panther-analysis-all.zip and optionally generates "\
+                        + "panther-analysis-all.sig"
+>>>>>>> Stashed changes
     publish_parser = subparsers.add_parser(
         "publish",
         help=publish_help_text,
@@ -1712,9 +1724,13 @@ def setup_parser() -> argparse.ArgumentParser:
 
     # -- sdk command
 
+<<<<<<< Updated upstream
     sdk_help_text = (
         "Perform operations using the Panther SDK exclusively " "(pass sdk --help for more)"
     )
+=======
+    sdk_help_text = "Perform operations using the Panther SDK exclusively (pass sdk --help for more)"
+>>>>>>> Stashed changes
     panthersdk_parser = subparsers.add_parser(
         "sdk",
         help=sdk_help_text,


### PR DESCRIPTION
### Background

Ensure that the text that displays per-subcommand when running `panther_analysis_tool --help` also displays when running `panther_analysis_tool subcommand --help`. Provides useful context about the subcommands

### Changes

* duplicate subparser help as description
* add arg default values to help output

### Testing

* Manually checked that output appeared
