### PR TITLE
Remove CODEOWNERS entry for now-nonexistent Security Team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,3 @@
 # These owners will be the default owners for everything in the repo.
 * @panther-labs/detections
 
-VERSION @panther-labs/security


### PR DESCRIPTION
### Background
We no longer have a Security Team, so we should not block version bumps on them anymore
<High level overview here>

### Changes

* Remove CODEOWNERS reference to Security Team

### Testing

* N/A
