### PR TITLE
ci: split into 5 parallel jobs with caching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
@@ -26,6 +28,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
@@ -42,6 +46,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
@@ -58,6 +64,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
@@ -74,6 +82,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Install Poetry
+        run: pipx install poetry
       - name: Setup Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,8 +113,8 @@ jobs:
           cd panther-analysis
           pipenv lock
           pipenv requirements | grep -v 'panther-analysis-tool==' > requirements.ci.txt
-          pipenv install -r requirements.ci.txt
-          pipenv install -e ..
-          pip install schema==0.7.5
+          pipenv run pip install -r requirements.ci.txt
+          pipenv run pip install -e ..
+          pipenv run pip install schema==0.7.5
           pipenv run panther_analysis_tool --version
           pipenv run panther_analysis_tool test --path .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,20 +101,17 @@ jobs:
         run: poetry run panther_analysis_tool test --path tests/fixtures/detections/valid_analysis
       - name: Shallow clone panther-analysis
         run: git clone --depth 1 https://github.com/panther-labs/panther-analysis.git
+      - name: Install pipenv
+        run: pip install pipenv
       - name: Cache pipenv dependencies
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.local/share/virtualenvs
           key: pipenv-${{ hashFiles('panther-analysis/Pipfile.lock') }}
-      - name: Install pipenv
-        run: pip install pipenv
       - name: Run panther-analysis integration tests
         run: |
           cd panther-analysis
-          pipenv lock
-          pipenv requirements | grep -v 'panther-analysis-tool==' > requirements.ci.txt
-          pipenv run pip install -r requirements.ci.txt
+          pipenv install
           pipenv run pip install -e ..
-          pipenv run pip install schema==0.7.5
           pipenv run panther_analysis_tool --version
           pipenv run panther_analysis_tool test --path .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
       - main
   pull_request:
     branches:
-      - "*"
+      - "**"
 
 permissions:
   contents: read
@@ -22,7 +22,7 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.11
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry sync
       - name: Run mypy
@@ -40,7 +40,7 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.11
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry sync
       - name: Run bandit
@@ -58,7 +58,7 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.11
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry sync
       - name: Run pylint
@@ -76,7 +76,7 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.11
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry sync
       - name: Run tests
@@ -94,7 +94,7 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.11
-          cache: 'poetry'
+          cache: "poetry"
       - name: Install dependencies
         run: poetry sync
       - name: Run fixture integration test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,10 @@
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - "*"
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
 
 jobs:
-  ci:
+  mypy:
     if: ${{ github.actor != 'panther-bot-automation' }}
     runs-on: ubuntu-latest
     steps:
@@ -14,7 +14,91 @@ jobs:
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
         with:
           python-version: 3.11
-      - name: Setup Virtual Environment
-        run: make venv
-      - name: Run CLI Tests
-        run: make ci
+          cache: 'poetry'
+      - name: Install dependencies
+        run: poetry sync
+      - name: Run mypy
+        run: poetry run mypy panther_analysis_tool
+
+  bandit:
+    if: ${{ github.actor != 'panther-bot-automation' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Install dependencies
+        run: poetry sync
+      - name: Run bandit
+        run: poetry run bandit -r panther_analysis_tool
+
+  pylint:
+    if: ${{ github.actor != 'panther-bot-automation' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Install dependencies
+        run: poetry sync
+      - name: Run pylint
+        run: poetry run pylint panther_analysis_tool
+
+  test:
+    if: ${{ github.actor != 'panther-bot-automation' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Install dependencies
+        run: poetry sync
+      - name: Run tests
+        run: poetry run pytest --cov=panther_analysis_tool --cov-report=html
+
+  integration:
+    if: ${{ github.actor != 'panther-bot-automation' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - name: Setup Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b
+        with:
+          python-version: 3.11
+          cache: 'poetry'
+      - name: Install dependencies
+        run: poetry sync
+      - name: Run fixture integration test
+        run: poetry run panther_analysis_tool test --path tests/fixtures/detections/valid_analysis
+      - name: Shallow clone panther-analysis
+        run: git clone --depth 1 https://github.com/panther-labs/panther-analysis.git
+      - name: Cache pipenv dependencies
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.local/share/virtualenvs
+          key: pipenv-${{ hashFiles('panther-analysis/Pipfile.lock') }}
+      - name: Install pipenv
+        run: pip install pipenv
+      - name: Run panther-analysis integration tests
+        run: |
+          cd panther-analysis
+          pipenv lock
+          pipenv requirements | grep -v 'panther-analysis-tool==' > requirements.ci.txt
+          pipenv install -r requirements.ci.txt
+          pipenv install -e ..
+          pip install schema==0.7.5
+          pipenv run panther_analysis_tool --version
+          pipenv run panther_analysis_tool test --path .

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,6 @@ fmt: ## Format panther_analysis_tool (black)
 
 .PHONY: install
 install: ## Install dependencies (including dev dependencies) using poetry
-	poetry lock
 	poetry sync
 
 .PHONY: test


### PR DESCRIPTION
## Summary
- Split single sequential CI job into 5 parallel jobs (mypy, bandit, pylint, test, integration)
- Add Poetry dependency caching via `setup-python`'s built-in `cache: 'poetry'`
- Remove redundant `poetry lock` from CI (lockfile is committed)
- Optimize integration test with shallow clone (`--depth 1`) and pipenv dependency caching
- Remove unnecessary `rm -rf panther-analysis` cleanup (runner is ephemeral)

If these changes are approved, I will ask platform to update the required checks (so it no longer is just ci) 

## Test plan
- [ ] Verify all 5 jobs appear in PR checks and start concurrently
- [ ] Verify Poetry cache hits on subsequent runs
- [ ] Verify integration test shallow clone works correctly
- [ ] Verify pipenv cache key is based on Pipfile.lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)