### PR TITLE
Add colors to test output

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -53,6 +53,7 @@ import dateutil.parser
 import jsonschema
 import requests
 import schema
+from colorama import Fore, Style
 from dynaconf import Dynaconf, Validator
 from gql.transport.aiohttp import log as aiohttp_logger
 from jsonschema.validators import Draft202012Validator
@@ -685,7 +686,10 @@ def upload_assets_github(upload_url: str, headers: dict, release_dir: str) -> in
 
 
 def load_analysis(
-    path: str, ignore_table_names: bool, valid_table_names: List[str], ignore_files: List[str]
+    path: str,
+    ignore_table_names: bool,
+    valid_table_names: List[str],
+    ignore_files: List[str],
 ) -> Tuple[Any, List[Any]]:
     """Loads each policy or rule into memory.
 
@@ -956,7 +960,8 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-m
 
         if is_correlation_rule(analysis_spec):
             logging.warning(
-                "Skipping Correlation Rule '%s', testing not supported", analysis_spec.get("RuleID")
+                "Skipping Correlation Rule '%s', testing not supported",
+                analysis_spec.get("RuleID"),
             )
             continue
 
@@ -1536,8 +1541,9 @@ def _run_tests(  # pylint: disable=too-many-arguments
 def _print_test_result(
     detection: Detection, test_result: TestResult, failed_tests: DefaultDict[str, list]
 ) -> None:
-    status_pass = "PASS"  # nosec
-    status_fail = "FAIL"
+    status_pass = Fore.GREEN + "PASS" + Style.RESET_ALL  # nosec
+    status_fail = Fore.RED + "FAIL" + Style.RESET_ALL  # nosec
+
     if test_result.passed:
         outcome = status_pass
     else:


### PR DESCRIPTION
### Background

Adds ASCII color codes on `PASS` and `FAIL` outputs of the `test` command.

### Changes

![Screenshot 2024-03-28 at 7 33 55 PM](https://github.com/panther-labs/panther_analysis_tool/assets/1270063/1acc8bd8-9858-425e-a846-0a1def383dfe)

### Testing

* CI
