### PR TITLE
Make PAT work better on Windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,12 @@ setup(
     url="https://github.com/panther-labs/panther_analysis_tool",
     download_url=f"https://github.com/panther-labs/panther_analysis_tool/archive/v{PAT_VERSION}.tar.gz",
     keywords=["Security", "CLI"],
-    scripts=["bin/panther_analysis_tool", "bin/pat"],
+    entry_points={
+        "console_scripts": [
+            "panther_analysis_tool=panther_analysis_tool.main:run",
+            "pat=panther_analysis_tool.main:run",
+        ],
+    },
     install_requires=install_requires,
     classifiers=[
         "Development Status :: 4 - Beta",


### PR DESCRIPTION
### Background

PAT doesn't work well on Windows because you can't natively execute python files; you have to invoke them using the python executable. This is troublesome because you then have to fully specify the path to PAT each time.

Python has a nice feature called `entry_points` which replaces the `scripts` configuration value and is more cross-platform friendly. By using this config parameter instead of scripts, `pip` knows to generate an EXE file for PAT as part of the installation process. You can then add the EXE to your path and call PAT from the command line anywhere in Windows.

Should fix #143!

### Changes

* swapped `scripts` with `entry_points` in setup.py

### Testing

* Tried installing from source in a Windows VM and it worked great!
