### PR TITLE
Allow JSON files to be used for LUT data

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -392,24 +392,6 @@ def load_analysis_specs_ex(
                                 yaml_ctx=yaml,
                                 error=err,
                             )
-                if fnmatch(filename, "*.json"):
-                    with open(spec_filename, "r", encoding="utf-8") as spec_file_obj:
-                        try:
-                            yield LoadAnalysisSpecsResult(
-                                spec_filename=spec_filename,
-                                relative_path=relative_path,
-                                analysis_spec=json.load(spec_file_obj),
-                                yaml_ctx=yaml,
-                                error=None,
-                            )
-                        except ValueError as err:
-                            yield LoadAnalysisSpecsResult(
-                                spec_filename=spec_filename,
-                                relative_path=relative_path,
-                                analysis_spec=None,
-                                yaml_ctx=yaml,
-                                error=err,
-                            )
 
 
 def to_relative_path(filename: str) -> str:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -2460,8 +2460,8 @@ def run() -> None:
         sys.exit(1)
     except Exception as err:  # pylint: disable=broad-except
         # Catch arbitrary exceptions without printing help message
-        logging.warning('Unhandled exception: "%s"', err, exc_info=err, stack_info=True)
-        logging.debug("Full error traceback:", exc_info=err)
+        logging.warning('Unhandled exception: "%s"', err)
+        logging.debug("Full error traceback:", exc_info=err, stack_info=True)
         sys.exit(1)
 
     if return_code == 1:


### PR DESCRIPTION
### Background

**THIS IS POTENTIALLY A BREAKING CHANGE.**

PAT currently has the undocumented behaviour of treating all JSON files in the repo as YAML files, meaning they will cause errors when they are missing fields like `AnalysisType`. This is problematic for a few reasons, since JSON files are often used for vscode configs, PAT configs, and most importantly, as data files for LUTs.

This behaviour seems to be left over from the original implementation of Panther with CI/CD. There's been no justification since in the code base for why we support this, and none of our guides or documentation suggest customers use JSON spec files over YAML spec files. Therefore it seems safe to assume this is leftover functionality from a time when we envisioned customers may wish to choose between YAML and JSON, and is not necessary in today's ecosystem.

By removing this behaviour, we can enable customers to use JSON files for various purposes within their repo, without needing to use an alternate file ending or listing them as excluded files in their PAT commands. Any customers who have been using JSON in their uploads may be affected by this, but since this feature is undocumented, and therefore not really supported, the chance of users doing this is slim.

I also cleaned up the error reporting slightly for missing LUT data files.

### Changes

* remove spec loading from JSON files
* remove traceback from default error message when a LUT file is missing the associated data file
* add the traceback from the above point to the debug-level log generated for the same instance

### Testing

* unit tests pass
* manual testing for uploading a json file work
