### PR TITLE
Sign fmt commits via gitsign

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   fmt:
@@ -23,6 +24,8 @@ jobs:
             pypi.org:443
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
+      
+      - uses: chainguard-dev/actions/setup-gitsign@e82b4e5ae10182af72972addcb3fedf7454621c8
 
       - name: Setup Python
         uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d
@@ -59,6 +62,7 @@ jobs:
           else
             echo "Committing auto-formatted files"
             git push origin HEAD:$BRANCH
+            gitsign verify $(git rev-parse HEAD) --certificate-identity-regexp="https://github.com/${{ github.repository }}/*" --certificate-oidc-issuer="https://token.actions.githubusercontent.com"
           fi
         env:
           GH_TOKEN: ${{ secrets.PANTHER_BOT_AUTOMATION_TOKEN }}

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -21,6 +21,7 @@ jobs:
           allowed-endpoints: >
             files.pythonhosted.org:443
             github.com:443
+            objects.githubusercontent.com:443
             pypi.org:443
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29


### PR DESCRIPTION
This PR uses Chainguard's `setup-gitsign` action to sign our `fmt` commits via Gitsign so that we can verify that `panther-bot-automation` did indeed make the change.

Trust, but verify!