### PR TITLE
Use harden-runner Action for all Workflows

### DIFF
--- a/.github/workflows/asana.yml
+++ b/.github/workflows/asana.yml
@@ -6,11 +6,17 @@ on:
       - opened
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   update_task_on_pr_open:
     if: ${{ github.event.pull_request.state == 'open' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - uses: panther-labs/github-asana-action@v3.0.7
         name: Adds a comment to the related Asana task whenever a PR has been opened
         with:
@@ -30,6 +36,9 @@ jobs:
     if: ${{ github.event.pull_request.state == 'closed' }}
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - uses: panther-labs/github-asana-action@v3.0.7
         name: Adds a comment to the related Asana task when the PR is closed
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,15 @@
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Setup Python

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,13 @@ jobs:
     steps:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            ipinfo.io:443
+            pypi.org:443
       - name: Checkout
         uses: actions/checkout@v3.1.0
       - name: Setup Python

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -6,10 +6,16 @@ on:
     branches:
       - '*' # Match all branches
 
+permissions:
+  contents: write
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
+      - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+        with:
+          egress-policy: audit
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -15,7 +15,12 @@ jobs:
     steps:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
         with:
-          egress-policy: audit
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            files.pythonhosted.org:443
+            github.com:443
+            pypi.org:443
       - name: Checkout
         uses: actions/checkout@v3
 

--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -3,11 +3,18 @@ name: Build, Test, Publish Github and PyPI Releases
 on:
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   publish_github_release_and_pypi:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      with:
+        egress-policy: audit
+
     - name: Check out the repository
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/version_bump_pr.yml
+++ b/.github/workflows/version_bump_pr.yml
@@ -8,11 +8,17 @@ on:
         required: true
         default: 'minor'
 
+permissions:
+  contents: write
+
 jobs:
   version_bump_pr:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0
+      with:
+        egress-policy: audit
     - name: Check out the repository
       uses: actions/checkout@v3
       with:

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -580,8 +580,6 @@ def backend_response_failed(resp: BackendResponse) -> bool:
     return resp.status_code >= 400 or resp.data.get("statusCode", 0) >= 400
 
 
-
-
 def to_bulk_upload_response(data: Any) -> BackendResponse[BulkUploadResponse]:
     default_stats = {"total": 0, "new": 0, "modified": 0}
     return BackendResponse(

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -580,6 +580,8 @@ def backend_response_failed(resp: BackendResponse) -> bool:
     return resp.status_code >= 400 or resp.data.get("statusCode", 0) >= 400
 
 
+
+
 def to_bulk_upload_response(data: Any) -> BackendResponse[BulkUploadResponse]:
     default_stats = {"total": 0, "new": 0, "modified": 0}
     return BackendResponse(


### PR DESCRIPTION
### Background

Relates to EPD-368

This PR adds StepSecurity's `harden-runners` Action to all of our Workflows. 

We'll run egress blocks for Workflows that can be validated within a PR and audits for the other Workflows. Once the latter run at least once, we can implement the recommendations in a follow-up PR.

### Changes

- Adds the `harden-runner` Action to all Workflows

### Testing

- Checks pass as expected
