### PR TITLE
adding correlation rules to async bulk upload graphql

### DIFF
--- a/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
+++ b/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
@@ -21,12 +21,15 @@ query status($input: ID!) {
             queries {
                 ...UploadStatisticDetails
             }
+            correlationRules {
+                ...UploadStatisticDetails
+            }
         }
     }
 }
 
 fragment UploadStatisticDetails on UploadStatistics {
-  modified
-  new
-  total
+    modified
+    new
+    total
 }

--- a/panther_analysis_tool/backend/graphql/bulk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/bulk_upload.graphql
@@ -1,28 +1,31 @@
 mutation UploadDetections($input: UploadDetectionEntitiesInput!) {
-  uploadDetectionEntities(input: $input) {
-    dataModels {
-      ...UploadStatisticDetails
+    uploadDetectionEntities(input: $input) {
+        dataModels {
+            ...UploadStatisticDetails
+        }
+        globalHelpers {
+            ...UploadStatisticDetails
+        }
+        lookupTables {
+            ...UploadStatisticDetails
+        }
+        policies {
+            ...UploadStatisticDetails
+        }
+        rules {
+            ...UploadStatisticDetails
+        }
+        queries {
+            ...UploadStatisticDetails
+        }
+        correlationRules {
+            ...UploadStatisticDetails
+        }
     }
-    globalHelpers {
-      ...UploadStatisticDetails
-    }
-    lookupTables {
-      ...UploadStatisticDetails
-    }
-    policies {
-      ...UploadStatisticDetails
-    }
-    rules {
-      ...UploadStatisticDetails
-    }
-    queries {
-      ...UploadStatisticDetails
-    }
-  }
 }
 
 fragment UploadStatisticDetails on UploadStatistics {
-  modified
-  new
-  total
+    modified
+    new
+    total
 }


### PR DESCRIPTION
### Background

Correlation rule statistics were being returned from bulk upload, but the data wasn't actually being populated. 

### Changes

* Added correlation rules to both types of bulk upload

### Testing

* Manually tested
