### PR TITLE
allows resource types to be optional

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -188,7 +188,7 @@ POLICY_SCHEMA = Schema(
         "Enabled": bool,
         "Filename": str,
         "PolicyID": And(str, NAME_ID_VALIDATION_REGEX),
-        "ResourceTypes": And([str], [RESOURCE_TYPE_REGEX]),
+        Optional("ResourceTypes"): And([str], [RESOURCE_TYPE_REGEX]),
         "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
         Optional("ActionDelaySeconds"): int,
         Optional("AutoRemediationID"): str,

--- a/panther_analysis_tool/validation.py
+++ b/panther_analysis_tool/validation.py
@@ -123,7 +123,7 @@ def validate_packs(analysis_specs: ClassifiedAnalysisContainer) -> List[Any]:
                 (
                     analysis_spec_filename,
                     f"pack ({analysis_spec['PackID']}) definition includes item(s)"
-                    f" that do no exist ({', '.join(pack_invalid_ids)})",
+                    f" that do not exist ({', '.join(pack_invalid_ids)})",
                 )
             )
     return invalid_specs

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -259,6 +259,15 @@ class TestPATSchemas(unittest.TestCase):
             "ResourceTypes": ["AWS.DynamoDB.Table"]
         })
 
+    def test_policy_without_resource_types(self):
+        POLICY_SCHEMA.validate({
+            "AnalysisType": "policy", "Enabled": False, "Filename": "hmm", "PolicyID": "h", "Severity": "Info",
+            "ResourceTypes": []
+        })
+        POLICY_SCHEMA.validate({
+            "AnalysisType": "policy", "Enabled": False, "Filename": "hmm", "PolicyID": "h", "Severity": "Info",
+        })
+
 
 # This class was generated in whole or in part by GitHub Copilot
 class TestSimpleDetectionSchemas(unittest.TestCase):


### PR DESCRIPTION
### Background

The UI allows you to create a policy without resource types. This equates to a policy that looks at all resources. This update adjusts the PAT schema to match behavior in panther.

### Changes

* Allows resource types to be optional for policies

### Testing

- [x] Manual via test and upload command
- [x] Unit tests
