### PR TITLE
adds option to auto disable base

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -201,7 +201,9 @@ def disable_all_base_detections(paths: List[str], ignore_files: List[str]) -> No
         for analysis_spec_res in analysis_specs:
             rule: Dict[str, Any] = analysis_spec_res.analysis_spec
             if rule.get(rule_id_key, "") == base_detection_id:
-                logging.info("Setting %s=False for %s", enabled_key, analysis_spec_res.spec_filename)
+                logging.info(
+                    "Setting %s=False for %s", enabled_key, analysis_spec_res.spec_filename
+                )
                 rule[enabled_key] = False
                 analysis_spec_res.serialize_to_file()
 

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -184,7 +184,7 @@ def load_analysis_specs(
     for result in load_analysis_specs_ex(directories, ignore_files, roundtrip_yaml=False):
         yield result.spec_filename, result.relative_path, result.analysis_spec, result.error
 
-def disable_all_base_detections(paths: List[str], ignore_files: List[str]):
+def disable_all_base_detections(paths: List[str], ignore_files: List[str]) -> None:
     analysis_specs = list(load_analysis_specs_ex(paths, ignore_files, roundtrip_yaml=True))
     base_ids_to_disable = set()
     base_detection_key = 'BaseDetection'
@@ -198,12 +198,11 @@ def disable_all_base_detections(paths: List[str], ignore_files: List[str]):
         base_ids_to_disable.add(base_id)
     for base_detection_id in base_ids_to_disable:
         for analysis_spec_res in analysis_specs:
-            spec: Dict[str, Any] = analysis_spec_res.analysis_spec
-            if spec.get(rule_id_key, "") == base_detection_id:
+            rule: Dict[str, Any] = analysis_spec_res.analysis_spec
+            if rule.get(rule_id_key, "") == base_detection_id:
                 logging.info(f"Setting {enabled_key}=False for {analysis_spec_res.spec_filename}")
-                spec[enabled_key] = False
+                rule[enabled_key] = False
                 analysis_spec_res.serialize_to_file()
-    pass
 
 @dataclasses.dataclass
 class LoadAnalysisSpecsResult:

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -184,12 +184,13 @@ def load_analysis_specs(
     for result in load_analysis_specs_ex(directories, ignore_files, roundtrip_yaml=False):
         yield result.spec_filename, result.relative_path, result.analysis_spec, result.error
 
+
 def disable_all_base_detections(paths: List[str], ignore_files: List[str]) -> None:
     analysis_specs = list(load_analysis_specs_ex(paths, ignore_files, roundtrip_yaml=True))
     base_ids_to_disable = set()
-    base_detection_key = 'BaseDetection'
-    rule_id_key = 'RuleID'
-    enabled_key = 'Enabled'
+    base_detection_key = "BaseDetection"
+    rule_id_key = "RuleID"
+    enabled_key = "Enabled"
     for analysis_spec_res in analysis_specs:
         spec: Dict[str, Any] = analysis_spec_res.analysis_spec
         base_id = spec.get(base_detection_key, "")
@@ -203,6 +204,7 @@ def disable_all_base_detections(paths: List[str], ignore_files: List[str]) -> No
                 logging.info(f"Setting {enabled_key}=False for {analysis_spec_res.spec_filename}")
                 rule[enabled_key] = False
                 analysis_spec_res.serialize_to_file()
+
 
 @dataclasses.dataclass
 class LoadAnalysisSpecsResult:

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -201,7 +201,7 @@ def disable_all_base_detections(paths: List[str], ignore_files: List[str]) -> No
         for analysis_spec_res in analysis_specs:
             rule: Dict[str, Any] = analysis_spec_res.analysis_spec
             if rule.get(rule_id_key, "") == base_detection_id:
-                logging.info(f"Setting {enabled_key}=False for {analysis_spec_res.spec_filename}")
+                logging.info("Setting %s=False for %s", enabled_key, analysis_spec_res.spec_filename)
                 rule[enabled_key] = False
                 analysis_spec_res.serialize_to_file()
 

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -184,6 +184,26 @@ def load_analysis_specs(
     for result in load_analysis_specs_ex(directories, ignore_files, roundtrip_yaml=False):
         yield result.spec_filename, result.relative_path, result.analysis_spec, result.error
 
+def disable_all_base_detections(paths: List[str], ignore_files: List[str]):
+    analysis_specs = list(load_analysis_specs_ex(paths, ignore_files, roundtrip_yaml=True))
+    base_ids_to_disable = set()
+    base_detection_key = 'BaseDetection'
+    rule_id_key = 'RuleID'
+    enabled_key = 'Enabled'
+    for analysis_spec_res in analysis_specs:
+        spec: Dict[str, Any] = analysis_spec_res.analysis_spec
+        base_id = spec.get(base_detection_key, "")
+        if base_id == "":
+            continue
+        base_ids_to_disable.add(base_id)
+    for base_detection_id in base_ids_to_disable:
+        for analysis_spec_res in analysis_specs:
+            spec: Dict[str, Any] = analysis_spec_res.analysis_spec
+            if spec.get(rule_id_key, "") == base_detection_id:
+                logging.info(f"Setting {enabled_key}=False for {analysis_spec_res.spec_filename}")
+                spec[enabled_key] = False
+                analysis_spec_res.serialize_to_file()
+    pass
 
 @dataclasses.dataclass
 class LoadAnalysisSpecsResult:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -84,6 +84,7 @@ from panther_analysis_tool import util as pat_utils
 from panther_analysis_tool.analysis_utils import (
     ClassifiedAnalysis,
     ClassifiedAnalysisContainer,
+    disable_all_base_detections,
     filter_analysis,
     get_simple_detections_as_python,
     load_analysis_specs,
@@ -315,6 +316,10 @@ def upload_analysis(backend: BackendClient, args: argparse.Namespace) -> Tuple[i
     Returns:
         A tuple of return code and error if applicable.
     """
+    if args.auto_disable_base:
+        zipargs = ZipArgs.from_args(args)
+        disable_all_base_detections([zipargs.path], zipargs.ignore_files)
+
     use_async = (not args.no_async) and backend.supports_async_uploads()
     if args.batch and not use_async:
         if not args.skip_tests:
@@ -1668,6 +1673,13 @@ def setup_parser() -> argparse.ArgumentParser:
         help=upload_help_text,
         description=upload_help_text,
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    upload_parser.add_argument(
+        "--auto-disable-base",
+        help="If uploading derived detections, set the corresponding base detection's Enabled status to false prior to upload",
+        default=False,
+        required=False,
+        action="store_true",
     )
     upload_parser.add_argument(
         "--max-retries",


### PR DESCRIPTION
### Background

With inheritance there's a UX issue where a user could have a base detection and a derived detection enabled at the same time, creating duplicate alerts for each event that matches the base detection's logic. We wish to give users a convenient option to not have to remember to disable a base detection when creating a derived detection from it. This manifests as a:

- `--auto-disable-base` CLI option
- as well as a `auto_disable_base: true` option in the `.panther_settings.yml` file



<High level overview here>

### Changes

* adds option to auto disable base
* when true, for every derived detection, find the base detection, and set `Enabled: false` in the base detection yaml file prior to uploading

### Testing

* tested e2e in dev env.
* tested with CLI arg and `auto_disable_base: true` in `.panther_settings.yml`
* 
<img width="1208" alt="Screenshot 2023-12-04 at 5 27 53 PM" src="https://github.com/panther-labs/panther_analysis_tool/assets/93276498/050fabac-e9d4-403c-8dbe-fffc83d57d71">
