### PR TITLE
updates release job to run integration test instead of unit tests

### DIFF
--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Build and Run PAT Tests
       run: |
         pipenv run pip install --root-user-action=ignore dist/panther_analysis_tool-*.tar.gz
-        pipenv run make test
+        pipenv run make integration
 
     - name: Create Github Release
       run: |


### PR DESCRIPTION
### Background
We still need to get to the bottom of the unit test issue we've been seeing. In the mean time we'll update our release job to run integration tests instead.

### Changes

* updates release job to run integration tests

### Testing

* [x] manually verify that build step with just the integration logic will work
