### PR TITLE
Ignore dependabot.yml

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -340,7 +340,7 @@ def load_analysis_specs_ex(
     """
     # setup a list of paths to ensure we do not import the same files
     # multiple times, which can happen when testing from root directory without filters
-    ignored_normalized = ["package.json", "package-lock.json"]
+    ignored_normalized = ["dependabot.yml", "package.json", "package-lock.json"]
     for file in ignore_files:
         ignored_normalized.append(os.path.normpath(file))
 


### PR DESCRIPTION
### Background

We have a pattern for ignoring files and this needs to be extended to include `dependabot.yml` since PAT treats any JSON or YAML files as valid files.

### Changes

* Adds `dependabot.yml` to `ignored_normalized`

### Testing

* Checks pass as expected
