### PR TITLE
DAC-501 PAT can test derived detections w/ inheritance and overrides

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -454,9 +454,7 @@ def get_simple_detections_as_python(
     return enriched_specs if enriched_specs else specs
 
 
-def lookup_base_detection(
-    id: str, backend: Optional[BackendClient] = None
-) -> Dict[str, Any]:
+def lookup_base_detection(id: str, backend: Optional[BackendClient] = None) -> Dict[str, Any]:
     """Attempts to lookup base detection via its id"""
     out = {}
     if backend is not None:
@@ -466,7 +464,9 @@ def lookup_base_detection(
             if response.status_code == 200:
                 out["body"] = response.data.body
             else:
-                logging.warning("Unexpected error getting base detection, status code %s", response.status_code)
+                logging.warning(
+                    "Unexpected error getting base detection, status code %s", response.status_code
+                )
         except (BackendError, BaseException) as be_err:  # pylint: disable=broad-except
             logging.warning(
                 "Error getting base detection %s: %s",

--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -31,7 +31,6 @@ from panther_analysis_tool.backend.client import BackendError
 from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import (
     GetRuleBodyParams,
-    GetRuleBodyResponse,
     TranspileFiltersParams,
     TranspileToPythonParams,
 )
@@ -454,12 +453,12 @@ def get_simple_detections_as_python(
     return enriched_specs if enriched_specs else specs
 
 
-def lookup_base_detection(id: str, backend: Optional[BackendClient] = None) -> Dict[str, Any]:
+def lookup_base_detection(the_id: str, backend: Optional[BackendClient] = None) -> Dict[str, Any]:
     """Attempts to lookup base detection via its id"""
     out = {}
     if backend is not None:
         try:
-            params = GetRuleBodyParams(id=id)
+            params = GetRuleBodyParams(id=the_id)
             response = backend.get_rule_body(params)
             if response.status_code == 200:
                 out["body"] = response.data.body
@@ -470,7 +469,7 @@ def lookup_base_detection(id: str, backend: Optional[BackendClient] = None) -> D
         except (BackendError, BaseException) as be_err:  # pylint: disable=broad-except
             logging.warning(
                 "Error getting base detection %s: %s",
-                id,
+                the_id,
                 be_err,
             )
     return out

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -291,7 +291,7 @@ class TranspileToPythonResponse:
 
 @dataclass(frozen=True)
 class GetRuleBodyParams:
-    id: str
+    id: str  # pylint: disable=invalid-name
 
 
 @dataclass(frozen=True)

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -465,9 +465,7 @@ class Client(ABC):
         pass
 
     @abstractmethod
-    def get_rule_body(
-        self, params: GetRuleBodyParams
-    ) -> BackendResponse[GetRuleBodyResponse]:
+    def get_rule_body(self, params: GetRuleBodyParams) -> BackendResponse[GetRuleBodyResponse]:
         pass
 
     @abstractmethod

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -290,6 +290,16 @@ class TranspileToPythonResponse:
 
 
 @dataclass(frozen=True)
+class GetRuleBodyParams:
+    id: str
+
+
+@dataclass(frozen=True)
+class GetRuleBodyResponse:
+    body: str
+
+
+@dataclass(frozen=True)
 class TranspileFiltersParams:
     data: List[str]
     pat_version: str
@@ -452,6 +462,12 @@ class Client(ABC):
 
     @abstractmethod
     def bulk_validate(self, params: BulkUploadParams) -> BulkUploadValidateStatusResponse:
+        pass
+
+    @abstractmethod
+    def get_rule_body(
+        self, params: GetRuleBodyParams
+    ) -> BackendResponse[GetRuleBodyResponse]:
         pass
 
     @abstractmethod

--- a/panther_analysis_tool/backend/graphql/get_rule_body.graphql
+++ b/panther_analysis_tool/backend/graphql/get_rule_body.graphql
@@ -1,0 +1,5 @@
+query GetRuleBody($input: ID!) {
+    rulePythonBody(input: $input) {
+        pythonBody
+    }
+}

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -286,9 +286,7 @@ class LambdaClient(Client):
     ) -> BackendResponse[TranspileFiltersResponse]:
         raise BaseException("transpile filters is not supported with lambda client")
 
-    def get_rule_body(
-        self, params: GetRuleBodyParams
-    ) -> BackendResponse[GetRuleBodyResponse]:
+    def get_rule_body(self, params: GetRuleBodyParams) -> BackendResponse[GetRuleBodyResponse]:
         raise BaseException("get rule body is not supported with lambda client")
 
     @staticmethod

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -39,6 +39,8 @@ from .client import (
     DeleteSavedQueriesResponse,
     GenerateEnrichedEventParams,
     GenerateEnrichedEventResponse,
+    GetRuleBodyParams,
+    GetRuleBodyResponse,
     ListSchemasParams,
     ListSchemasResponse,
     MetricsParams,
@@ -283,6 +285,11 @@ class LambdaClient(Client):
         self, params: TranspileFiltersParams
     ) -> BackendResponse[TranspileFiltersResponse]:
         raise BaseException("transpile filters is not supported with lambda client")
+
+    def get_rule_body(
+        self, params: GetRuleBodyParams
+    ) -> BackendResponse[GetRuleBodyResponse]:
+        raise BaseException("get rule body is not supported with lambda client")
 
     @staticmethod
     def _serialize_request(data: Dict[str, Any]) -> str:

--- a/panther_analysis_tool/backend/mocks.py
+++ b/panther_analysis_tool/backend/mocks.py
@@ -13,6 +13,8 @@ from panther_analysis_tool.backend.client import (
     DeleteSavedQueriesParams,
     GenerateEnrichedEventParams,
     GenerateEnrichedEventResponse,
+    GetRuleBodyParams,
+    GetRuleBodyResponse,
     ListSchemasParams,
     MetricsParams,
     MetricsResponse,
@@ -48,6 +50,9 @@ class MockBackend(BackendClient):
         pass
 
     def supports_async_uploads(self) -> bool:
+        pass
+
+    def get_rule_body(self, params: GetRuleBodyParams) -> BackendResponse[GetRuleBodyResponse]:
         pass
 
     def transpile_simple_detection_to_python(

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -238,9 +238,7 @@ class PublicAPIClient(Client):
                 raise BackendError(f"unexpected status: {status}")
 
     # This function was generated in whole or in part by GitHub Copilot.
-    def get_rule_body(
-        self, params: GetRuleBodyParams
-    ) -> BackendResponse[GetRuleBodyResponse]:
+    def get_rule_body(self, params: GetRuleBodyParams) -> BackendResponse[GetRuleBodyResponse]:
         query: DocumentNode = self._requests.get_rule_body()
         input = {"input": params.id}
         res = self._safe_execute(query, variable_values=input)

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -240,8 +240,8 @@ class PublicAPIClient(Client):
     # This function was generated in whole or in part by GitHub Copilot.
     def get_rule_body(self, params: GetRuleBodyParams) -> BackendResponse[GetRuleBodyResponse]:
         query: DocumentNode = self._requests.get_rule_body()
-        input = {"input": params.id}
-        res = self._safe_execute(query, variable_values=input)
+        params = {"input": params.id}
+        res = self._safe_execute(query, variable_values=params)
         data = res.data.get("rulePythonBody", {})  # type: ignore
 
         return BackendResponse(

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -240,8 +240,8 @@ class PublicAPIClient(Client):
     # This function was generated in whole or in part by GitHub Copilot.
     def get_rule_body(self, params: GetRuleBodyParams) -> BackendResponse[GetRuleBodyResponse]:
         query: DocumentNode = self._requests.get_rule_body()
-        params = {"input": params.id}
-        res = self._safe_execute(query, variable_values=params)
+        params = {"input": params.id}  # type: ignore
+        res = self._safe_execute(query, variable_values=params)  # type: ignore
         data = res.data.get("rulePythonBody", {})  # type: ignore
 
         return BackendResponse(

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -46,6 +46,8 @@ from .client import (
     DeleteSavedQueriesResponse,
     GenerateEnrichedEventParams,
     GenerateEnrichedEventResponse,
+    GetRuleBodyParams,
+    GetRuleBodyResponse,
     ListSchemasParams,
     ListSchemasResponse,
     MetricsParams,
@@ -109,6 +111,9 @@ class PublicAPIRequests:
 
     def delete_saved_queries(self) -> DocumentNode:
         return self._load("delete_saved_queries")
+
+    def get_rule_body(self) -> DocumentNode:
+        return self._load("get_rule_body")
 
     def transpile_simple_detection_to_python(self) -> DocumentNode:
         return self._load("transpile_sdl")
@@ -231,6 +236,22 @@ class PublicAPIClient(Client):
 
             if status not in ["NOT_PROCESSED"]:
                 raise BackendError(f"unexpected status: {status}")
+
+    # This function was generated in whole or in part by GitHub Copilot.
+    def get_rule_body(
+        self, params: GetRuleBodyParams
+    ) -> BackendResponse[GetRuleBodyResponse]:
+        query: DocumentNode = self._requests.get_rule_body()
+        input = {"input": params.id}
+        res = self._safe_execute(query, variable_values=input)
+        data = res.data.get("rulePythonBody", {})  # type: ignore
+
+        return BackendResponse(
+            status_code=200,
+            data=GetRuleBodyResponse(
+                body=data.get("pythonBody") or "",
+            ),
+        )
 
     # This function was generated in whole or in part by GitHub Copilot.
     def transpile_simple_detection_to_python(

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -133,7 +133,6 @@ from panther_analysis_tool.util import (
     add_path_to_filename,
     convert_unicode,
     is_correlation_rule,
-    is_derived_detection,
     is_simple_detection,
 )
 from panther_analysis_tool.validation import (
@@ -893,7 +892,7 @@ def setup_data_models(
     return log_type_to_data_model, invalid_specs
 
 
-def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
+def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-many-statements
     log_type_to_data_model: Dict[str, DataModel],
     analysis: List[ClassifiedAnalysis],
     minimum_tests: int,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -956,6 +956,7 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
             if "body" in found_base_detection:
                 detection_args["body"] = found_base_detection.get("body")
             else:
+                found_base_path: str = found_base_path
                 detection_args["path"] = os.path.join(
                     found_base_path, found_base_detection["Filename"]
                 )

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -931,12 +931,17 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
             # this is a derived detection
             found_base_detection = None
             found_base_path = None
+            found_base_tests = None
             for other_item in analysis:
                 if other_item.analysis_spec.get("RuleID", "") != base_id:
                     continue
                 found_base_detection = other_item.analysis_spec
                 found_base_path = other_item.dir_name
+                found_base_tests = other_item.analysis_spec.get("Tests")
                 break
+            # inherit the tests from the base if we dont have any
+            if "Tests" not in analysis_spec and found_base_tests:
+                analysis_spec["Tests"] = found_base_tests
             if not found_base_detection:
                 base_lookup = lookup_base_detection(base_id, backend)
                 if "body" in base_lookup:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -956,9 +956,8 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
             if "body" in found_base_detection:
                 detection_args["body"] = found_base_detection.get("body")
             else:
-                found_base_path: str = found_base_path
                 detection_args["path"] = os.path.join(
-                    found_base_path, found_base_detection["Filename"]
+                    found_base_path, found_base_detection["Filename"]  # type: ignore
                 )
         elif is_simple_detection(analysis_spec):
             # skip tests when the body is empty

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -944,13 +944,16 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments
             if not found_base_detection:
                 logging.warning(
                     "Skipping Derived Detection '%s', could not lookup base detection '%s'",
-                    analysis_spec.get("RuleID"), base_id
+                    analysis_spec.get("RuleID"),
+                    base_id,
                 )
                 continue
             if "body" in found_base_detection:
                 detection_args["body"] = found_base_detection.get("body")
             else:
-                detection_args["path"] = os.path.join(found_base_path, found_base_detection["Filename"])
+                detection_args["path"] = os.path.join(
+                    found_base_path, found_base_detection["Filename"]
+                )
         elif is_simple_detection(analysis_spec):
             # skip tests when the body is empty
             if not analysis_spec.get("body"):

--- a/tests/fixtures/derived_without_base/derived.yml
+++ b/tests/fixtures/derived_without_base/derived.yml
@@ -1,0 +1,9 @@
+AnalysisType: rule
+RuleID: 'Sus.Login.Derived'
+BaseDetection: 'Sus.Login.Base'
+Severity: High
+Enabled: true
+Tests:
+    - ExpectedResult: false
+      Log: {}
+      Name: t1

--- a/tests/fixtures/tests_can_be_inherited/base.py
+++ b/tests/fixtures/tests_can_be_inherited/base.py
@@ -1,0 +1,4 @@
+def rule(event):
+    if event.get("operationName") == "Sign-in activity":
+        return True
+    return False

--- a/tests/fixtures/tests_can_be_inherited/base.yml
+++ b/tests/fixtures/tests_can_be_inherited/base.yml
@@ -1,0 +1,21 @@
+AnalysisType: rule
+Description: This rule alerts for suspicious login activity
+DisplayName: 'Suspicious Logins'
+Enabled: false
+Runbook: Examine other activities done by this user to determine whether or not activity is suspicious.
+Severity: Medium
+DedupPeriodMinutes: 60
+LogTypes:
+  - AWS.CloudTrail
+  - Azure.Audit
+RuleID: 'Sus.Login.Base'
+Threshold: 1
+Filename: base.py
+Tests:
+    - ExpectedResult: false
+      Log: {}
+      Name: t1
+    - ExpectedResult: true
+      Log:
+        operationName: "Sign-in activity"
+      Name: t2

--- a/tests/fixtures/tests_can_be_inherited/derive.yml
+++ b/tests/fixtures/tests_can_be_inherited/derive.yml
@@ -1,0 +1,5 @@
+AnalysisType: rule
+RuleID: 'Sus.Login.Derived'
+BaseDetection: 'Sus.Login.Base'
+Severity: High
+Enabled: true

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -729,6 +729,24 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
+    
+    def test_can_inherit_tests_from_base(self):
+        import sys
+        from io import StringIO
+
+        old_stdout = sys.stdout
+        sys.stdout = mystdout = StringIO()
+        with Pause(self.fs):
+            file_path = f"{FIXTURES_PATH}/tests_can_be_inherited"
+            args = pat.setup_parser().parse_args(f"test " f"--path " f" {file_path}".split())
+            return_code, invalid_specs = pat.test_analysis(args)
+        sys.stdout = old_stdout
+        assert_equal(return_code, 0)
+        assert_equal(len(invalid_specs), 0)
+        stdout_str = mystdout.getvalue()
+        assert_equal(stdout_str.count("[PASS] t1"), 2)
+        assert_equal(stdout_str.count("[PASS] t2"), 2)
+
     def test_bulk_validate_happy_path(self):
         backend = MockBackend()
         backend.supports_bulk_validate = mock.MagicMock(return_value=True)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -724,7 +724,7 @@ class TestPantherAnalysisTool(TestCase):
                 args = pat.setup_parser().parse_args(f"test " f"--path " f" {file_path}".split())
                 return_code, invalid_specs = pat.test_analysis(args, backend=backend)
                 warning_logs = logging_mocks["warning"].call_args.args
-                # assert that we were able to look up the base of this derived detection
+                # assert that we skipped because we could not lookup base
                 assert_true(any("Skipping Derived Detection" in s for s in warning_logs))
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -680,14 +680,13 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_can_retrieve_base_detection_for_test(self):
         import logging
+
         with Pause(self.fs):
             file_path = f"{FIXTURES_PATH}/derived_without_base"
             backend = MockBackend()
             backend.get_rule_body = mock.MagicMock(
                 return_value=BackendResponse(
-                    data=GetRuleBodyResponse(
-                        body="def rule(_):\n\treturn False"
-                    ),
+                    data=GetRuleBodyResponse(body="def rule(_):\n\treturn False"),
                     status_code=200,
                 )
             )
@@ -705,6 +704,7 @@ class TestPantherAnalysisTool(TestCase):
 
     def test_logs_warning_if_cannot_retrieve_base(self):
         import logging
+
         with Pause(self.fs):
             file_path = f"{FIXTURES_PATH}/derived_without_base"
             backend = MockBackend()
@@ -729,7 +729,6 @@ class TestPantherAnalysisTool(TestCase):
         assert_equal(return_code, 0)
         assert_equal(len(invalid_specs), 0)
 
-    
     def test_can_inherit_tests_from_base(self):
         import sys
         from io import StringIO


### PR DESCRIPTION
### Background

We wish to add testing support to derived detections, and therefore PAT test must take derived detections into account.


<High level overview here>

### Changes

* PAT test can lookup base detections if its referenced in a derived detection that is being tested
* PAT test can test overrides of a derived detection
* PAT test can inherit base test cases if no overrides are provided

### Testing

* added unit tests
* tested manually in dev env with PAT
