### PR TITLE
Ignore package-lock and package JSON files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,4 +67,3 @@ coverage.xml
 .vscode
 
 *.orig
-.panther_settings.yml

--- a/.panther_settings.yml
+++ b/.panther_settings.yml
@@ -1,0 +1,3 @@
+ignore_files:
+  - "package-lock.json"
+  - "package.json"


### PR DESCRIPTION
### Background

JSON files are considered by PAT as detections and need to be explicitly ignored in order to avoid commands like `panther_analysis_tool test` to parse them as tests.

This PR makes PAT ignore `package-lock.json` and `package.json`, which will be introduced by [this](https://github.com/panther-labs/panther-analysis/pull/1153) PR in panther-analysis in order to install and manage the YAML/Markdown formatter.

### Changes

* Removes `.panther_settings.yml` from .gitignore
* Ignores `package-lock.json` and `package.json` files

### Testing

* CI
