### PR TITLE
update schemas to support cr unit tests

### DIFF
--- a/panther_analysis_tool/detection_schemas/analysis_config_schema.json
+++ b/panther_analysis_tool/detection_schemas/analysis_config_schema.json
@@ -22,6 +22,37 @@
         "Selectors"
       ]
     },
+    "CorrelationRuleTestCaseMatch": {
+      "patternProperties": {
+        ".*": {
+          "items": {
+            "type": "integer"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "CorrelationRuleTestCaseOutput": {
+      "properties": {
+        "ID": {
+          "type": "string"
+        },
+        "Matches": {
+          "patternProperties": {
+            ".*": {
+              "$ref": "#/$defs/CorrelationRuleTestCaseMatch"
+            }
+          },
+          "type": "object"
+        }
+      },
+      "additionalProperties": false,
+      "type": "object",
+      "required": [
+        "ID"
+      ]
+    },
     "DynamicSeverity": {
       "properties": {
         "ChangeTo": {
@@ -1101,9 +1132,6 @@
                     "RuleID": {
                       "type": "string"
                     },
-                    "SignalMatch": {
-                      "type": "string"
-                    },
                     "MinMatchCount": {
                       "type": "integer"
                     },
@@ -1115,7 +1143,10 @@
                     }
                   },
                   "additionalProperties": false,
-                  "type": "object"
+                  "type": "object",
+                  "required": [
+                    "RuleID"
+                  ]
                 },
                 "type": "array"
               },
@@ -1212,9 +1243,6 @@
                     "RuleID": {
                       "type": "string"
                     },
-                    "SignalMatch": {
-                      "type": "string"
-                    },
                     "MinMatchCount": {
                       "type": "integer"
                     },
@@ -1226,7 +1254,10 @@
                     }
                   },
                   "additionalProperties": false,
-                  "type": "object"
+                  "type": "object",
+                  "required": [
+                    "RuleID"
+                  ]
                 },
                 "type": "array"
               },
@@ -1599,7 +1630,13 @@
           "$ref": "#/$defs/Mocks"
         },
         "Log": true,
-        "Resource": true
+        "Resource": true,
+        "RuleOutputs": {
+          "items": {
+            "$ref": "#/$defs/CorrelationRuleTestCaseOutput"
+          },
+          "type": "array"
+        }
       },
       "additionalProperties": false,
       "type": "object",

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -242,6 +242,18 @@ CORRELATION_RULE_SCHEMA = Schema(
         Optional("Tags"): [str],
         Optional("Reports"): {str: list},
         Optional("CreateAlert"): bool,
+        Optional("Tests"): [
+            {
+                "Name": str,
+                "ExpectedResult": bool,
+                "RuleOutputs": [
+                    {
+                        "ID": str,
+                        Optional("Matches"): object,
+                    }
+                ],
+            }
+        ],
     },
     ignore_extra_keys=False,
 )

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -6,6 +6,7 @@ from schema import SchemaError
 
 from panther_analysis_tool.schemas import (
     ANALYSIS_CONFIG_SCHEMA,
+    CORRELATION_RULE_SCHEMA,
     DATA_MODEL_SCHEMA,
     LOG_TYPE_REGEX,
     MOCK_SCHEMA,
@@ -13,7 +14,6 @@ from panther_analysis_tool.schemas import (
     RULE_SCHEMA,
     SAVED_QUERY_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
-    CORRELATION_RULE_SCHEMA,
 )
 
 
@@ -569,7 +569,7 @@ class TestPATSchemas(unittest.TestCase):
                                 "ID": "First",
                                 "Matches": {
                                     "p_actor": {
-                                        "jane.smith": [1,2,3,4],
+                                        "jane.smith": [1, 2, 3, 4],
                                     },
                                 },
                             },
@@ -583,8 +583,7 @@ class TestPATSchemas(unittest.TestCase):
                             },
                         ],
                     },
-                ]
-
+                ],
             }
         )
 

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -13,6 +13,7 @@ from panther_analysis_tool.schemas import (
     RULE_SCHEMA,
     SAVED_QUERY_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
+    CORRELATION_RULE_SCHEMA,
 )
 
 
@@ -494,6 +495,96 @@ class TestPATSchemas(unittest.TestCase):
                 "Filename": "hmm",
                 "PolicyID": "h",
                 "Severity": "Info",
+            }
+        )
+
+    def test_correlation_rule_unit_tests(self):
+        # works without unit tests
+        CORRELATION_RULE_SCHEMA.validate(
+            {
+                "AnalysisType": "correlation_rule",
+                "DisplayName": "Example Correlation Rule",
+                "Enabled": True,
+                "RuleID": "My.Correlation.Rule",
+                "Severity": "High",
+                "Detection": [
+                    {
+                        "Sequence": [
+                            {
+                                "ID": "First",
+                                "RuleID": "Okta.Global.MFA.Disabled",
+                                "MinMatchCount": 7,
+                            },
+                            {
+                                "ID": "Second",
+                                "RuleID": "Okta.Support.Access",
+                                "MinMatchCount": 1,
+                            },
+                        ],
+                        "LookbackWindowMinutes": 15,
+                        "Schedule": {
+                            "RateMinutes": 5,
+                            "TimeoutMinutes": 3,
+                        },
+                    }
+                ],
+            }
+        )
+
+        # works with unit tests
+        CORRELATION_RULE_SCHEMA.validate(
+            {
+                "AnalysisType": "correlation_rule",
+                "DisplayName": "Example Correlation Rule",
+                "Enabled": True,
+                "RuleID": "My.Correlation.Rule",
+                "Severity": "High",
+                "Detection": [
+                    {
+                        "Sequence": [
+                            {
+                                "ID": "First",
+                                "RuleID": "Okta.Global.MFA.Disabled",
+                                "MinMatchCount": 7,
+                            },
+                            {
+                                "ID": "Second",
+                                "RuleID": "Okta.Support.Access",
+                                "MinMatchCount": 1,
+                            },
+                        ],
+                        "LookbackWindowMinutes": 15,
+                        "Schedule": {
+                            "RateMinutes": 5,
+                            "TimeoutMinutes": 3,
+                        },
+                    }
+                ],
+                "Tests": [
+                    {
+                        "Name": "alert because the other fields are absent",
+                        "ExpectedResult": True,
+                        "RuleOutputs": [
+                            {
+                                "ID": "First",
+                                "Matches": {
+                                    "p_actor": {
+                                        "jane.smith": [1,2,3,4],
+                                    },
+                                },
+                            },
+                            {
+                                "ID": "Second",
+                                "Matches": {
+                                    "p_enrichment.endpoint_mapping.aid.assigned_user": {
+                                        "jane.smith": [6],
+                                    },
+                                },
+                            },
+                        ],
+                    },
+                ]
+
             }
         )
 


### PR DESCRIPTION
### Background

we wish to support PAT testing CR unit tests in the future. this PR is a primer for that: supporting the schema prior to adding explicit test support.

<High level overview here>

### Changes

* schema update to support CR unit tests

### Testing

- uploading a CR yaml file w/ unit tests works:


```
Panther CLI Test Summary
	Path: ./rules/mycorr
	Passed: 1
	Failed: 0
	Invalid: 0

[INFO][root]: Zipping analysis items in ./rules/mycorr to .
[INFO][root]: Uploading items to Panther
[INFO][root]: API Response:
{
    "rules": {
...
```
