### PR TITLE
fix direct lambda upload

### DIFF
--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -585,13 +585,41 @@ def to_bulk_upload_response(data: Any) -> BackendResponse[BulkUploadResponse]:
     return BackendResponse(
         status_code=200,
         data=BulkUploadResponse(
-            rules=BulkUploadStatistics(**data.get("rules", default_stats)),
-            queries=BulkUploadStatistics(**data.get("queries", default_stats)),
-            policies=BulkUploadStatistics(**data.get("policies", default_stats)),
-            data_models=BulkUploadStatistics(**data.get("dataModels", default_stats)),
-            lookup_tables=BulkUploadStatistics(**data.get("lookupTables", default_stats)),
-            global_helpers=BulkUploadStatistics(**data.get("globalHelpers", default_stats)),
-            correlation_rules=BulkUploadStatistics(**data.get("correlationRules", default_stats)),
+            rules=BulkUploadStatistics(
+                total=data.get("rules", default_stats).get("total"),
+                new=data.get("rules", default_stats).get("new"),
+                modified=data.get("rules", default_stats).get("modified"),
+            ),
+            queries=BulkUploadStatistics(
+                total=data.get("queries", default_stats).get("total"),
+                new=data.get("queries", default_stats).get("new"),
+                modified=data.get("queries", default_stats).get("modified"),
+            ),
+            policies=BulkUploadStatistics(
+                total=data.get("policies", default_stats).get("total"),
+                new=data.get("policies", default_stats).get("new"),
+                modified=data.get("policies", default_stats).get("modified"),
+            ),
+            data_models=BulkUploadStatistics(
+                total=data.get("data_models", default_stats).get("total"),
+                new=data.get("data_models", default_stats).get("new"),
+                modified=data.get("data_models", default_stats).get("modified"),
+            ),
+            lookup_tables=BulkUploadStatistics(
+                total=data.get("lookup_tables", default_stats).get("total"),
+                new=data.get("lookup_tables", default_stats).get("new"),
+                modified=data.get("lookup_tables", default_stats).get("modified"),
+            ),
+            global_helpers=BulkUploadStatistics(
+                total=data.get("global_helpers", default_stats).get("total"),
+                new=data.get("global_helpers", default_stats).get("new"),
+                modified=data.get("global_helpers", default_stats).get("modified"),
+            ),
+            correlation_rules=BulkUploadStatistics(
+                total=data.get("correlation_rules", default_stats).get("total"),
+                new=data.get("correlation_rules", default_stats).get("new"),
+                modified=data.get("correlation_rules", default_stats).get("modified"),
+            ),
         ),
     )
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -340,9 +340,9 @@ def upload_analysis(backend: BackendClient, args: argparse.Namespace) -> Tuple[i
         for idx, archive in enumerate(zip_analysis_chunks(args)):
             batch_idx = idx + 1
             logging.info("Uploading Batch %d...", batch_idx)
-            return_code, _ = upload_zip(backend, args, archive, False)
+            return_code, err = upload_zip(backend, args, archive, False)
             if return_code != 0:
-                return return_code, ""
+                return return_code, err
             logging.info("Uploaded Batch %d", batch_idx)
 
         return 0, ""

--- a/tests/unit/panther_analysis_tool/backend/test_lambda_client.py
+++ b/tests/unit/panther_analysis_tool/backend/test_lambda_client.py
@@ -71,7 +71,15 @@ class TestLambdaClient(TestCase):
 
     def test_bulk_upload(self) -> None:
         mock_lambda_res = _make_mock_response_with_string_body(
-            http_status=200, payload={"policies": {"total": 2, "new": 0, "modified": 0}}
+            http_status=200, payload={
+                "rules": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+                "queries": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+                "policies": {"total": 2, "new": 0, "modified": 0, "deleted": 0},
+                "data_models": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+                "lookup_tables": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+                "global_helpers": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+                "correlation_rules": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+            }
         )
 
         with mock.patch("boto3.client", return_value=MockBoto(invoke_returns=mock_lambda_res)):

--- a/tests/unit/panther_analysis_tool/backend/test_lambda_client.py
+++ b/tests/unit/panther_analysis_tool/backend/test_lambda_client.py
@@ -71,7 +71,8 @@ class TestLambdaClient(TestCase):
 
     def test_bulk_upload(self) -> None:
         mock_lambda_res = _make_mock_response_with_string_body(
-            http_status=200, payload={
+            http_status=200,
+            payload={
                 "rules": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
                 "queries": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
                 "policies": {"total": 2, "new": 0, "modified": 0, "deleted": 0},
@@ -79,7 +80,7 @@ class TestLambdaClient(TestCase):
                 "lookup_tables": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
                 "global_helpers": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
                 "correlation_rules": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
-            }
+            },
         )
 
         with mock.patch("boto3.client", return_value=MockBoto(invoke_returns=mock_lambda_res)):


### PR DESCRIPTION
### Background

Direct lambda invoke bulk upload was failing because we added a new output field `deleted`. Also fixes a problem when running in batch mode where we were not printing out the error if the upload failed.

### Changes

fix it

### Testing

Added unit test and manually confirmed I can upload with this change
