### PR TITLE
Switching to PAT for GH_TOKEN

### DIFF
--- a/.github/workflows/version_bump_pr.yml
+++ b/.github/workflows/version_bump_pr.yml
@@ -53,4 +53,4 @@ jobs:
         git push --set-upstream origin "$NEW_VERSION"
         gh pr create -t "Version bump to v$NEW_VERSION" -b "Bumping Version to v$NEW_VERSION ahead of release."
       env:
-        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
### Background

GITHUB_TOKEN cannot trigger other GHA's, we have `fmt` and `ci` as required checks on PR's, switching to a PAT will allow those GHA's to trigger on PR's created by a PAT (not GITHUB_TOKEN)

### Changes

* <Describe changes here>

### Testing

* <Testing steps>
