### PR TITLE
Fix filesystem-related errors in test suite

### DIFF
--- a/.github/workflows/test_release_publish.yml
+++ b/.github/workflows/test_release_publish.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Install Build and Run PAT Tests
       run: |
         pipenv run pip install --root-user-action=ignore dist/panther_analysis_tool-*.tar.gz
-        pipenv run make integration
+        pipenv run make test integration
 
     - name: Create Github Release
       run: |

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 .PHONY: ci
-ci: lint integration
+ci: lint test integration
 
 .PHONY: install-pipenv
 install-pipenv:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -391,7 +391,7 @@ def upload_zip(
 ) -> Tuple[int, str]:
     # extract max retries we should handle
     max_retries = args.max_retries
-    
+
     # Validate and limit max_retries
     if max_retries < 0:
         logging.warning("Invalid max-retries value %s, using 0 instead", max_retries)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -392,7 +392,7 @@ def upload_zip(
     # extract max retries we should handle
     max_retries = args.max_retries
 
-    # Validate and limit max_retries
+    # Validate and limit max_retries 
     if max_retries < 0:
         logging.warning("Invalid max-retries value %s, using 0 instead", max_retries)
         max_retries = 0

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -392,7 +392,7 @@ def upload_zip(
     # extract max retries we should handle
     max_retries = args.max_retries
 
-    # Validate and limit max_retries 
+    # Validate and limit max_retries
     if max_retries < 0:
         logging.warning("Invalid max-retries value %s, using 0 instead", max_retries)
         max_retries = 0

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -391,6 +391,14 @@ def upload_zip(
 ) -> Tuple[int, str]:
     # extract max retries we should handle
     max_retries = args.max_retries
+    
+    # Validate and limit max_retries
+    if max_retries < 0:
+        logging.warning("Invalid max-retries value %s, using 0 instead", max_retries)
+        max_retries = 0
+    elif max_retries > 10:
+        logging.warning("max-retries value %s exceeds maximum of 10, using 10 instead", max_retries)
+        max_retries = 10
 
     with open(archive, "rb") as analysis_zip:
         logging.info("Uploading items to Panther")
@@ -2044,7 +2052,6 @@ def setup_parser() -> argparse.ArgumentParser:
         help="Retry to upload on a failure for a maximum number of times",
         default=10,
         type=int,
-        choices=range(1, 11),
         required=False,
     )
 

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -389,7 +389,7 @@ def print_upload_summary(response: dict) -> None:
 def upload_zip(
     backend: BackendClient, args: argparse.Namespace, archive: str, use_async: bool
 ) -> Tuple[int, str]:
-    # extract max retries we should handle
+    # Extract max retries we should handle
     max_retries = args.max_retries
 
     # Validate and limit max_retries

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -74,12 +74,12 @@ class TestPantherAnalysisTool(TestCase):
         # Data Models and Globals write the source code to a file and import it as module.
         # This will not work if we are simply writing on the in-memory, fake filesystem.
         # We thus copy to a temporary space the Data Model Python modules.
-        
+
         # Ensure _DATAMODEL_FOLDER is a directory, not a file
         if os.path.exists(_DATAMODEL_FOLDER) and not os.path.isdir(_DATAMODEL_FOLDER):
             os.remove(_DATAMODEL_FOLDER)
         os.makedirs(_DATAMODEL_FOLDER, exist_ok=True)
-            
+
         self.data_model_modules = [
             os.path.join(
                 DETECTIONS_FIXTURES_PATH, "valid_analysis/data_models/GSuite.Events.DataModel.py"

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -74,6 +74,12 @@ class TestPantherAnalysisTool(TestCase):
         # Data Models and Globals write the source code to a file and import it as module.
         # This will not work if we are simply writing on the in-memory, fake filesystem.
         # We thus copy to a temporary space the Data Model Python modules.
+        
+        # Ensure _DATAMODEL_FOLDER is a directory, not a file
+        if os.path.exists(_DATAMODEL_FOLDER) and not os.path.isdir(_DATAMODEL_FOLDER):
+            os.remove(_DATAMODEL_FOLDER)
+        os.makedirs(_DATAMODEL_FOLDER, exist_ok=True)
+            
         self.data_model_modules = [
             os.path.join(
                 DETECTIONS_FIXTURES_PATH, "valid_analysis/data_models/GSuite.Events.DataModel.py"
@@ -104,7 +110,9 @@ class TestPantherAnalysisTool(TestCase):
     def tearDown(self) -> None:
         with Pause(self.fs):
             for data_model_module in self.data_model_modules:
-                os.remove(os.path.join(_DATAMODEL_FOLDER, os.path.split(data_model_module)[-1]))
+                file_path = os.path.join(_DATAMODEL_FOLDER, os.path.split(data_model_module)[-1])
+                if os.path.exists(file_path):
+                    os.remove(file_path)
 
     def test_valid_json_policy_spec(self):
         for spec_filename, _, loaded_spec, _ in pat.load_analysis_specs(


### PR DESCRIPTION
### Problem
Tests were failing due to filesystem issues when running on macOS:
_DATAMODEL_FOLDER was sometimes created as a file instead of a directory
The tearDown method was trying to remove files without checking if they exist
The --max-retries argument was too restrictive, causing test failures with negative values

### Changes
Added checks to ensure _DATAMODEL_FOLDER is a directory, removing it if it's a file
Added proper directory creation with os.makedirs(_DATAMODEL_FOLDER, exist_ok=True)
Improved tearDown robustness by checking if files exist before removing them
Removed the choices constraint from --max-retries argument
Added validation in the upload_zip function to handle negative values and values over 10
Reverts https://github.com/panther-labs/panther_analysis_tool/pull/532 and https://github.com/panther-labs/panther_analysis_tool/pull/536

### Testing
All tests now pass successfully. These changes improve test reliability across different environments where the temp directory might be in different states.