### PR TITLE
yaml formatter

### DIFF
--- a/panther_analysis_tool/core/yaml_formatter.py
+++ b/panther_analysis_tool/core/yaml_formatter.py
@@ -1,0 +1,151 @@
+import io
+from typing import Any, Iterable
+
+from ruamel.yaml import YAML
+from ruamel.yaml.comments import CommentedMap, CommentedSeq
+from ruamel.yaml.scalarstring import DoubleQuotedScalarString, FoldedScalarString
+
+from panther_analysis_tool.constants import AnalysisTypes
+
+_yaml = YAML(typ="safe")
+_yaml.indent(mapping=2, sequence=4, offset=2)
+
+_rt_yaml = YAML(typ="rt")
+_rt_yaml.indent(mapping=2, sequence=4, offset=2)
+_rt_yaml.width = 80
+
+
+def analysis_spec_dump(data: Any, sort: bool = True) -> bytes:
+    if isinstance(data, bytes):
+        data = _yaml.load(io.BytesIO(data))
+    elif isinstance(data, str):
+        data = _yaml.load(io.StringIO(data))
+    if sort:
+        data = sort_yaml(data)
+    data = {k: v.strip() if isinstance(v, str) else v for k, v in data.items()}
+    data = analysis_spec_to_ruamel(data)
+    dumped = io.BytesIO()
+    _rt_yaml.dump(data, dumped)
+    return dumped.getvalue()
+
+
+def analysis_spec_to_ruamel(data: Any) -> Any:
+    if not isinstance(data, dict):
+        return data
+
+    match data["AnalysisType"]:
+        case AnalysisTypes.RULE | AnalysisTypes.CORRELATION_RULE | AnalysisTypes.SCHEDULED_RULE:
+            return rule_to_ruamel(data)
+        case AnalysisTypes.GLOBAL:
+            return global_to_ruamel(data)
+        case AnalysisTypes.DATA_MODEL:
+            return datamodel_to_ruamel(data)
+        case AnalysisTypes.POLICY:
+            return policy_to_ruamel(data)
+        case AnalysisTypes.SAVED_QUERY | AnalysisTypes.SCHEDULED_QUERY:
+            return query_to_ruamel(data)
+        case AnalysisTypes.LOOKUP_TABLE:
+            return lookuptable_to_ruamel(data)
+        case _:
+            return data
+
+
+def rule_to_ruamel(data: Any) -> Any:
+    for key, value in data.items():
+        if key in ["Description", "Runbook"]:
+            if isinstance(value, str):
+                data[key] = FoldedScalarString(value)
+        if key in ["Tests"]:
+            format_tests(value)
+        if key in ["DisplayName", "RuleID"]:
+            data[key] = DoubleQuotedScalarString(value)
+    return data
+
+
+def global_to_ruamel(data: Any) -> Any:
+    for key, value in data.items():
+        if key in ["Description"]:
+            if isinstance(value, str):
+                data[key] = FoldedScalarString(value)
+        if key in ["GlobalID"]:
+            data[key] = DoubleQuotedScalarString(value)
+    return data
+
+
+def datamodel_to_ruamel(data: Any) -> Any:
+    for key, value in data.items():
+        if key in ["DataModelID", "DisplayName"]:
+            data[key] = DoubleQuotedScalarString(value)
+    return data
+
+
+def policy_to_ruamel(data: Any) -> Any:
+    for key, value in data.items():
+        if key in ["Description", "Runbook"]:
+            if isinstance(value, str):
+                data[key] = FoldedScalarString(value)
+        if key in ["Tests"]:
+            format_tests(value)
+        if key in ["PolicyID", "DisplayName"]:
+            data[key] = DoubleQuotedScalarString(value)
+    return data
+
+
+def query_to_ruamel(data: Any) -> Any:
+    for key, value in data.items():
+        if key in ["Query"]:
+            if isinstance(value, str):
+                data[key] = FoldedScalarString(value)
+        if key in ["Tests"]:
+            format_tests(value)
+        if key in ["QueryName"]:
+            data[key] = DoubleQuotedScalarString(value)
+    return data
+
+
+def lookuptable_to_ruamel(data: Any) -> Any:
+    for key, value in data.items():
+        if key in ["LookupName"]:
+            data[key] = DoubleQuotedScalarString(value)
+    return data
+
+
+def format_tests(tests: Iterable[Any]) -> Any:
+    for test in tests:
+        if isinstance(test, dict):
+            for key, value in test.items():
+                if key in ["Log", "Resource"]:
+                    test[key] = to_inline_map(value)
+
+            format_tests(test)
+        elif isinstance(test, list):
+            format_tests(test)
+
+
+def to_inline_map(data: Any) -> Any:
+    if isinstance(data, dict):
+        m = CommentedMap()
+        m.fa.set_flow_style()
+        m.fa.set_block_style()
+        for k, v in data.items():
+            m[to_inline_map(k)] = to_inline_map(v)
+        return m
+    elif isinstance(data, list):
+        s = CommentedSeq()
+        for v in data:
+            s.append(to_inline_map(v))
+        return s
+    elif isinstance(data, str):
+        return DoubleQuotedScalarString(data)
+    return data
+
+
+def sort_yaml(data: Any) -> Any:
+    if isinstance(data, dict):
+        keys = sorted(data.keys())
+        return {k: sort_yaml(data[k]) for k in keys}
+    elif isinstance(data, list):
+        return [sort_yaml(v) for v in data]
+    elif isinstance(data, tuple):
+        return tuple(sort_yaml(v) for v in data)
+    return data

--- a/tests/unit/panther_analysis_tool/core/test_yaml_formatter.py
+++ b/tests/unit/panther_analysis_tool/core/test_yaml_formatter.py
@@ -1,0 +1,207 @@
+import unittest
+
+from ruamel import yaml
+
+from panther_analysis_tool.core import yaml_formatter
+
+
+class TestYamlFormatter(unittest.TestCase):
+    def test_sort_yaml_dict(self) -> None:
+        data = {
+            "b": 1,
+            "a": 2,
+            "c": 3,
+        }
+        self.assertEqual(yaml_formatter.sort_yaml(data), {
+            "a": 2,
+            "b": 1,
+            "c": 3,
+        })
+
+    def test_sort_yaml_list(self) -> None:
+        data = [
+            {"b": 1, "a": 2, "c": 3},
+            {"f": 4, "e": 5, "d": 6},
+            "h",
+            [3,2],
+            (5,4,6),
+            "j",
+        ]
+        self.assertEqual(yaml_formatter.sort_yaml(data), [
+            {"a": 2, "b": 1, "c": 3}, 
+            {"d": 6, "e": 5, "f": 4},
+            "h", 
+            [3,2], 
+            (5,4,6), 
+            "j",
+        ])
+
+    def test_sort_yaml_tuple(self) -> None:
+        data = (
+            {"b": 1, "a": 2, "c": 3},
+            {"f": 4, "e": 5, "d": 6},
+            "h",
+            [3,2],
+            (5,4,6),
+            "j",
+        )
+        self.assertEqual(yaml_formatter.sort_yaml(data), (
+            {"a": 2, "b": 1, "c": 3}, 
+            {"d": 6, "e": 5, "f": 4},
+            "h", 
+            [3,2], 
+            (5,4,6), 
+            "j",
+        ))
+
+    def test_sort_yaml_string(self) -> None:
+        data = "b"
+        self.assertEqual(yaml_formatter.sort_yaml(data), "b")
+
+    def test_sort_yaml_int(self) -> None:
+        data = 1
+        self.assertEqual(yaml_formatter.sort_yaml(data), 1)
+
+    def test_analysis_spec_dump_rule_quotes_rule_id(self) -> None:
+        input_yaml = "AnalysisType: rule\nRuleID: foo.bar.rule\n"
+        expected_yaml = "AnalysisType: rule\nRuleID: \"foo.bar.rule\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_rule_quotes_display_name(self) -> None:
+        input_yaml = "AnalysisType: rule\DisplayName: foo.bar.rule\n"
+        expected_yaml = "AnalysisType: rule\DisplayName: \"foo.bar.rule\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_rule_folds_desc(self) -> None:
+        input_yaml = "AnalysisType: rule\nDescription: foo.bar.rule\n"
+        expected_yaml = "AnalysisType: rule\nDescription: >-\n  foo.bar.rule\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_rule_folds_runbook(self) -> None:
+        input_yaml = "AnalysisType: rule\nRunbook: foo.bar.rule\n"
+        expected_yaml = "AnalysisType: rule\nRunbook: >-\n  foo.bar.rule\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_rule_formats_tests(self) -> None:
+        input_yaml = "AnalysisType: rule\nTests:\n  - Name: Test1\n    ExpectedResult: true\n    Log: {\"a\": \"thing\"}\n"
+        expected_yaml = "AnalysisType: rule\nTests:\n  - ExpectedResult: true\n    Log:\n      \"a\": \"thing\"\n    Name: Test1\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_global_folds_desc(self) -> None:
+        input_yaml = "AnalysisType: global\nDescription: duh\n"
+        expected_yaml = "AnalysisType: global\nDescription: >-\n  duh\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_global_quotes_global_id(self) -> None:
+        input_yaml = "AnalysisType: global\nGlobalID: foo.bar.global\n"
+        expected_yaml = "AnalysisType: global\nGlobalID: \"foo.bar.global\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_datamodel_quotes_id(self) -> None:
+        input_yaml = "AnalysisType: datamodel\nDataModelID: foo.bar.datamodel\n"
+        expected_yaml = "AnalysisType: datamodel\nDataModelID: \"foo.bar.datamodel\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_datamodel_quotes_display_name(self) -> None:
+        input_yaml = "AnalysisType: datamodel\nDisplayName: foo.bar.datamodel\n"
+        expected_yaml = "AnalysisType: datamodel\nDisplayName: \"foo.bar.datamodel\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_policy_quotes_policy_id(self) -> None:
+        input_yaml = "AnalysisType: policy\nPolicyID: foo.bar.policy\n"
+        expected_yaml = "AnalysisType: policy\nPolicyID: \"foo.bar.policy\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_policy_quotes_display_name(self) -> None:
+        input_yaml = "AnalysisType: policy\nDisplayName: foo.bar.policy\n"
+        expected_yaml = "AnalysisType: policy\nDisplayName: \"foo.bar.policy\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_policy_folds_desc(self) -> None:
+        input_yaml = "AnalysisType: policy\nDescription: foo.bar.policy\n"
+        expected_yaml = "AnalysisType: policy\nDescription: >-\n  foo.bar.policy\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_policy_folds_runbook(self) -> None:
+        input_yaml = "AnalysisType: policy\nRunbook: foo.bar.policy\n"
+        expected_yaml = "AnalysisType: policy\nRunbook: >-\n  foo.bar.policy\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_policy_formats_tests(self) -> None:
+        input_yaml = "AnalysisType: policy\nTests:\n  - Name: Test1\n    ExpectedResult: true\n    Log: {\"a\": \"thing\"}\n"
+        expected_yaml = "AnalysisType: policy\nTests:\n  - ExpectedResult: true\n    Log:\n      \"a\": \"thing\"\n    Name: Test1\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_saved_query_quotes_query_name(self) -> None:
+        input_yaml = "AnalysisType: saved_query\nQueryName: foo.bar.query\n"
+        expected_yaml = "AnalysisType: saved_query\nQueryName: \"foo.bar.query\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_saved_query_folds_query(self) -> None:
+        input_yaml = "AnalysisType: saved_query\nQuery: foo.bar.query\n"
+        expected_yaml = "AnalysisType: saved_query\nQuery: >-\n  foo.bar.query\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+    
+    def test_analysis_spec_dump_saved_query_formats_tests(self) -> None:
+        input_yaml = "AnalysisType: saved_query\nTests:\n  - Name: Test1\n    ExpectedResult: true\n    Log: {\"a\": \"thing\"}\n"
+        expected_yaml = "AnalysisType: saved_query\nTests:\n  - ExpectedResult: true\n    Log:\n      \"a\": \"thing\"\n    Name: Test1\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_scheduled_query_quotes_query_name(self) -> None:
+        input_yaml = "AnalysisType: scheduled_query\nQueryName: foo.bar.query\n"
+        expected_yaml = "AnalysisType: scheduled_query\nQueryName: \"foo.bar.query\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+
+    def test_analysis_spec_dump_scheduled_query_folds_query(self) -> None:
+        input_yaml = "AnalysisType: scheduled_query\nQuery: foo.bar.query\n"
+        expected_yaml = "AnalysisType: scheduled_query\nQuery: >-\n  foo.bar.query\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+    
+    def test_analysis_spec_dump_scheduled_query_formats_tests(self) -> None:
+        input_yaml = "AnalysisType: scheduled_query\nTests:\n  - Name: Test1\n    ExpectedResult: true\n    Log: {\"a\": \"thing\"}\n"
+        expected_yaml = "AnalysisType: scheduled_query\nTests:\n  - ExpectedResult: true\n    Log:\n      \"a\": \"thing\"\n    Name: Test1\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+    
+    
+    def test_analysis_spec_dump_lookuptable_quotes_lookup_name(self) -> None:
+        input_yaml = "AnalysisType: lookuptable\nLookupName: foo.bar.lookuptable\n"
+        expected_yaml = "AnalysisType: lookuptable\nLookupName: \"foo.bar.lookuptable\"\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+    
+    
+    def test_analysis_spec_dump_lookuptable_folds_query(self) -> None:
+        input_yaml = "AnalysisType: lookuptable\nQuery: foo.bar.lookuptable\n"
+        expected_yaml = "AnalysisType: lookuptable\nQuery: >-\n  foo.bar.lookuptable\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+    
+    
+    def test_analysis_spec_dump_lookuptable_formats_tests(self) -> None:
+        input_yaml = "AnalysisType: lookuptable\nTests:\n  - Name: Test1\n    ExpectedResult: true\n    Log: {\"a\": \"thing\"}\n"
+        expected_yaml = "AnalysisType: lookuptable\nTests:\n  - ExpectedResult: true\n    Log:\n      \"a\": \"thing\"\n    Name: Test1\n"
+        result = yaml_formatter.analysis_spec_dump(yaml.safe_load(input_yaml)).decode("utf-8")
+        self.assertEqual(result, expected_yaml)
+    
+    
+


### PR DESCRIPTION
### Background

YAML Formatter will allow us to force a particular YAML format for all analysis configurations. This will help reduce merge conflicts. 

### Changes

* new yaml_formatter.py file

### Testing

* unit tests
