### PR TITLE
Removing references to Azure.SignIn schema

### DIFF
--- a/panther_analysis_tool/schema_regexs.py
+++ b/panther_analysis_tool/schema_regexs.py
@@ -29,7 +29,6 @@ LOG_TYPE_REGEX = Regex(
     r"Atlassian\.Audit|"
     r"Auth0\.Events|"
     r"Azure\.Audit|"
-    r"Azure\.SignIn|"
     r"Bitwarden\.Events|"
     r"Box\.Event|"
     r"CarbonBlack\.AlertV2|"

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -41,7 +41,6 @@ class TestPATSchemas(unittest.TestCase):
             "Atlassian.Audit",
             "Auth0.Events",
             "Azure.Audit",
-            "Azure.SignIn",
             "Bitwarden.Events",
             "Box.Event",
             "CarbonBlack.Audit",


### PR DESCRIPTION
### Background

Removing references to Azure.SignIn schema. 

All related detections are already removed as seen [here](https://github.com/panther-labs/panther-analysis/pull/953) and discussed [here](https://panther-labs.halp.com/tickets/6024). 

### Changes

* Removing `Azure.SignIn` from list of allowed schemas


