### PR TITLE
Upload and validate error improvements/alignment

### DIFF
--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -206,10 +206,6 @@ class BulkUploadValidateStatusResponse(BackendMultipartError):
         status = data.get("status") or ""
         err = data.get("error") or ""
         err = parse_graphql_error(err)
-
-        if status != "" and status not in ["NOT_PROCESSED", "FAILED", "COMPLETED"]:
-            raise BackendError(f"unexpected status: {status}")
-
         return cls(result=result, status=status, error=err)
 
     def has_error(self) -> bool:

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -231,7 +231,13 @@ class PublicAPIClient(Client):
             params = {"input": receipt_id}  # type: ignore
             res = self._potentially_supported_execute(query, variable_values=params)  # type: ignore
             result = res.data.get("validateBulkUploadStatus", {})  # type: ignore
-            return BulkUploadValidateStatusResponse.from_json(data=result)
+            status = result.get("status")
+
+            if status in ["FAILED", "COMPLETED"]:
+                return BulkUploadValidateStatusResponse.from_json(data=result)
+
+            if status not in ["NOT_PROCESSED"]:
+                raise BackendError(f"unexpected status: {status}")
 
     # This function was generated in whole or in part by GitHub Copilot.
     def transpile_simple_detection_to_python(

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -40,7 +40,6 @@ from .client import (
     BulkUploadParams,
     BulkUploadResponse,
     BulkUploadStatistics,
-    BulkUploadValidateResult,
     BulkUploadValidateStatusResponse,
     Client,
     DeleteDetectionsParams,
@@ -232,20 +231,7 @@ class PublicAPIClient(Client):
             params = {"input": receipt_id}  # type: ignore
             res = self._potentially_supported_execute(query, variable_values=params)  # type: ignore
             result = res.data.get("validateBulkUploadStatus", {})  # type: ignore
-            status = result.get("status", "")
-            error = result.get("error", "")
-
-            response = BulkUploadValidateStatusResponse(
-                error=error,
-                status=status,
-                result=BulkUploadValidateResult.from_json(result.get("result")),
-            )
-
-            if status in ["FAILED", "COMPLETED"]:
-                return response
-
-            if status not in ["NOT_PROCESSED"]:
-                raise BackendError(f"unexpected status: {status}")
+            return BulkUploadValidateStatusResponse.from_json(data=result)
 
     # This function was generated in whole or in part by GitHub Copilot.
     def transpile_simple_detection_to_python(

--- a/panther_analysis_tool/cli_output.py
+++ b/panther_analysis_tool/cli_output.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 from panther_analysis_tool.backend.client import BackendMultipartError
 
 
@@ -15,59 +13,55 @@ class BColors:
     UNDERLINE = "\033[4m"
 
     @classmethod
-    def bold(cls, text: str) -> str:
-        return cls.wrap(cls.BOLD, text)
-
-    @classmethod
-    def header(cls, text: str) -> str:
-        return cls.wrap(cls.HEADER, text)
-
-    @classmethod
-    def blue(cls, text: str) -> str:
-        return cls.wrap(cls.OKBLUE, text)
-
-    @classmethod
-    def cyan(cls, text: str) -> str:
-        return cls.wrap(cls.OKCYAN, text)
-
-    @classmethod
-    def green(cls, text: str) -> str:
-        return cls.wrap(cls.OKGREEN, text)
-
-    @classmethod
-    def warning(cls, text: str) -> str:
-        return cls.wrap(cls.WARNING, text)
-
-    @classmethod
-    def underline(cls, text: str) -> str:
-        return cls.wrap(cls.UNDERLINE, text)
-
-    @classmethod
-    def failed(cls, text: str) -> str:
-        return cls.wrap(cls.FAIL, text)
-
-    @classmethod
     def wrap(cls, start: str, text: str) -> str:
         return f"{start}{text}{cls.ENDC}"
 
 
-def print_op_success_msg(msg: Any) -> None:
-    print(f"{BColors.green(msg)}")
+def bold(text: str) -> str:
+    return BColors.wrap(BColors.BOLD, text)
+
+
+def header(text: str) -> str:
+    return BColors.wrap(BColors.HEADER, text)
+
+
+def blue(text: str) -> str:
+    return BColors.wrap(BColors.OKBLUE, text)
+
+
+def cyan(text: str) -> str:
+    return BColors.wrap(BColors.OKCYAN, text)
+
+
+def success(text: str) -> str:
+    return BColors.wrap(BColors.OKGREEN, text)
+
+
+def warning(text: str) -> str:
+    return BColors.wrap(BColors.WARNING, text)
+
+
+def underline(text: str) -> str:
+    return BColors.wrap(BColors.UNDERLINE, text)
+
+
+def failed(text: str) -> str:
+    return BColors.wrap(BColors.FAIL, text)
 
 
 def multipart_error_msg(result: BackendMultipartError, msg: str) -> str:
     return_str = "\n-----\n"
 
     if result.has_error():
-        return_str += f"{BColors.bold('Error')}: {result.get_error()}\n-----\n"
+        return_str += f"{bold('Error')}: {result.get_error()}\n-----\n"
 
     for issue in result.get_issues():
         if issue.path and issue.path != "":
-            return_str += f"{BColors.bold('Path')}: {issue.path}\n"
+            return_str += f"{bold('Path')}: {issue.path}\n"
 
         if issue.error_message and issue.error_message != "":
-            return_str += f"{BColors.bold('Error')}: {issue.error_message}\n"
+            return_str += f"{bold('Error')}: {issue.error_message}\n"
 
         return_str += "-----\n"
 
-    return f"{return_str}\n{BColors.failed(msg)}"
+    return f"{return_str}\n{failed(msg)}"

--- a/panther_analysis_tool/cli_output.py
+++ b/panther_analysis_tool/cli_output.py
@@ -1,0 +1,73 @@
+from typing import Any
+
+from panther_analysis_tool.backend.client import BackendMultipartError
+
+
+class BColors:
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKCYAN = "\033[96m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+
+    @classmethod
+    def bold(cls, text: str) -> str:
+        return cls.wrap(cls.BOLD, text)
+
+    @classmethod
+    def header(cls, text: str) -> str:
+        return cls.wrap(cls.HEADER, text)
+
+    @classmethod
+    def blue(cls, text: str) -> str:
+        return cls.wrap(cls.OKBLUE, text)
+
+    @classmethod
+    def cyan(cls, text: str) -> str:
+        return cls.wrap(cls.OKCYAN, text)
+
+    @classmethod
+    def green(cls, text: str) -> str:
+        return cls.wrap(cls.OKGREEN, text)
+
+    @classmethod
+    def warning(cls, text: str) -> str:
+        return cls.wrap(cls.WARNING, text)
+
+    @classmethod
+    def underline(cls, text: str) -> str:
+        return cls.wrap(cls.UNDERLINE, text)
+
+    @classmethod
+    def failed(cls, text: str) -> str:
+        return cls.wrap(cls.FAIL, text)
+
+    @classmethod
+    def wrap(cls, start: str, text: str) -> str:
+        return f"{start}{text}{cls.ENDC}"
+
+
+def print_op_success_msg(msg: Any) -> None:
+    print(f"{BColors.green(msg)}")
+
+
+def multipart_error_msg(result: BackendMultipartError, msg: str) -> str:
+    return_str = "\n-----\n"
+
+    if result.has_error():
+        return_str += f"{BColors.bold('Error')}: {result.get_error()}\n-----\n"
+
+    for issue in result.get_issues():
+        if issue.path and issue.path != "":
+            return_str += f"{BColors.bold('Path')}: {issue.path}\n"
+
+        if issue.error_message and issue.error_message != "":
+            return_str += f"{BColors.bold('Error')}: {issue.error_message}\n"
+
+        return_str += "-----\n"
+
+    return f"{return_str}\n{BColors.failed(msg)}"

--- a/panther_analysis_tool/command/validate.py
+++ b/panther_analysis_tool/command/validate.py
@@ -5,7 +5,10 @@ import zipfile
 from typing import Tuple
 
 from panther_analysis_tool import cli_output
-from panther_analysis_tool.backend.client import BulkUploadParams
+from panther_analysis_tool.backend.client import (
+    BulkUploadParams,
+    BulkUploadValidateStatusResponse,
+)
 from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import UnsupportedEndpointError
 from panther_analysis_tool.zip_chunker import ZipArgs, analysis_chunks
@@ -34,8 +37,9 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
         return 1, cli_output.multipart_error_msg(result, "Validation failed")
     except UnsupportedEndpointError as err:
         logging.debug(err)
-        return 1, cli_output.warning("Your panther instance does not support this feature")
+        return 1, cli_output.warning("Your Panther instance does not support this feature")
 
     except BaseException as err:  # pylint: disable=broad-except
-        logging.error("Failed to upload to backend: %s", err)
-        return 1, ""
+        return 1, cli_output.multipart_error_msg(
+            BulkUploadValidateStatusResponse.from_json({"error": str(err)}), "Validation failed"
+        )

--- a/panther_analysis_tool/command/validate.py
+++ b/panther_analysis_tool/command/validate.py
@@ -4,58 +4,11 @@ import logging
 import zipfile
 from typing import Tuple
 
+from panther_analysis_tool import cli_output
 from panther_analysis_tool.backend.client import BulkUploadParams
 from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import UnsupportedEndpointError
 from panther_analysis_tool.zip_chunker import ZipArgs, analysis_chunks
-
-
-class BColors:
-    HEADER = "\033[95m"
-    OKBLUE = "\033[94m"
-    OKCYAN = "\033[96m"
-    OKGREEN = "\033[92m"
-    WARNING = "\033[93m"
-    FAIL = "\033[91m"
-    ENDC = "\033[0m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
-
-    @classmethod
-    def bold(cls, text: str) -> str:
-        return cls.wrap(cls.BOLD, text)
-
-    @classmethod
-    def header(cls, text: str) -> str:
-        return cls.wrap(cls.HEADER, text)
-
-    @classmethod
-    def blue(cls, text: str) -> str:
-        return cls.wrap(cls.OKBLUE, text)
-
-    @classmethod
-    def cyan(cls, text: str) -> str:
-        return cls.wrap(cls.OKCYAN, text)
-
-    @classmethod
-    def green(cls, text: str) -> str:
-        return cls.wrap(cls.OKGREEN, text)
-
-    @classmethod
-    def warning(cls, text: str) -> str:
-        return cls.wrap(cls.WARNING, text)
-
-    @classmethod
-    def underline(cls, text: str) -> str:
-        return cls.wrap(cls.UNDERLINE, text)
-
-    @classmethod
-    def failed(cls, text: str) -> str:
-        return cls.wrap(cls.FAIL, text)
-
-    @classmethod
-    def wrap(cls, start: str, text: str) -> str:
-        return f"{start}{text}{cls.ENDC}"
 
 
 def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
@@ -73,35 +26,16 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
     buffer.seek(0, 0)
     params = BulkUploadParams(zip_bytes=buffer.read())
 
-    return_code = 0
-    return_str = ""
     try:
         result = backend.bulk_validate(params)
         if result.is_valid():
-            return return_code, f"{BColors.green('validation success')}"
+            return 0, f"{cli_output.BColors.green('validation success')}"
 
-        return_str += "\n-----\n"
-
-        if result.has_error():
-            return_str += f"{BColors.bold('Error')}: {result.error}\n-----\n"
-
-        for issue in result.issues():
-            if issue.path and issue.path != "":
-                return_str += f"{BColors.bold('Path')}: {issue.path}\n"
-
-            if issue.error_message and issue.error_message != "":
-                return_str += f"{BColors.bold('Error')}: {issue.error_message}\n"
-
-            return_str += "-----\n"
-
-        return_code = 1
-        return_str = f"{return_str}\n{BColors.failed('validation failed')}"
+        return 1, cli_output.multipart_error_msg(result, "validation failed")
     except UnsupportedEndpointError as err:
         logging.debug(err)
-        return 1, BColors.warning("your panther instance does not support this feature")
+        return 1, cli_output.BColors.warning("your panther instance does not support this feature")
 
     except BaseException as err:  # pylint: disable=broad-except
         logging.error("failed to upload to backend: %s", err)
-        return_code = 1
-
-    return return_code, return_str
+        return 1, ""

--- a/panther_analysis_tool/command/validate.py
+++ b/panther_analysis_tool/command/validate.py
@@ -29,13 +29,13 @@ def run(backend: BackendClient, args: argparse.Namespace) -> Tuple[int, str]:
     try:
         result = backend.bulk_validate(params)
         if result.is_valid():
-            return 0, f"{cli_output.BColors.green('validation success')}"
+            return 0, f"{cli_output.success('Validation success')}"
 
-        return 1, cli_output.multipart_error_msg(result, "validation failed")
+        return 1, cli_output.multipart_error_msg(result, "Validation failed")
     except UnsupportedEndpointError as err:
         logging.debug(err)
-        return 1, cli_output.BColors.warning("your panther instance does not support this feature")
+        return 1, cli_output.warning("Your panther instance does not support this feature")
 
     except BaseException as err:  # pylint: disable=broad-except
-        logging.error("failed to upload to backend: %s", err)
+        logging.error("Failed to upload to backend: %s", err)
         return 1, ""

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -362,15 +362,14 @@ def upload_zip(
                     response = backend.bulk_upload(upload_params)
 
                 logging.info("API Response:\n%s", json.dumps(asdict(response.data), indent=4))
-                logging.info("Upload success.")
+                # logging.info()
 
-                return_code = 0
-                break
+                return 0, cli_output.success("Upload succeeded")
 
             except BackendError as be_err:
                 err = cli_output.multipart_error_msg(
                     BulkUploadMultipartError.from_json(json.loads(convert_unicode(be_err))),
-                    "upload failed",
+                    "Upload failed",
                 )
                 if be_err.permanent is True:
                     return 1, f"Failed to upload to Panther: {err}"
@@ -393,13 +392,6 @@ def upload_zip(
             # PEP8 guide states it is OK to catch BaseException if you log it.
             except BaseException as err:  # pylint: disable=broad-except
                 return 1, f"Failed to upload to Panther: {err}"
-
-    if return_code != 0:
-        return return_code, ""
-
-    return_code, _ = panthersdk_upload.run(backend=backend, args=args, indirect_invocation=True)
-
-    return return_code, ""
 
 
 def parse_lookup_table(args: argparse.Namespace) -> dict:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -362,13 +362,11 @@ def upload_zip(
                     response = backend.bulk_upload(upload_params)
 
                 logging.info("API Response:\n%s", json.dumps(asdict(response.data), indent=4))
-                # logging.info()
-
                 return 0, cli_output.success("Upload succeeded")
 
             except BackendError as be_err:
                 err = cli_output.multipart_error_msg(
-                    BulkUploadMultipartError.from_json(json.loads(convert_unicode(be_err))),
+                    BulkUploadMultipartError.from_jsons(convert_unicode(be_err)),
                     "Upload failed",
                 )
                 if be_err.permanent is True:
@@ -1124,7 +1122,12 @@ def enrich_test_data(backend: BackendClient, args: argparse.Namespace) -> Tuple[
     specs, invalid_specs = classify_analysis(
         # unpack the nice dataclass into a tuple because we use Tuples too much everywhere
         [
-            (raw_item.spec_filename, raw_item.relative_path, raw_item.analysis_spec, raw_item.error)
+            (
+                raw_item.spec_filename,
+                raw_item.relative_path,
+                raw_item.analysis_spec,
+                raw_item.error,
+            )
             for raw_item in raw_analysis_items
         ],
         ignore_table_names=args.ignore_table_names,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -79,6 +79,7 @@ from schema import (
     SchemaWrongKeyError,
 )
 
+from panther_analysis_tool import cli_output
 from panther_analysis_tool import util as pat_utils
 from panther_analysis_tool.analysis_utils import (
     ClassifiedAnalysis,
@@ -89,7 +90,11 @@ from panther_analysis_tool.analysis_utils import (
     load_analysis_specs_ex,
     transpile_inline_filters,
 )
-from panther_analysis_tool.backend.client import BackendError, BulkUploadParams
+from panther_analysis_tool.backend.client import (
+    BackendError,
+    BulkUploadMultipartError,
+    BulkUploadParams,
+)
 from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.command import (
     benchmark,
@@ -305,7 +310,7 @@ def upload_analysis(backend: BackendClient, args: argparse.Namespace) -> Tuple[i
         args: The populated Argparse namespace with parsed command-line arguments.
 
     Returns:
-        A tuple of return code and the archive filename.
+        A tuple of return code and error if applicable.
     """
     use_async = (not args.no_async) and backend.supports_async_uploads()
     if args.batch and not use_async:
@@ -335,7 +340,6 @@ def upload_analysis(backend: BackendClient, args: argparse.Namespace) -> Tuple[i
 def upload_zip(
     backend: BackendClient, args: argparse.Namespace, archive: str, use_async: bool
 ) -> Tuple[int, str]:
-    return_archive_fname = ""
     # extract max retries we should handle
     max_retries = 10
     if args.max_retries > 10:
@@ -357,21 +361,22 @@ def upload_zip(
                 else:
                     response = backend.bulk_upload(upload_params)
 
-                logging.info("Upload success.")
                 logging.info("API Response:\n%s", json.dumps(asdict(response.data), indent=4))
+                logging.info("Upload success.")
 
                 return_code = 0
-                return_archive_fname = ""
                 break
 
             except BackendError as be_err:
+                err = cli_output.multipart_error_msg(
+                    BulkUploadMultipartError.from_json(json.loads(convert_unicode(be_err))),
+                    "upload failed",
+                )
                 if be_err.permanent is True:
-                    logging.error("Failed to upload to backend: %s", convert_unicode(be_err))
-                    return_code = 1
-                    break
+                    return 1, f"Failed to upload to Panther: {err}"
 
                 if max_retries - retry_count > 0:
-                    logging.debug("Failed to upload to Panther: %s.", convert_unicode(be_err))
+                    logging.debug("Failed to upload to Panther: %s.", convert_unicode(err))
                     retry_count += 1
 
                     # typical bulk upload takes 30 seconds, allow any currently running one to complete
@@ -383,24 +388,18 @@ def upload_zip(
 
                 else:
                     logging.warning("Exhausted retries attempting to perform bulk upload.")
-                    logging.error("Failed to upload to backend: %s", convert_unicode(be_err))
-                    return_code = 1
-                    return_archive_fname = ""
-                    break
+                    return 1, f"Failed to upload to Panther: {err}"
 
             # PEP8 guide states it is OK to catch BaseException if you log it.
             except BaseException as err:  # pylint: disable=broad-except
-                logging.error("failed to upload to backend: %s", err)
-                return_code = 1
-                return_archive_fname = ""
-                break
+                return 1, f"Failed to upload to Panther: {err}"
 
     if return_code != 0:
-        return return_code, return_archive_fname
+        return return_code, ""
 
     return_code, _ = panthersdk_upload.run(backend=backend, args=args, indirect_invocation=True)
 
-    return return_code, return_archive_fname
+    return return_code, ""
 
 
 def parse_lookup_table(args: argparse.Namespace) -> dict:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -38,6 +38,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime
+
 # Comment below disabling pylint checks is due to a bug in the CircleCi image with Pylint
 # It seems to be unable to import the distutils module, however the module is present and importable
 # in the Python Repl.

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -38,7 +38,6 @@ from collections import defaultdict
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from datetime import datetime
-
 # Comment below disabling pylint checks is due to a bug in the CircleCi image with Pylint
 # It seems to be unable to import the distutils module, however the module is present and importable
 # in the Python Repl.
@@ -373,7 +372,7 @@ def upload_zip(
                     return 1, f"Failed to upload to Panther: {err}"
 
                 if max_retries - retry_count > 0:
-                    logging.debug("Failed to upload to Panther: %s.", convert_unicode(err))
+                    logging.debug("Failed to upload to Panther: %s.", err)
                     retry_count += 1
 
                     # typical bulk upload takes 30 seconds, allow any currently running one to complete

--- a/panther_analysis_tool/validation.py
+++ b/panther_analysis_tool/validation.py
@@ -8,6 +8,7 @@ from sqlfluff import parse
 from panther_analysis_tool.analysis_utils import ClassifiedAnalysisContainer
 from panther_analysis_tool.constants import SET_FIELDS
 
+
 # This file was generated in whole or in part by GitHub Copilot.
 
 
@@ -31,7 +32,7 @@ def contains_invalid_field_set(analysis_spec: Any) -> List[str]:
 
 
 def contains_invalid_table_names(
-    analysis_spec: Any, analysis_id: str, valid_table_names: List[str]
+        analysis_spec: Any, analysis_id: str, valid_table_names: List[str]
 ) -> List[str]:
     invalid_table_names = []
     query = lookup_snowflake_query(analysis_spec)
@@ -42,7 +43,8 @@ def contains_invalid_table_names(
         except Exception:  # pylint: disable=broad-except
             # Intentionally broad exception catch:
             # We want to fall back on original behavior if this third-party parser cannot tell us the table names
-            logging.info("Failed to parse query for scheduled query %s", analysis_id)
+            logging.info("Failed to parse query %s. Skipping table name validation", analysis_id)
+            return []
         tables = nested_lookup("table_reference", parsed_query)
         aliases = [alias[0] for alias in nested_lookup("common_table_expression", parsed_query)]
         for table in tables:
@@ -67,12 +69,12 @@ def contains_invalid_table_names(
                 else:
                     is_public_table = components[1] == "public"
                     is_snowflake_account_usage_table = (
-                        components[0] == "snowflake" and components[1] == "account_usage"
+                            components[0] == "snowflake" and components[1] == "account_usage"
                     )
                     if not is_public_table and not is_snowflake_account_usage_table:
                         invalid_table_names.append(table_name)
     else:
-        logging.info("No query found for scheduled query %s", analysis_id)
+        logging.info("No query found for %s", analysis_id)
     return invalid_table_names
 
 
@@ -87,8 +89,8 @@ def lookup_snowflake_query(analysis_spec: Any) -> Optional[str]:
 def matches_valid_table_name(table_name: str, valid_table_names: List[str]) -> bool:
     for valid_table_name in valid_table_names:
         if (
-            re.match(valid_table_name.replace(".", "\\.").replace("*", ".*"), table_name)
-            is not None
+                re.match(valid_table_name.replace(".", "\\.").replace("*", ".*"), table_name)
+                is not None
         ):
             return True
     return False
@@ -101,13 +103,13 @@ def validate_packs(analysis_specs: ClassifiedAnalysisContainer) -> List[Any]:
     for item in analysis_specs.items():
         analysis_spec = item.analysis_spec
         analysis_id = (
-            analysis_spec.get("PolicyID")
-            or analysis_spec.get("RuleID")
-            or analysis_spec.get("DataModelID")
-            or analysis_spec.get("GlobalID")
-            or analysis_spec.get("PackID")
-            or analysis_spec.get("QueryName")
-            or analysis_spec["LookupName"]
+                analysis_spec.get("PolicyID")
+                or analysis_spec.get("RuleID")
+                or analysis_spec.get("DataModelID")
+                or analysis_spec.get("GlobalID")
+                or analysis_spec.get("PackID")
+                or analysis_spec.get("QueryName")
+                or analysis_spec["LookupName"]
         )
         id_to_detection[analysis_id] = analysis_spec
     for item in analysis_specs.packs:

--- a/panther_analysis_tool/validation.py
+++ b/panther_analysis_tool/validation.py
@@ -8,7 +8,6 @@ from sqlfluff import parse
 from panther_analysis_tool.analysis_utils import ClassifiedAnalysisContainer
 from panther_analysis_tool.constants import SET_FIELDS
 
-
 # This file was generated in whole or in part by GitHub Copilot.
 
 
@@ -32,7 +31,7 @@ def contains_invalid_field_set(analysis_spec: Any) -> List[str]:
 
 
 def contains_invalid_table_names(
-        analysis_spec: Any, analysis_id: str, valid_table_names: List[str]
+    analysis_spec: Any, analysis_id: str, valid_table_names: List[str]
 ) -> List[str]:
     invalid_table_names = []
     query = lookup_snowflake_query(analysis_spec)
@@ -69,7 +68,7 @@ def contains_invalid_table_names(
                 else:
                     is_public_table = components[1] == "public"
                     is_snowflake_account_usage_table = (
-                            components[0] == "snowflake" and components[1] == "account_usage"
+                        components[0] == "snowflake" and components[1] == "account_usage"
                     )
                     if not is_public_table and not is_snowflake_account_usage_table:
                         invalid_table_names.append(table_name)
@@ -89,8 +88,8 @@ def lookup_snowflake_query(analysis_spec: Any) -> Optional[str]:
 def matches_valid_table_name(table_name: str, valid_table_names: List[str]) -> bool:
     for valid_table_name in valid_table_names:
         if (
-                re.match(valid_table_name.replace(".", "\\.").replace("*", ".*"), table_name)
-                is not None
+            re.match(valid_table_name.replace(".", "\\.").replace("*", ".*"), table_name)
+            is not None
         ):
             return True
     return False
@@ -103,13 +102,13 @@ def validate_packs(analysis_specs: ClassifiedAnalysisContainer) -> List[Any]:
     for item in analysis_specs.items():
         analysis_spec = item.analysis_spec
         analysis_id = (
-                analysis_spec.get("PolicyID")
-                or analysis_spec.get("RuleID")
-                or analysis_spec.get("DataModelID")
-                or analysis_spec.get("GlobalID")
-                or analysis_spec.get("PackID")
-                or analysis_spec.get("QueryName")
-                or analysis_spec["LookupName"]
+            analysis_spec.get("PolicyID")
+            or analysis_spec.get("RuleID")
+            or analysis_spec.get("DataModelID")
+            or analysis_spec.get("GlobalID")
+            or analysis_spec.get("PackID")
+            or analysis_spec.get("QueryName")
+            or analysis_spec["LookupName"]
         )
         id_to_detection[analysis_id] = analysis_spec
     for item in analysis_specs.packs:


### PR DESCRIPTION
### Background

The validate cmd introduced some nicer error messaging. This PR gets upload to use that same messaging.

### Changes

* Improves upload errors by matching validate errors
* Formats errors here and there to match the rest of the app

### Testing

Manual

#### Validate Error: 
<img width="547" alt="image" src="https://github.com/panther-labs/panther_analysis_tool/assets/46904505/34069a78-d83f-48eb-a724-59dd9179988d">

#### Upload Error:
<img width="649" alt="image" src="https://github.com/panther-labs/panther_analysis_tool/assets/46904505/7ead727a-4cac-4fd4-810c-a85e6743ddf4">

#### Validate Issues:
<img width="790" alt="image" src="https://github.com/panther-labs/panther_analysis_tool/assets/46904505/e1c9998e-80eb-4a56-83fe-11cc5177582c">

#### Upload Issues: 
<img width="1402" alt="image" src="https://github.com/panther-labs/panther_analysis_tool/assets/46904505/75badbfe-4bd2-47ee-a124-e90ff8cbbdee">
