### PR TITLE
eliminate import race condition for tempdir

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 import re
+import tempfile
 from fnmatch import fnmatch
 from importlib.abc import Loader
 from typing import Any, Dict, Iterator, List, Optional, Tuple
@@ -16,14 +17,14 @@ from ruamel.yaml import YAML
 from ruamel.yaml import parser as YAMLParser
 from ruamel.yaml import scanner as YAMLScanner
 
-from panther_analysis_tool.backend.client import BackendError
-from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import (
+    BackendError,
     GetRuleBodyParams,
     TestCorrelationRuleParams,
     TranspileFiltersParams,
     TranspileToPythonParams,
 )
+from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.constants import (
     BACKEND_FILTERS_ANALYSIS_SPEC_KEY,
     DATA_MODEL_LOCATION,
@@ -744,3 +745,6 @@ def load_module(filename: str) -> Tuple[Any, Any]:
         print("\t[ERROR] Error loading module, skipping\n")
         return None, err
     return module, None
+
+def get_tmp_helper_module_location() -> str:
+    return os.path.join(tempfile.gettempdir(), "panther-path", "globals")

--- a/panther_analysis_tool/constants.py
+++ b/panther_analysis_tool/constants.py
@@ -1,6 +1,4 @@
 import importlib.metadata
-import os
-import tempfile
 from typing import Dict, Final
 
 from schema import Schema
@@ -32,8 +30,6 @@ PACKS_PATH_PATTERN = "*/packs"
 POLICIES_PATH_PATTERN = "*policies*"
 QUERIES_PATH_PATTERN = "*queries*"
 RULES_PATH_PATTERN = "*rules*"
-TMP_HELPER_MODULE_LOCATION = os.path.join(tempfile.gettempdir(), "panther-path", "globals")
-
 
 class AnalysisTypes:
     DATA_MODEL = "datamodel"

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -40,20 +40,11 @@ from typing import (
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
 
-import typer
-from typer_config import use_yaml_config
-from typing_extensions import Annotated
-
-from panther_analysis_tool import analysis_utils
-from panther_analysis_tool.directory import setup_temp
-
-# this is needed at this location so each process can have its own temp directory
-setup_temp()
-
 import botocore
 import dateutil.parser
 import requests
 import schema
+import typer
 from colorama import Fore, Style
 from gql.transport.aiohttp import log as aiohttp_logger
 from panther_core.data_model import DataModel
@@ -70,8 +61,10 @@ from panther_core.testing import (
 from ruamel.yaml import YAML, SafeConstructor, constructor
 from ruamel.yaml import parser as YAMLParser
 from ruamel.yaml import scanner as YAMLScanner
+from typer_config import use_yaml_config
+from typing_extensions import Annotated
 
-from panther_analysis_tool import cli_output
+from panther_analysis_tool import analysis_utils, cli_output
 from panther_analysis_tool import util as pat_utils
 from panther_analysis_tool.analysis_utils import (
     classify_analysis,
@@ -88,12 +81,10 @@ from panther_analysis_tool.backend.client import (
     BackendError,
     BulkUploadMultipartError,
     BulkUploadParams,
-)
-from panther_analysis_tool.backend.client import Client as BackendClient
-from panther_analysis_tool.backend.client import (
     FeatureFlagsParams,
     FeatureFlagWithDefault,
 )
+from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.command import (
     benchmark,
     bulk_delete,
@@ -124,7 +115,6 @@ from panther_analysis_tool.constants import (
     CONFIG_FILE,
     ENABLE_CORRELATION_RULES_FLAG,
     PACKAGE_NAME,
-    TMP_HELPER_MODULE_LOCATION,
     VERSION_STRING,
     AnalysisTypes,
 )
@@ -135,6 +125,7 @@ from panther_analysis_tool.core.definitions import (
 )
 from panther_analysis_tool.core.parse import Filter, parse_filter
 from panther_analysis_tool.destination import FakeDestination
+from panther_analysis_tool.directory import setup_temp
 from panther_analysis_tool.enriched_event_generator import EnrichedEventGenerator
 from panther_analysis_tool.log_schemas import user_defined
 from panther_analysis_tool.schemas import LOOKUP_TABLE_SCHEMA
@@ -986,19 +977,20 @@ def test_analysis(
 
 
 def setup_global_helpers(global_analysis: List[ClassifiedAnalysis]) -> None:
+    helper_location = analysis_utils.get_tmp_helper_module_location()
     # ensure the directory does not exist, else clear it
     cleanup_global_helpers(global_analysis)
-    os.makedirs(TMP_HELPER_MODULE_LOCATION)
+    os.makedirs(helper_location)
     # setup temp dir for globals
-    if TMP_HELPER_MODULE_LOCATION not in sys.path:
-        sys.path.append(TMP_HELPER_MODULE_LOCATION)
+    if helper_location not in sys.path:
+        sys.path.append(helper_location)
     # place globals in temp dir
     for item in global_analysis:
         dir_name = item.dir_name
         analysis_spec = item.analysis_spec
         analysis_id = analysis_spec["GlobalID"]
         source = os.path.join(dir_name, analysis_spec["Filename"])
-        destination = os.path.join(TMP_HELPER_MODULE_LOCATION, f"{analysis_id}.py")
+        destination = os.path.join(helper_location, f"{analysis_id}.py")
         shutil.copyfile(source, destination)
         # force reload of the module as necessary
         if analysis_id in sys.modules:
@@ -1010,6 +1002,7 @@ def setup_global_helpers(global_analysis: List[ClassifiedAnalysis]) -> None:
 
 
 def cleanup_global_helpers(global_analysis: List[ClassifiedAnalysis]) -> None:
+    helper_location = analysis_utils.get_tmp_helper_module_location()
     # clear the modules from the modules cache
     for item in global_analysis:
         analysis_id = item.analysis_spec["GlobalID"]
@@ -1017,8 +1010,8 @@ def cleanup_global_helpers(global_analysis: List[ClassifiedAnalysis]) -> None:
         if analysis_id in sys.modules:
             del sys.modules[analysis_id]
     # ensure the directory does not exist, else clear it
-    if os.path.exists(TMP_HELPER_MODULE_LOCATION):
-        shutil.rmtree(TMP_HELPER_MODULE_LOCATION)
+    if os.path.exists(helper_location):
+        shutil.rmtree(helper_location)
 
 
 def setup_data_models(
@@ -2398,6 +2391,7 @@ def check_packs_command(
 
 # pylint: disable=too-many-statements
 def run() -> None:
+    setup_temp()
     # setup logger and print version info as necessary
     logging.basicConfig(
         format="%(levelname)s: %(message)s",


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

* Makes the temp helper directory path accessed via a function instead of a global so that its functionality is not determined by import order.
* Moves `setup_temp()` to the first thing in `run()` instead of at the import level so it is not tied to import order. So it run after imports now but before any function calls. 
* Nothing else uses `tempdir` or `gettempdir()` so this should be the only change needed.

### Testing

No idea how to test this. But `pipenv run pat test --path ./rules` ran just fine. 
