### PR TITLE
Ban % from ids/names

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -43,7 +43,7 @@ class QueryScheduleSchema(Schema):
         return data
 
 
-NAME_ID_VALIDATION_REGEX = Regex(r"^[^<>&\"]+$")
+NAME_ID_VALIDATION_REGEX = Regex(r"^[^<>&\"%]+$")
 RESOURCE_TYPE_REGEX = Regex(
     r"^AWS\.(ACM\.Certificate|CloudFormation\.Stack|CloudTrail\.Meta|CloudTrail|CloudWatch"
     r"\.LogGroup|Config\.Recorder\.Meta|Config\.Recorder|DynamoDB\.Table|EC2\.AMI|EC2\.Instance"

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -498,6 +498,28 @@ class TestPATSchemas(unittest.TestCase):
             }
         )
 
+    def test_percent_sign_banned(self):
+        with self.assertRaises(SchemaError):
+            RULE_SCHEMA.validate({
+                "AnalysisType": "scheduled_rule",
+                "Enabled": False,
+                "Filename": "hmm",
+                "RuleID": "%s",
+                "Severity": "Info",
+                "LogTypes": ["AWS.ALB"],
+            })
+        with self.assertRaises(SchemaError):
+            POLICY_SCHEMA.validate(
+                {
+                    "AnalysisType": "policy",
+                    "Enabled": False,
+                    "Filename": "hmm",
+                    "PolicyID": "%s",
+                    "Severity": "Info",
+                    "ResourceTypes": ["AWS.DynamoDB.Table"],
+                }
+            )
+
 
 # This class was generated in whole or in part by GitHub Copilot
 class TestSimpleDetectionSchemas(unittest.TestCase):

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -500,14 +500,16 @@ class TestPATSchemas(unittest.TestCase):
 
     def test_percent_sign_banned(self):
         with self.assertRaises(SchemaError):
-            RULE_SCHEMA.validate({
-                "AnalysisType": "scheduled_rule",
-                "Enabled": False,
-                "Filename": "hmm",
-                "RuleID": "%s",
-                "Severity": "Info",
-                "LogTypes": ["AWS.ALB"],
-            })
+            RULE_SCHEMA.validate(
+                {
+                    "AnalysisType": "scheduled_rule",
+                    "Enabled": False,
+                    "Filename": "hmm",
+                    "RuleID": "%s",
+                    "Severity": "Info",
+                    "LogTypes": ["AWS.ALB"],
+                }
+            )
         with self.assertRaises(SchemaError):
             POLICY_SCHEMA.validate(
                 {


### PR DESCRIPTION
### Background
Including a % character in a rule/policy id results in both not being able to load the detection in the web console and alerts that fire from the detection failing to be created properly.

We have two options for how to address this:

1. Ban % symbol
    - **Pro:** Easy to implement, guaranteed correct
    - **Con:** Risks breaking customer workflow for any existing % detections (none known but we don't have full data)
2. Fix each spot in the code where % is broken
    - **Pro:** Won't break customer workflows
    - **Con:** Hard to implement, potentially error-prone

I prefer **1** because the workaround on the customer side is relatively straightforward (clone and swap to new detection) and we don't expect it to be frequently needed, plus it's low risk

<High level overview here>

### Changes

* Add `%` to the list of disallowed characters for ids/names

### Testing

* Added new unit test
* Existing tests pass
