### PR TITLE
Allow fulcio egress for Gitsign

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -20,6 +20,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             files.pythonhosted.org:443
+            fulcio.sigstore.dev:443
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443


### PR DESCRIPTION
### Background

This was blocked by StepSecurity:
![CleanShot 2024-06-06 at 07 16 35@2x](https://github.com/panther-labs/panther_analysis_tool/assets/20933572/f9e6b2dc-37ac-407d-8308-e138cdbe441c)

We need this for Gitsign to work correctly.

Relates to: EPD-429

### Changes

* Allows egress for `fulcio.sigstore.dev` via HTTPS

### Testing

* N/A
