### PR TITLE
Updating fmt GHA logic

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -1,41 +1,36 @@
 on:
   push:
-    branches-ignore:
-      - master
+    branches:
+      - master  # Splitting out master here ensures we do not redundantly run this workflow on merge from a PR
+  pull_request:
+    branches:
+      - '*' # Match all branches
 
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - name: Configure git user
-        run: |
-          if [[ -n "${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}" ]]; then
-            echo "GIT_USER_NAME=panther-bot-automation" >> $GITHUB_ENV
-            echo "GIT_USER_EMAIL=github-service-account-automation@panther.io" >> $GITHUB_ENV
-            echo "GIT_TOKEN=${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}" >> $GITHUB_ENV
-          else
-            echo "GIT_USER_NAME=${{ github.actor }}" >> $GITHUB_ENV
-            echo "GIT_USER_EMAIL=$(git log -n 1 --pretty=format:%ae)" >> $GITHUB_ENV
-            echo "GIT_TOKEN=${{ github.token }}" >> $GITHUB_ENV
-          fi
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          token: ${{ env.GIT_TOKEN }}
+
       - name: Setup Python
-        uses: actions/setup-python@v4.3.0
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9.15
+          python-version: 3.9
+
       - name: Install pipenv
         run: make install-pipenv
+
       - name: Install
         run: make install
+
       - name: Format
         run: make fmt
+
       - name: Commit formatting
         run: |
-          git config --global user.name "$GIT_USER_NAME"
-          git config --global user.email "$GIT_USER_EMAIL"
+          git config --global user.name "panther-bot-automation"
+          git config --global user.email "github-service-account-automation@panther.io"
           
           git add -A .
 
@@ -47,3 +42,5 @@ jobs:
             echo "Committing auto-formatted files"
             git push origin HEAD:${{ github.ref }}
           fi
+        env:
+          GH_TOKEN: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}


### PR DESCRIPTION
### Background

Updated logic a bit and removed code paths that may cause failures and added some new lines for easier readability between steps.

### Changes

* Added `on` logic for master and all branches such that we do not redundantly call this GHA after merging in a PR but also ensuring we trigger on all new PR's
* Removed GITHUB_TOKEN if / else logic, GITHUB_TOKEN causes issues when used to commit changes to a branch (e.g. when using GITHUB_TOKEN, by design other GHA's will not trigger.) TL;DR we need to ensure we always use a PAT (which is what my changes do by forcing the use of PANTHER_BOT_AUTOMATION_TOKEN)
* Generalized to 3.9 (not pinning to specific minor version)
* Generalized GHA step for python as well to v4 (no minor version pin)

### Testing

* <Testing steps>
