### PR TITLE
More egress allows for fmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ permissions:
 
 jobs:
   ci:
+    if: ${{ github.actor != 'panther-bot-automation' }}
     runs-on: ubuntu-latest
     steps:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -12,6 +12,7 @@ permissions:
 
 jobs:
   fmt:
+    if: ${{ github.actor != 'panther-bot-automation' }}
     runs-on: ubuntu-latest
     steps:
       - uses: step-security/harden-runner@f086349bfa2bd1361f7909c78558e816508cdc10 # v2.8.0

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -24,6 +24,8 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
+            rekor.sigstore.dev
+            tuf-repo-cdn.sigstore.dev:443
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29
       

--- a/panther_analysis_tool/log_schemas/user_defined.py
+++ b/panther_analysis_tool/log_schemas/user_defined.py
@@ -37,9 +37,6 @@ from panther_analysis_tool.backend.client import (
     UpdateSchemaParams,
 )
 
-
-
-
 logger = logging.getLogger(__file__)
 
 

--- a/panther_analysis_tool/log_schemas/user_defined.py
+++ b/panther_analysis_tool/log_schemas/user_defined.py
@@ -37,6 +37,9 @@ from panther_analysis_tool.backend.client import (
     UpdateSchemaParams,
 )
 
+
+
+
 logger = logging.getLogger(__file__)
 
 


### PR DESCRIPTION
### Background

We need a couple more allows for Gitsign to work properly. This PR adds them.

### Changes

* Allows `rekor.sigstore.dev` and `tuf-repo-cdn.sigstore.dev:443`

### Testing

* [`96ed7e9` (#517)](https://github.com/panther-labs/panther_analysis_tool/pull/517/commits/96ed7e9ab54f5a5e7c101b05512ed47a96057092)