### PR TITLE
Whitelisting 'tests' as an allowed field in derived detection YAML

### DIFF
--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -216,6 +216,7 @@ DERIVED_SCHEMA = Schema(
         Optional("AlertTitle"): str,
         Optional("AlertContext"): object,
         Optional("GroupBy"): object,
+        Optional("Tests"): object,
     },
     ignore_extra_keys=False,
 )


### PR DESCRIPTION
### Background

We had previously disallowed defining tests in a derived detection YAML. This change reverts that decision as defining tests is a safe operation, even if inheritance is not supported for tests right now.

### Changes

* Added `Tests` to the Schema governing the list of valid keys in a derived detection YAML

### Testing

* Manually tested uploading a derived detection with tests
