### PR TITLE
Adding body flag to version bump GHA

### DIFF
--- a/.github/workflows/version_bump_pr.yml
+++ b/.github/workflows/version_bump_pr.yml
@@ -51,6 +51,6 @@ jobs:
         git checkout -b "$NEW_VERSION"
         git commit -a -m "Bump version to $NEW_VERSION"
         git push --set-upstream origin "$NEW_VERSION"
-        gh pr create -t "Version bump to v$NEW_VERSION"
+        gh pr create -t "Version bump to v$NEW_VERSION" -b "Bumping Version to v$NEW_VERSION ahead of release."
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

* when running `gh` to create a PR in non-interactive mode, the body flag is required. This PR adds the body flag.

### Testing

* <Testing steps>
