### PR TITLE
Omit rules with Configuration Required Tag from Pack check

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1316,7 +1316,9 @@ def check_packs(args: argparse.Namespace) -> Tuple[int, str]:
             if is_simple_pack != is_simple_rule:
                 # simple rules should be in simple packs
                 continue
-            requires_configuration = [x for x in detection.analysis_spec.get("Tags", []) if "Configuration Required" in x]
+            requires_configuration = [
+                x for x in detection.analysis_spec.get("Tags", []) if "Configuration Required" in x
+            ]
             if requires_configuration:
                 # skip detections that require configuration
                 continue

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1316,6 +1316,10 @@ def check_packs(args: argparse.Namespace) -> Tuple[int, str]:
             if is_simple_pack != is_simple_rule:
                 # simple rules should be in simple packs
                 continue
+            requires_configuration = [x for x in detection.analysis_spec.get("Tags", []) if "Configuration Required" in x]
+            if requires_configuration:
+                # skip detections that require configuration
+                continue
             # remove leading ./
             # ./some-dir -> some-dir
             dir_name = detection.dir_name.strip("./")


### PR DESCRIPTION
### Background

We need to ignore Rules that contain the `Configuration Required` from Pack checks. This will also require that Packs containing these rules already be updated to not include these rules.

### Changes

* Ignores Rules that contain the `Configuration Required` Tag

### Testing

* Tests pass as expected
