### PR TITLE
ASK 2325: Remove DedupPeriodMinutes limits

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1200,6 +1200,24 @@ def classify_analysis(
                     )
             analysis_ids.append(analysis_id)
 
+            # Raise warnings for dedup minutes
+            if "DedupPeriodMinutes" in analysis_spec:
+                if analysis_spec["DedupPeriodMinutes"] == 0:
+                    logging.warning(
+                        "DedupPeriodMinutes is set to 0 for %s. "
+                        "This will be ignored by the backend. "
+                        "If you want to disable dedup, "
+                        "alter the `dedup` function to return 'p_row_id' instead.",
+                        analysis_id,
+                    )
+                elif analysis_spec["DedupPeriodMinutes"] < 5:
+                    logging.warning(
+                        "DedupPeriodMinutes for %s is less than 5. "
+                        "This is below Panther's DedupPeriodMinutes threshold, "
+                        "and will be treated as '5' upon upload.",
+                        analysis_id,
+                    )
+
             classified_analysis = ClassifiedAnalysis(
                 analysis_spec_filename, dir_name, analysis_spec
             )

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1203,20 +1203,20 @@ def classify_analysis(
             # Raise warnings for dedup minutes
             if "DedupPeriodMinutes" in analysis_spec:
                 if analysis_spec["DedupPeriodMinutes"] == 0:
-                    logging.warning(
-                        "DedupPeriodMinutes is set to 0 for %s. "
+                    msg = (
+                        f"DedupPeriodMinutes is set to 0 for {analysis_id}. "
                         "This will be ignored by the backend. "
                         "If you want to disable dedup, "
-                        "alter the `dedup` function to return 'p_row_id' instead.",
-                        analysis_id,
+                        "alter the `dedup` function to return 'p_row_id' instead."
                     )
+                    logging.warning(msg)
                 elif analysis_spec["DedupPeriodMinutes"] < 5:
-                    logging.warning(
-                        "DedupPeriodMinutes for %s is less than 5. "
+                    msg = (
+                        f"DedupPeriodMinutes for {analysis_id} is less than 5. "
                         "This is below Panther's DedupPeriodMinutes threshold, "
-                        "and will be treated as '5' upon upload.",
-                        analysis_id,
+                        "and will be treated as '5' upon upload."
                     )
+                    logging.warning(msg)
 
             classified_analysis = ClassifiedAnalysis(
                 analysis_spec_filename, dir_name, analysis_spec

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -25,13 +25,6 @@ class QueryScheduleSchema(Schema):
         return data
 
 
-# Add validation function for DedupPeriodMinutes
-def validate_dedup_period(minutes: int) -> int:
-    if minutes < 5 or minutes > 1440:
-        raise SchemaError("DedupPeriodMinutes must be between 5 and 1440")
-    return minutes
-
-
 NAME_ID_VALIDATION_REGEX = Regex(r"^[^<>&\"%]+$")
 RESOURCE_TYPE_REGEX = Regex(
     r"^AWS\.(ACM\.Certificate|CloudFormation\.Stack|CloudTrail\.Meta|CloudTrail|CloudWatch"
@@ -154,7 +147,7 @@ RULE_SCHEMA = Schema(
         Or("LogTypes", "ScheduledQueries", only_one=True): And([str], [LOG_TYPE_REGEX]),
         "Severity": Or("Info", "Low", "Medium", "High", "Critical"),
         Optional("Description"): str,
-        Optional("DedupPeriodMinutes"): And(int, validate_dedup_period),
+        Optional("DedupPeriodMinutes"): int,
         Optional("InlineFilters"): object,
         Optional("DisplayName"): And(str, NAME_ID_VALIDATION_REGEX),
         Optional("OnlyUseBaseRiskScore"): bool,
@@ -194,7 +187,7 @@ DERIVED_SCHEMA = Schema(
         Optional("Enabled"): bool,
         Optional("Severity"): Or("Info", "Low", "Medium", "High", "Critical"),
         Optional("Description"): str,
-        Optional("DedupPeriodMinutes"): And(int, validate_dedup_period),
+        Optional("DedupPeriodMinutes"): int,
         Optional("InlineFilters"): object,
         Optional("DisplayName"): And(str, NAME_ID_VALIDATION_REGEX),
         Optional("OnlyUseBaseRiskScore"): bool,

--- a/tests/unit/panther_analysis_tool/test_schemas.py
+++ b/tests/unit/panther_analysis_tool/test_schemas.py
@@ -693,67 +693,6 @@ class TestPATSchemas(unittest.TestCase):
                 }
             )
 
-    def test_dedup_period_valid_values(self):
-        """Test that DedupPeriodMinutes accepts values between 5 and 1440."""
-        # Test valid values for standard rule
-        valid_rule = {
-            "AnalysisType": "rule",
-            "Enabled": True,
-            "Filename": "test.py",
-            "RuleID": "Test.Rule",
-            "LogTypes": ["AWS.CloudTrail"],
-            "Severity": "Medium",
-            "DedupPeriodMinutes": 5,  # Minimum valid value
-        }
-        RULE_SCHEMA.validate(valid_rule)
-
-        valid_rule["DedupPeriodMinutes"] = 60  # Common value
-        RULE_SCHEMA.validate(valid_rule)
-
-        valid_rule["DedupPeriodMinutes"] = 1440  # Maximum valid value
-        RULE_SCHEMA.validate(valid_rule)
-
-        # Test valid values for derived rule
-        valid_derived_rule = {
-            "AnalysisType": "rule",
-            "RuleID": "Test.DerivedRule",
-            "BaseDetection": "Test.BaseRule",
-            "DedupPeriodMinutes": 60,  # Valid value
-        }
-        DERIVED_SCHEMA.validate(valid_derived_rule)
-
-    def test_dedup_period_invalid_values(self):
-        """Test that DedupPeriodMinutes rejects values outside of 5-1440 range."""
-        # Test invalid values for standard rule
-        invalid_rule = {
-            "AnalysisType": "rule",
-            "Enabled": True,
-            "Filename": "test.py",
-            "RuleID": "Test.Rule",
-            "LogTypes": ["AWS.CloudTrail"],
-            "Severity": "Medium",
-            "DedupPeriodMinutes": 4,  # Below minimum
-        }
-        with self.assertRaises(SchemaError) as context:
-            RULE_SCHEMA.validate(invalid_rule)
-        self.assertIn("must be between 5 and 1440", str(context.exception))
-
-        invalid_rule["DedupPeriodMinutes"] = 1441  # Above maximum
-        with self.assertRaises(SchemaError) as context:
-            RULE_SCHEMA.validate(invalid_rule)
-        self.assertIn("must be between 5 and 1440", str(context.exception))
-
-        # Test invalid values for derived rule
-        invalid_derived_rule = {
-            "AnalysisType": "rule",
-            "RuleID": "Test.DerivedRule",
-            "BaseDetection": "Test.BaseRule",
-            "DedupPeriodMinutes": 2000,  # Invalid value
-        }
-        with self.assertRaises(SchemaError) as context:
-            DERIVED_SCHEMA.validate(invalid_derived_rule)
-        self.assertIn("must be between 5 and 1440", str(context.exception))
-
 
 # This class was generated in whole or in part by GitHub Copilot
 class TestSimpleDetectionSchemas(unittest.TestCase):


### PR DESCRIPTION
### Background

[A previous PR](https://github.com/panther-labs/panther_analysis_tool/pull/600) added enforced upper and lower bounds for the `DedupPeriodMinutes` spec field to match the options in the UI. However, despite the limits in the UI, Panther's backend doesn't disallow any positive values.

The backend behaviour is:

- `DedupPeriodMinutes` < 5: Silently treat it as 5
- `DedupPeriodMinutes` > 1440: Dedup according to the provided value; i.e. backend enforces no upper limit

This PR removes the failed upload for breaching either limit, and adds a warning if the specified dedup value is under 5 to inform the customer the behaviour they experience may be unexpected.

Internal: See [ASK-2325](https://panther-labs.atlassian.net/browse/ASK-2325) for more context.

### Changes

* remove schema validation of `DedupPeriodMinutes`
* add warning if `DedupPeriodMinutes` is too low

### Testing

* removed schema tests for `DedupPeriodMinutes`
* added unit tests for `classify_analysis` to ensure warning is raised
* added other unit tests for `classify_analysis` since there weren't any to start


[ASK-2325]: https://panther-labs.atlassian.net/browse/ASK-2325?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ