### PR TITLE
fix batch chunking issue

### DIFF
--- a/panther_analysis_tool/zip_chunker.py
+++ b/panther_analysis_tool/zip_chunker.py
@@ -105,8 +105,9 @@ class ChunkFiles:
             self.files.append(filename)
             if parent is None:
                 self.primary_files.append(filename)
-            else:
-                self.related_files[parent] = filename
+            
+        if parent:
+            self.related_files[parent] = filename
 
     def can_chunk_further(self) -> bool:
         if self.chunk.max_size is None:

--- a/panther_analysis_tool/zip_chunker.py
+++ b/panther_analysis_tool/zip_chunker.py
@@ -105,7 +105,7 @@ class ChunkFiles:
             self.files.append(filename)
             if parent is None:
                 self.primary_files.append(filename)
-            
+
         if parent:
             self.related_files[parent] = filename
 

--- a/tests/unit/panther_analysis_tool/test_zip_chunker.py
+++ b/tests/unit/panther_analysis_tool/test_zip_chunker.py
@@ -1,28 +1,33 @@
 import unittest
 
-from panther_analysis_tool.zip_chunker import ChunkFiles, ZipChunk, create_additional_chunks_if_needed
+from panther_analysis_tool.zip_chunker import (
+    ChunkFiles,
+    ZipChunk,
+    create_additional_chunks_if_needed,
+)
+
 
 class TestZipChunks(unittest.TestCase):
     def test_shared_parents_matches(self) -> None:
         # tests that a single file can have multiple parents
         chunk = ChunkFiles(ZipChunk(patterns=["*"]))
-        chunk.add_file('file1')
-        chunk.add_file('shared_dep', 'file1')
-        chunk.add_file('file2')
-        chunk.add_file('shared_dep', 'file2')
+        chunk.add_file("file1")
+        chunk.add_file("shared_dep", "file1")
+        chunk.add_file("file2")
+        chunk.add_file("shared_dep", "file2")
 
-        self.assertEqual(chunk.related_files, {'file1': 'shared_dep', 'file2': 'shared_dep'})
+        self.assertEqual(chunk.related_files, {"file1": "shared_dep", "file2": "shared_dep"})
 
     def test_additional_chunks_does_not_split_shared_files(self) -> None:
         # tests that a single file can have multiple parents
         chunk = ChunkFiles(ZipChunk(patterns=["*"], max_size=1))
-        chunk.add_file('file1')
-        chunk.add_file('shared_dep', 'file1')
-        chunk.add_file('file2')
-        chunk.add_file('shared_dep', 'file2')
+        chunk.add_file("file1")
+        chunk.add_file("shared_dep", "file1")
+        chunk.add_file("file2")
+        chunk.add_file("shared_dep", "file2")
 
         chunks = create_additional_chunks_if_needed([chunk])
 
         self.assertEqual(len(chunks), 2)
-        self.assertEqual(chunks[0].files, ['file1', 'shared_dep'])
-        self.assertEqual(chunks[1].files, ['file2', 'shared_dep'])
+        self.assertEqual(chunks[0].files, ["file1", "shared_dep"])
+        self.assertEqual(chunks[1].files, ["file2", "shared_dep"])

--- a/tests/unit/panther_analysis_tool/test_zip_chunker.py
+++ b/tests/unit/panther_analysis_tool/test_zip_chunker.py
@@ -1,0 +1,28 @@
+import unittest
+
+from panther_analysis_tool.zip_chunker import ChunkFiles, ZipChunk, create_additional_chunks_if_needed
+
+class TestZipChunks(unittest.TestCase):
+    def test_shared_parents_matches(self) -> None:
+        # tests that a single file can have multiple parents
+        chunk = ChunkFiles(ZipChunk(patterns=["*"]))
+        chunk.add_file('file1')
+        chunk.add_file('shared_dep', 'file1')
+        chunk.add_file('file2')
+        chunk.add_file('shared_dep', 'file2')
+
+        self.assertEqual(chunk.related_files, {'file1': 'shared_dep', 'file2': 'shared_dep'})
+
+    def test_additional_chunks_does_not_split_shared_files(self) -> None:
+        # tests that a single file can have multiple parents
+        chunk = ChunkFiles(ZipChunk(patterns=["*"], max_size=1))
+        chunk.add_file('file1')
+        chunk.add_file('shared_dep', 'file1')
+        chunk.add_file('file2')
+        chunk.add_file('shared_dep', 'file2')
+
+        chunks = create_additional_chunks_if_needed([chunk])
+
+        self.assertEqual(len(chunks), 2)
+        self.assertEqual(chunks[0].files, ['file1', 'shared_dep'])
+        self.assertEqual(chunks[1].files, ['file2', 'shared_dep'])

--- a/tests/unit/panther_analysis_tool/test_zip_chunker.py
+++ b/tests/unit/panther_analysis_tool/test_zip_chunker.py
@@ -19,7 +19,7 @@ class TestZipChunks(unittest.TestCase):
         self.assertEqual(chunk.related_files, {"file1": "shared_dep", "file2": "shared_dep"})
 
     def test_additional_chunks_does_not_split_shared_files(self) -> None:
-        # tests that a single file can have multiple parents
+        # tests that a shared file is included in both chunks
         chunk = ChunkFiles(ZipChunk(patterns=["*"], max_size=1))
         chunk.add_file("file1")
         chunk.add_file("shared_dep", "file1")


### PR DESCRIPTION
### Background

This addresses an issue with batch chunking where dependent files that were referenced by more than one analysis item might not be included in the upload chunk.

### Changes

* fix to the chunker to track files that have more than one parent

### Testing

* Added unit tests that were failing before I fixed this issue
