### PR TITLE
fixes bug that prevented multiple saved queries from being uploaded

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1214,6 +1214,8 @@ def lookup_analysis_id(analysis_spec: Any, analysis_type: str) -> str:
         analysis_id = analysis_spec["PolicyID"]
     elif analysis_type == AnalysisTypes.SCHEDULED_QUERY:
         analysis_id = analysis_spec["QueryName"]
+    elif analysis_type == AnalysisTypes.SAVED_QUERY:
+        analysis_id = analysis_spec["QueryName"]
     elif analysis_type in [AnalysisTypes.RULE, AnalysisTypes.SCHEDULED_RULE]:
         analysis_id = analysis_spec["RuleID"]
     return analysis_id


### PR DESCRIPTION
### Background

When we introduced the `saved_query` type a few months back it came with a bug that prevented a user from having multiple saved queries stored in their repo

### Changes

* Updates our logic to properly use the query name field as a unique id

### Testing

* Manual testing to verify behavior
