### PR TITLE
updates mock values to always process as a string to align with enterprise behavior.

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1443,11 +1443,18 @@ def _run_tests(  # pylint: disable=too-many-arguments
             mocks = unit_test.get("Mocks")
             mock_methods: Dict[str, Any] = {}
             if mocks:
-                mock_methods = {
-                    each_mock["objectName"]: MagicMock(return_value=each_mock["returnValue"])
-                    for each_mock in mocks
-                    if "objectName" in each_mock and "returnValue" in each_mock
-                }
+                for each_mock in mocks:
+                    if "objectName" in each_mock and "returnValue" in each_mock:
+                        key = each_mock["objectName"]
+                        value = each_mock["returnValue"]
+                        if isinstance(value, bool):
+                            value = json.dumps(value)
+                        if not isinstance(key, str):
+                            raise KeyError("objectName must be a string value for mocks")
+                        if not isinstance(value, str):
+                            raise KeyError("returnValue must be a string for mocks")
+                        mock_methods[key] = value
+
             test_case: Mapping = entry
             if detection.detection_type.upper() != TYPE_POLICY.upper():
                 test_case = PantherEvent(entry, analysis_data_models.get(log_type))

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -45,7 +45,7 @@ from datetime import datetime
 from distutils.util import strtobool  # pylint: disable=E0611, E0401
 from importlib.abc import Loader
 from typing import Any, DefaultDict, Dict, List, Tuple, Type
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 from uuid import uuid4
 
 import botocore
@@ -136,6 +136,7 @@ from panther_analysis_tool.schemas import (
 from panther_analysis_tool.util import (
     BackendNotFoundException,
     add_path_to_filename,
+    convert_mocks,
     convert_unicode,
     is_correlation_rule,
     is_simple_detection,
@@ -1441,19 +1442,7 @@ def _run_tests(  # pylint: disable=too-many-arguments
             entry = unit_test.get("Resource") or unit_test["Log"]
             log_type = entry.get("p_log_type", "")
             mocks = unit_test.get("Mocks")
-            mock_methods: Dict[str, Any] = {}
-            if mocks:
-                for each_mock in mocks:
-                    if "objectName" in each_mock and "returnValue" in each_mock:
-                        key = each_mock["objectName"]
-                        value = each_mock["returnValue"]
-                        if isinstance(value, bool):
-                            value = json.dumps(value)
-                        if not isinstance(key, str):
-                            raise KeyError("objectName must be a string value for mocks")
-                        if not isinstance(value, str):
-                            raise KeyError("returnValue must be a string for mocks")
-                        mock_methods[key] = value
+            mock_methods: Dict[str, Any] = convert_mocks(mocks)
 
             test_case: Mapping = entry
             if detection.detection_type.upper() != TYPE_POLICY.upper():

--- a/panther_analysis_tool/util.py
+++ b/panther_analysis_tool/util.py
@@ -18,6 +18,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import argparse
+import json
 import logging
 import os
 import re
@@ -25,6 +26,7 @@ from functools import reduce
 from importlib import util as import_util
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TextIO, Tuple
+from unittest.mock import MagicMock
 
 import boto3
 import requests
@@ -252,3 +254,20 @@ def log_and_write_to_file(msgs: List[str], filename: TextIO) -> None:
     for msg in msgs:
         filename.write(msg + "\n")
         logging.info(msg)
+
+
+def convert_mocks(mocks: Any) -> Dict[str, Any]:
+    mock_methods: Dict[str, Any] = {}
+    if mocks:
+        for each_mock in mocks:
+            if "objectName" in each_mock and "returnValue" in each_mock:
+                key = each_mock["objectName"]
+                value = each_mock["returnValue"]
+                if isinstance(value, bool):
+                    value = json.dumps(value)
+                if not isinstance(key, str):
+                    raise KeyError("objectName must be a string value for mocks")
+                if not isinstance(value, str):
+                    raise KeyError("returnValue must be a string for mocks")
+                mock_methods[key] = MagicMock(return_value=value)
+    return mock_methods


### PR DESCRIPTION
### Background
Today if a mock is set as a bool value PAT treats the mock as a bool. But when we upload the detection to enterprise it gets converted to a string, which can create conflicting unit test results between local PAT and panther enterprise.


### Changes

* Updates PAT mocking logic to treat bools as a string the same way enterprise does today

### Testing
* Manual testing was done to verify this behavior
