### PR TITLE
fix feature flags not checking for lambda exception

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -378,7 +378,10 @@ def upload_zip(
                 flags_params = FeatureFlagsParams(
                     flags=[FeatureFlagWithDefault(flag=ENABLE_CORRELATION_RULES_FLAG)]
                 )
-                if not backend.feature_flags(flags_params).data.flags[0].treatment:
+                try:
+                    if not backend.feature_flags(flags_params).data.flags[0].treatment:
+                        del resp_dict["correlation_rules"]
+                except BaseException:
                     del resp_dict["correlation_rules"]
 
                 logging.info("API Response:\n%s", json.dumps(resp_dict, indent=4))

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -381,6 +381,7 @@ def upload_zip(
                 try:
                     if not backend.feature_flags(flags_params).data.flags[0].treatment:
                         del resp_dict["correlation_rules"]
+                # pylint: disable=broad-except
                 except BaseException:
                     del resp_dict["correlation_rules"]
 


### PR DESCRIPTION
### Background

if user is using the old lambda client, this will throw an exception, breaking the upload.

<High level overview here>

### Changes

* we check for this exception and catch it

### Testing

* <Testing steps>
