### PR TITLE
Add missed port to egress rule

### DIFF
--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -25,7 +25,7 @@ jobs:
             github.com:443
             objects.githubusercontent.com:443
             pypi.org:443
-            rekor.sigstore.dev
+            rekor.sigstore.dev:443
             tuf-repo-cdn.sigstore.dev:443
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29


### PR DESCRIPTION
### Background

Good catch @c0nfleis!

### Changes

* Adds `443` to the `rekor.sigstore.dev` rule

### Testing

* N/A
