### PR TITLE
Update logic for determining if an AnalysisType is a simple detection.

### DIFF
--- a/panther_analysis_tool/util.py
+++ b/panther_analysis_tool/util.py
@@ -214,17 +214,22 @@ def convert_unicode(obj: Any) -> str:
 
 
 def is_simple_detection(analysis_item: Dict[str, Any]) -> bool:
-    return all([
-        analysis_item.get('Detection') is not None,
-        is_correlation_rule(analysis_item) is False,
-        is_policy(analysis_item) is False,
-    ])
+    return all(
+        [
+            analysis_item.get("Detection") is not None,
+            is_correlation_rule(analysis_item) is False,
+            is_policy(analysis_item) is False,
+        ]
+    )
+
 
 def is_correlation_rule(analysis_item: Dict[str, Any]) -> bool:
-    return analysis_item.get('AnalysisType') == AnalysisTypes.CORRELATION_RULE
+    return analysis_item.get("AnalysisType") == AnalysisTypes.CORRELATION_RULE
+
 
 def is_policy(analysis_item: Dict[str, Any]) -> bool:
-    return analysis_item.get('AnalysisType') == AnalysisTypes.POLICY
+    return analysis_item.get("AnalysisType") == AnalysisTypes.POLICY
+
 
 def is_derived_detection(analysis_item: Dict[str, Any]) -> bool:
     return analysis_item.get("BaseDetection") is not None

--- a/tests/unit/panther_analysis_tool/test_util.py
+++ b/tests/unit/panther_analysis_tool/test_util.py
@@ -139,28 +139,27 @@ class TestConvertUnicode(unittest.TestCase):
 class TestAnalysisTypePredicates(unittest.TestCase):
     def test_is_simple_detection(self):
         test_cases = [
-             {
+            {
                 "analysis_type": {"AnalysisType": "rule", "Detection": "something"},
                 "expected": True,
-             },
-             {
+            },
+            {
                 "analysis_type": {"AnalysisType": "rule", "Filename": "foo.py"},
                 "expected": False,
-             },
-             {
+            },
+            {
                 "analysis_type": {"AnalysisType": "correlation_rule", "Detection": "hurgledurgle"},
                 "expected": False,
-             },
-             {
+            },
+            {
                 "analysis_type": {"AnalysisType": "policy", "Filename": "foo.py"},
                 "expected": False,
-             },
+            },
         ]
 
         for case in test_cases:
             res = pat_utils.is_simple_detection(case["analysis_type"])
             self.assertEqual(case["expected"], res)
-
 
     def test_is_correlation_rule(self):
         test_cases = [
@@ -181,7 +180,6 @@ class TestAnalysisTypePredicates(unittest.TestCase):
         for case in test_cases:
             res = pat_utils.is_correlation_rule(case["analysis_type"])
             self.assertEqual(case["expected"], res)
-
 
     def test_is_policy(self):
         test_cases = [


### PR DESCRIPTION
### Background

These helpers get used in a few places and need updating in light of the new CORRELATION_RULE hegemony.

### Changes

* update `is_simple_detection`
* add `is_correlation_rule`
* add `is_policy`

You might be asking yourself - why didn't he add `is_python_rule`? Well, because we weren't using it anywhere and I didn't need it for the other helpers I added.

### Testing

* new tests to please the test throne
