### PR TITLE
feat: add global --output-format json for structured CLI output

### DIFF
--- a/panther_analysis_tool/command/benchmark.py
+++ b/panther_analysis_tool/command/benchmark.py
@@ -51,14 +51,22 @@ class BenchmarkArgs:
     hour: Optional[datetime.datetime]
 
 
-def run(  # pylint: disable=too-many-locals,too-many-return-statements
+def run(  # pylint: disable=too-many-locals,too-many-return-statements,too-many-statements
     backend: BackendClient, args: BenchmarkArgs
 ) -> Tuple[int, str]:
+    json_mode = is_json_mode()
+
     if backend is None or not backend.supports_perf_test():
-        return 1, "Invalid backend. `benchmark` is only supported via API token"
+        msg = "Invalid backend. `benchmark` is only supported via API token"
+        if json_mode:
+            _emit_benchmark_error_json(1, msg)
+        return 1, msg
 
     if args.iterations <= 0:
-        return 1, f"benchmark must perform at least 1 iteration, {args.iterations} requested"
+        msg = f"benchmark must perform at least 1 iteration, {args.iterations} requested"
+        if json_mode:
+            _emit_benchmark_error_json(1, msg)
+        return 1, msg
 
     zip_args = ZipArgs(
         out=args.out,
@@ -71,14 +79,21 @@ def run(  # pylint: disable=too-many-locals,too-many-return-statements
 
     rule_or_err = validate_rule_count(analyses)
     if isinstance(rule_or_err, str):
+        if json_mode:
+            _emit_benchmark_error_json(1, rule_or_err)
         return 1, rule_or_err
 
     log_type, err_msg = validate_log_type(args.log_type, rule_or_err)
     if err_msg is not None or not isinstance(log_type, str):
-        return 1, err_msg or "No log_type found"
+        msg = err_msg or "No log_type found"
+        if json_mode:
+            _emit_benchmark_error_json(1, msg)
+        return 1, msg
 
     hour_or_err = validate_hour(args.hour, log_type, backend)
     if isinstance(hour_or_err, str):
+        if json_mode:
+            _emit_benchmark_error_json(1, hour_or_err)
         return 1, hour_or_err
 
     chunks = chunk_analysis(analyses)
@@ -124,11 +139,21 @@ def run(  # pylint: disable=too-many-locals,too-many-return-statements
     if not logged:
         log_output(args.out, hour_or_err, iterations, rule_or_err, now)
 
-    if is_json_mode():
+    if json_mode:
         _emit_benchmark_json(iterations, rule_or_err, hour_or_err, logged)
         return 0, ""
 
     return 0, ""
+
+
+def _emit_benchmark_error_json(return_code: int, error: str) -> None:
+    """Emit a structured JSON error envelope for the benchmark command."""
+    print(
+        json.dumps(
+            {"command": "benchmark", "return_code": return_code, "status": "error", "error": error},
+            default=str,
+        )
+    )
 
 
 def _emit_benchmark_json(

--- a/panther_analysis_tool/command/benchmark.py
+++ b/panther_analysis_tool/command/benchmark.py
@@ -1,10 +1,11 @@
 import datetime
 import io
+import json
 import sys
 import zipfile
 from dataclasses import dataclass
 from statistics import mean, median
-from typing import List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import dateutil.parser
 
@@ -13,6 +14,7 @@ from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import MetricsParams, PerfTestParams
 from panther_analysis_tool.constants import AnalysisTypes, ReplayStatus
 from panther_analysis_tool.core.parse import Filter
+from panther_analysis_tool.output import is_json_mode
 from panther_analysis_tool.util import log_and_write_to_file
 from panther_analysis_tool.zip_chunker import (
     ZipArgs,
@@ -49,11 +51,9 @@ class BenchmarkArgs:
     hour: Optional[datetime.datetime]
 
 
-def run(  # pylint: disable=too-many-locals
+def run(  # pylint: disable=too-many-locals,too-many-return-statements
     backend: BackendClient, args: BenchmarkArgs
 ) -> Tuple[int, str]:
-    from panther_analysis_tool.main import is_json_mode
-
     if backend is None or not backend.supports_perf_test():
         return 1, "Invalid backend. `benchmark` is only supported via API token"
 
@@ -265,8 +265,8 @@ def validate_hour(
 
     max_data_hour = max(
         data_for_log_type.breakdown,
-        key=data_for_log_type.breakdown.get,
-        default=None,  # type: ignore
+        key=data_for_log_type.breakdown.get,  # type: ignore[arg-type]
+        default=None,
     )
     if max_data_hour is None or data_for_log_type.breakdown[max_data_hour] == 0:
         return err_msg

--- a/panther_analysis_tool/command/benchmark.py
+++ b/panther_analysis_tool/command/benchmark.py
@@ -20,6 +20,9 @@ from panther_analysis_tool.zip_chunker import (
     chunk_analysis,
 )
 
+_HIGHLY_PERFORMANT_MINUTES = 1
+_AT_RISK_TIMEOUT_MINUTES = 10
+
 
 class PerformanceTestIteration:
     def __init__(self, read_time_nanos: int, processing_time_nanos: int) -> None:
@@ -49,6 +52,8 @@ class BenchmarkArgs:
 def run(  # pylint: disable=too-many-locals
     backend: BackendClient, args: BenchmarkArgs
 ) -> Tuple[int, str]:
+    from panther_analysis_tool.main import is_json_mode
+
     if backend is None or not backend.supports_perf_test():
         return 1, "Invalid backend. `benchmark` is only supported via API token"
 
@@ -119,7 +124,58 @@ def run(  # pylint: disable=too-many-locals
     if not logged:
         log_output(args.out, hour_or_err, iterations, rule_or_err, now)
 
+    if is_json_mode():
+        _emit_benchmark_json(iterations, rule_or_err, hour_or_err, logged)
+        return 0, ""
+
     return 0, ""
+
+
+def _emit_benchmark_json(
+    iterations: List["PerformanceTestIteration"],
+    rule: ClassifiedAnalysis,
+    hour: datetime.datetime,
+    had_error: bool,
+) -> None:
+    """Emit structured JSON for the benchmark command."""
+    envelope: Dict[str, Any] = {
+        "command": "benchmark",
+        "return_code": 0,
+        "status": "success",
+        "data": {
+            "rule": rule.file_name,
+            "hour": hour.isoformat(),
+            "iterations_completed": len(iterations),
+            "had_error": had_error,
+        },
+    }
+    if iterations:
+        read_times = [i.read_time_nanos for i in iterations]
+        proc_times = [i.processing_time_nanos for i in iterations]
+        envelope["data"]["read_time_seconds"] = {
+            "mean": nanos_to_seconds(mean(read_times)),
+            "median": nanos_to_seconds(median(read_times)),
+            "max": nanos_to_seconds(max(read_times)),
+            "min": nanos_to_seconds(min(read_times)),
+        }
+        envelope["data"]["processing_time_seconds"] = {
+            "mean": nanos_to_seconds(mean(proc_times)),
+            "median": nanos_to_seconds(median(proc_times)),
+            "max": nanos_to_seconds(max(proc_times)),
+            "min": nanos_to_seconds(min(proc_times)),
+        }
+        total_median_minutes = nanos_to_seconds(median(read_times) + median(proc_times)) / 60
+        if total_median_minutes < _HIGHLY_PERFORMANT_MINUTES:
+            envelope["data"]["performance_rating"] = "highly_performant"
+        elif total_median_minutes >= _AT_RISK_TIMEOUT_MINUTES:
+            envelope["data"]["performance_rating"] = "at_risk_of_timeout"
+        else:
+            envelope["data"]["performance_rating"] = "less_performant"
+        envelope["data"]["iterations"] = [
+            {"read_time_nanos": i.read_time_nanos, "processing_time_nanos": i.processing_time_nanos}
+            for i in iterations
+        ]
+    print(json.dumps(envelope, default=str))
 
 
 def validate_rule_count(analyses: List[ClassifiedAnalysis]) -> Union[ClassifiedAnalysis, str]:
@@ -151,13 +207,12 @@ def validate_log_type(
                 f" --log-type arg to specify one.",
             )
         log_type = rule_log_types[0]
-    else:
-        if not str(log_type).casefold() in map(str.casefold, rule_log_types):
-            return (
-                log_type,
-                f"Provided log type {log_type} was not found in log types for {rule.file_name}:"
-                f" {rule_log_types}",
-            )
+    elif str(log_type).casefold() not in map(str.casefold, rule_log_types):
+        return (
+            log_type,
+            f"Provided log type {log_type} was not found in log types for {rule.file_name}:"
+            f" {rule_log_types}",
+        )
     return log_type, None
 
 
@@ -209,7 +264,9 @@ def validate_hour(
         )
 
     max_data_hour = max(
-        data_for_log_type.breakdown, key=data_for_log_type.breakdown.get, default=None  # type: ignore
+        data_for_log_type.breakdown,
+        key=data_for_log_type.breakdown.get,
+        default=None,  # type: ignore
     )
     if max_data_hour is None or data_for_log_type.breakdown[max_data_hour] == 0:
         return err_msg

--- a/panther_analysis_tool/command/bulk_delete.py
+++ b/panther_analysis_tool/command/bulk_delete.py
@@ -8,6 +8,7 @@ from panther_analysis_tool.backend.client import (
     DeleteDetectionsParams,
     DeleteSavedQueriesParams,
 )
+from panther_analysis_tool.output import is_json_mode
 
 
 @dataclass
@@ -40,8 +41,6 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
         Tuple of (return_code, message_string).
     """
     # pylint: disable=too-many-return-statements
-    from panther_analysis_tool.main import is_json_mode
-
     json_mode = is_json_mode()
 
     logging.info("preparing bulk delete...")

--- a/panther_analysis_tool/command/bulk_delete.py
+++ b/panther_analysis_tool/command/bulk_delete.py
@@ -30,7 +30,9 @@ def _emit_delete_json(return_code: int, **data: Any) -> None:
     print(json.dumps(envelope, default=str))
 
 
-def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
+def run(  # pylint: disable=too-many-statements
+    backend: BackendClient, args: BulkDeleteArgs
+) -> Tuple[int, str]:
     """Execute bulk deletion of detections and/or saved queries.
 
     Args:
@@ -54,6 +56,8 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
     if not targets_detections and not targets_saved_queries:
         logging.error("Must specify a list of analysis or queries to delete")
         logging.error("Run panther_analysis_tool -h for help statement")
+        if json_mode:
+            _emit_delete_json(1, error="Must specify a list of analysis or queries to delete")
         return 1, ""
 
     dry_run_results: Dict[str, Any] = {}
@@ -61,12 +65,16 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
     if targets_detections:
         code, msg = _delete_detections_dry_run(backend, detection_id_list)
         if code != 0:
+            if json_mode:
+                _emit_delete_json(code, error=msg or "Detection dry-run failed")
             return code, msg
         dry_run_results["detections_requested"] = detection_id_list
 
     if targets_saved_queries:
         code, msg = _delete_queries_dry_run(backend, query_name_list)
         if code != 0:
+            if json_mode:
+                _emit_delete_json(code, error=msg or "Query dry-run failed")
             return code, msg
         dry_run_results["queries_requested"] = query_name_list
 
@@ -87,6 +95,8 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
         code, msg = _delete_detections(backend, detection_id_list)
         if code != 0:
             logging.warning("error deleting detections: %s", msg)
+            if json_mode:
+                _emit_delete_json(code, error=msg or "Detection deletion failed")
             return code, msg
         logging.info("successfully deleted detections.")
         deleted["detections"] = detection_id_list
@@ -95,6 +105,8 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
         code, msg = _delete_queries(backend, query_name_list)
         if code != 0:
             logging.warning("error deleting saved queries: %s", msg)
+            if json_mode:
+                _emit_delete_json(code, error=msg or "Query deletion failed")
             return code, msg
         logging.info("successfully deleted saved queries.")
         deleted["queries"] = query_name_list

--- a/panther_analysis_tool/command/bulk_delete.py
+++ b/panther_analysis_tool/command/bulk_delete.py
@@ -1,6 +1,7 @@
+import json
 import logging
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import (
@@ -16,12 +17,35 @@ class BulkDeleteArgs:
     confirm: bool
 
 
+def _emit_delete_json(return_code: int, **data: Any) -> None:
+    """Emit structured JSON for the delete command."""
+    envelope: Dict[str, Any] = {
+        "command": "delete",
+        "return_code": return_code,
+        "status": "success" if return_code == 0 else "error",
+    }
+    if data:
+        envelope["data"] = data
+    print(json.dumps(envelope, default=str))
+
+
 def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
+    """Execute bulk deletion of detections and/or saved queries.
+
+    Args:
+        backend: API backend client.
+        args: Bulk delete arguments.
+
+    Returns:
+        Tuple of (return_code, message_string).
+    """
     # pylint: disable=too-many-return-statements
+    from panther_analysis_tool.main import is_json_mode
+
+    json_mode = is_json_mode()
 
     logging.info("preparing bulk delete...")
 
-    # Get lists of detection ids and query names from args
     query_name_list = args.query_id
     detection_id_list = args.analysis_id
 
@@ -33,20 +57,23 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
         logging.error("Run panther_analysis_tool -h for help statement")
         return 1, ""
 
-    # Dry Run: Detections
+    dry_run_results: Dict[str, Any] = {}
+
     if targets_detections:
         code, msg = _delete_detections_dry_run(backend, detection_id_list)
         if code != 0:
             return code, msg
+        dry_run_results["detections_requested"] = detection_id_list
 
-    # Dry Run: Saved Queries
     if targets_saved_queries:
         code, msg = _delete_queries_dry_run(backend, query_name_list)
         if code != 0:
             return code, msg
+        dry_run_results["queries_requested"] = query_name_list
 
-    # Prompt for user confirmation (unless bypassed)
-    if args.confirm:
+    if json_mode and args.confirm:
+        logging.info("JSON mode: skipping interactive confirmation")
+    if not json_mode and args.confirm:
         confirm = input("\nContinue? (y/n) ")
 
         if confirm.lower() != "y":
@@ -55,23 +82,27 @@ def run(backend: BackendClient, args: BulkDeleteArgs) -> Tuple[int, str]:
 
         print("")
 
-    # Delete Detections
+    deleted: Dict[str, Any] = {}
+
     if targets_detections:
         code, msg = _delete_detections(backend, detection_id_list)
         if code != 0:
             logging.warning("error deleting detections: %s", msg)
             return code, msg
-
         logging.info("successfully deleted detections.")
+        deleted["detections"] = detection_id_list
 
-    # Delete Saved Queries
     if targets_saved_queries:
         code, msg = _delete_queries(backend, query_name_list)
         if code != 0:
             logging.warning("error deleting saved queries: %s", msg)
             return code, msg
-
         logging.info("successfully deleted saved queries.")
+        deleted["queries"] = query_name_list
+
+    if json_mode:
+        _emit_delete_json(0, **deleted)
+        return 0, ""
 
     logging.info("done")
     return 0, ""

--- a/panther_analysis_tool/command/init_project.py
+++ b/panther_analysis_tool/command/init_project.py
@@ -1,3 +1,6 @@
+import contextlib
+import io
+import json
 import logging
 import pathlib
 import subprocess  # nosec:B404
@@ -8,10 +11,40 @@ from panther_analysis_tool.core import analysis_cache, git_helpers
 
 
 def run(working_dir: str) -> Tuple[int, str]:
-    analysis_cache.update_with_latest_panther_analysis(show_progress_bar=True)
-    setup_git_ignore()
-    enable_rerere()
-    pat_root_created = setup_pat_root(pathlib.Path(working_dir))
+    """Initialize a new Panther project.
+
+    Args:
+        working_dir: Directory to initialize in.
+
+    Returns:
+        Tuple of (return_code, message_string).
+    """
+    from panther_analysis_tool.main import is_json_mode
+
+    json_mode = is_json_mode()
+
+    # In JSON mode, suppress stdout from helpers so only our JSON goes to stdout.
+    # Progress bars and informational prints go to a discarded buffer.
+    ctx = contextlib.redirect_stdout(io.StringIO()) if json_mode else contextlib.nullcontext()
+
+    with ctx:
+        analysis_cache.update_with_latest_panther_analysis(show_progress_bar=not json_mode)
+        setup_git_ignore()
+        enable_rerere()
+        pat_root_created = setup_pat_root(pathlib.Path(working_dir))
+
+    if json_mode:
+        print(
+            json.dumps(
+                {
+                    "command": "init",
+                    "return_code": 0,
+                    "status": "success",
+                    "data": {"pat_root_created": pat_root_created},
+                }
+            )
+        )
+        return 0, ""
     print_ready_message(pat_root_created)
     return 0, ""
 

--- a/panther_analysis_tool/command/init_project.py
+++ b/panther_analysis_tool/command/init_project.py
@@ -8,6 +8,7 @@ from typing import Tuple
 
 from panther_analysis_tool.constants import PAT_ROOT_FILE_NAME
 from panther_analysis_tool.core import analysis_cache, git_helpers
+from panther_analysis_tool.output import is_json_mode
 
 
 def run(working_dir: str) -> Tuple[int, str]:
@@ -19,8 +20,6 @@ def run(working_dir: str) -> Tuple[int, str]:
     Returns:
         Tuple of (return_code, message_string).
     """
-    from panther_analysis_tool.main import is_json_mode
-
     json_mode = is_json_mode()
 
     # In JSON mode, suppress stdout from helpers so only our JSON goes to stdout.

--- a/panther_analysis_tool/command/merge.py
+++ b/panther_analysis_tool/command/merge.py
@@ -16,6 +16,7 @@ from panther_analysis_tool.core import (
     root,
     yaml,
 )
+from panther_analysis_tool.output import is_json_mode
 
 
 @dataclasses.dataclass
@@ -36,7 +37,7 @@ def run(args: MergeArgs) -> Tuple[int, str]:
         return 1, str(err)
 
 
-def merge_analysis(
+def merge_analysis(  # pylint: disable=too-many-return-statements
     analysis_id: str | None,
     editor: str | None,
     auto_accept: AutoAcceptOption | None = None,
@@ -53,8 +54,6 @@ def merge_analysis(
     Returns:
         Tuple of (return_code, message_string).
     """
-    from panther_analysis_tool.main import is_json_mode
-
     user_specs = list(load_analysis_specs_ex(["."], [], True))
 
     mergeable_items = get_mergeable_items(analysis_id, user_specs)
@@ -239,8 +238,6 @@ def merge_items(  # pylint: disable=too-many-arguments,too-many-positional-argum
 
         # consider updated if no conflict with both files
         updated_item_ids.append(mergeable_item.user_item.analysis_id())
-
-    from panther_analysis_tool.main import is_json_mode
 
     if analysis_id is not None:
         if is_json_mode():

--- a/panther_analysis_tool/command/merge.py
+++ b/panther_analysis_tool/command/merge.py
@@ -1,7 +1,8 @@
 import dataclasses
+import json
 import logging
 import pathlib
-from typing import Tuple
+from typing import Any, Dict, Tuple
 
 from rich.progress import track
 
@@ -41,18 +42,39 @@ def merge_analysis(
     auto_accept: AutoAcceptOption | None = None,
     write_merge_conflicts: bool = False,
 ) -> Tuple[int, str]:
-    # load all user analysis specs
+    """Merge analysis items with latest Panther content.
+
+    Args:
+        analysis_id: Optional specific analysis item to merge.
+        editor: Editor command for conflict resolution.
+        auto_accept: Auto-accept strategy for conflicts.
+        write_merge_conflicts: Whether to write merge conflict markers.
+
+    Returns:
+        Tuple of (return_code, message_string).
+    """
+    from panther_analysis_tool.main import is_json_mode
+
     user_specs = list(load_analysis_specs_ex(["."], [], True))
 
     mergeable_items = get_mergeable_items(analysis_id, user_specs)
     if not mergeable_items and analysis_id is None:
+        if is_json_mode():
+            _emit_merge_json([], [])
+            return 0, ""
         print("Nothing to merge.")
         return 0, ""
 
     if not mergeable_items and analysis_id is not None:
         spec_ids = [spec.analysis_id() for spec in user_specs]
         if analysis_id not in spec_ids:
+            if is_json_mode():
+                _emit_merge_json([], [], message=f"Analysis ID '{analysis_id}' not found")
+                return 0, ""
             print(f"Analysis ID '{analysis_id}' not found in user analysis items.")
+            return 0, ""
+        if is_json_mode():
+            _emit_merge_json([], [], message=f"Analysis ID '{analysis_id}' does not need merging")
             return 0, ""
         print(f"Analysis ID '{analysis_id}' does not need merging.")
         return 0, ""
@@ -218,7 +240,15 @@ def merge_items(  # pylint: disable=too-many-arguments,too-many-positional-argum
         # consider updated if no conflict with both files
         updated_item_ids.append(mergeable_item.user_item.analysis_id())
 
+    from panther_analysis_tool.main import is_json_mode
+
     if analysis_id is not None:
+        if is_json_mode():
+            _emit_merge_json(updated_item_ids, merge_conflict_item_ids)
+        return
+
+    if is_json_mode():
+        _emit_merge_json(updated_item_ids, merge_conflict_item_ids, preview=preview)
         return
 
     if preview:
@@ -250,3 +280,25 @@ def merge_items(  # pylint: disable=too-many-arguments,too-many-positional-argum
         print(
             "Run `git diff` to see the changes. Run `pat test` to test the changes and `pat upload` to upload them."
         )
+
+
+def _emit_merge_json(
+    updated: list[str],
+    conflicts: list[str],
+    preview: bool = False,
+    message: str | None = None,
+) -> None:
+    """Emit structured JSON for the merge command."""
+    envelope: Dict[str, Any] = {
+        "command": "merge",
+        "return_code": 0,
+        "status": "success",
+        "data": {
+            "preview": preview,
+            "updated_items": updated,
+            "merge_conflicts": conflicts,
+        },
+    }
+    if message:
+        envelope["data"]["message"] = message
+    print(json.dumps(envelope, default=str))

--- a/panther_analysis_tool/command/migrate.py
+++ b/panther_analysis_tool/command/migrate.py
@@ -256,6 +256,13 @@ def run(args: MigrateArgs) -> Tuple[int, str]:
             args.write_merge_conflicts,
         )
     except file_editor.EditorCommandNotFoundError as err:
+        if is_json_mode():
+            print(
+                json.dumps(
+                    {"command": "migrate", "return_code": 1, "status": "error", "error": str(err)},
+                    default=str,
+                )
+            )
         return 1, str(err)
 
     if is_json_mode():

--- a/panther_analysis_tool/command/migrate.py
+++ b/panther_analysis_tool/command/migrate.py
@@ -31,6 +31,7 @@ from panther_analysis_tool.core import (
     versions_file,
     yaml,
 )
+from panther_analysis_tool.output import is_json_mode
 
 
 @dataclasses.dataclass
@@ -244,8 +245,6 @@ def run(args: MigrateArgs) -> Tuple[int, str]:
     Returns:
         Tuple of (return_code, message_string).
     """
-    from panther_analysis_tool.main import is_json_mode
-
     root.chdir_to_project_root()
     analysis_cache.update_with_latest_panther_analysis(show_progress_bar=True)
 

--- a/panther_analysis_tool/command/migrate.py
+++ b/panther_analysis_tool/command/migrate.py
@@ -236,6 +236,16 @@ class MigrationStatus:
 
 
 def run(args: MigrateArgs) -> Tuple[int, str]:
+    """Run the migration workflow.
+
+    Args:
+        args: Migration arguments.
+
+    Returns:
+        Tuple of (return_code, message_string).
+    """
+    from panther_analysis_tool.main import is_json_mode
+
     root.chdir_to_project_root()
     analysis_cache.update_with_latest_panther_analysis(show_progress_bar=True)
 
@@ -249,8 +259,11 @@ def run(args: MigrateArgs) -> Tuple[int, str]:
     except file_editor.EditorCommandNotFoundError as err:
         return 1, str(err)
 
+    if is_json_mode():
+        _emit_migrate_json(migration_result, single_item=args.analysis_id is not None)
+        return 0, ""
+
     if args.analysis_id is not None:
-        # skip the completion message if the user specified an analysis id
         return 0, ""
 
     if not migration_result.empty():
@@ -275,6 +288,23 @@ def run(args: MigrateArgs) -> Tuple[int, str]:
         print("Run `pat --help` for more information.")
 
     return 0, ""
+
+
+def _emit_migrate_json(result: MigrationStatus, single_item: bool = False) -> None:
+    """Emit structured JSON for the migrate command."""
+    envelope = {
+        "command": "migrate",
+        "return_code": 0,
+        "status": "success",
+        "data": {
+            "single_item": single_item,
+            "has_conflicts": result.has_conflicts(),
+            "has_warnings": result.has_warnings(),
+            "empty": result.empty(),
+            **result.to_dict(),
+        },
+    }
+    print(json.dumps(envelope, default=str))
 
 
 def migrate(  # pylint: disable=too-many-locals

--- a/panther_analysis_tool/command/standard_args.py
+++ b/panther_analysis_tool/command/standard_args.py
@@ -169,5 +169,5 @@ class OutputFormat(str, Enum):
     JSON object to stdout and route all logging to stderr.
     """
 
-    text = "text"
-    json = "json"
+    text = "text"  # pylint: disable=invalid-name
+    json = "json"  # pylint: disable=invalid-name

--- a/panther_analysis_tool/command/standard_args.py
+++ b/panther_analysis_tool/command/standard_args.py
@@ -162,21 +162,12 @@ WorkersType: TypeAlias = Annotated[
 
 
 class OutputFormat(str, Enum):
-    """Output format choices for the test command."""
+    """Output format choices for CLI commands.
+
+    When 'json' is selected via the global ``--output-format`` flag (or the
+    ``PANTHER_OUTPUT_FORMAT`` environment variable), commands emit a single
+    JSON object to stdout and route all logging to stderr.
+    """
 
     text = "text"
     json = "json"
-
-
-OutputFormatType: TypeAlias = Annotated[
-    OutputFormat,
-    typer.Option(
-        "--output-format",
-        envvar="PANTHER_OUTPUT_FORMAT",
-        help=(
-            "Output format for test results. Only applies to the 'test' command. "
-            "'text' (default) prints human-readable colored output. "
-            "'json' prints a single JSON object to stdout suitable for CI/CD integration."
-        ),
-    ),
-]

--- a/panther_analysis_tool/command/standard_args.py
+++ b/panther_analysis_tool/command/standard_args.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Annotated, List, Optional, TypeAlias
 
 import typer
@@ -156,5 +157,26 @@ WorkersType: TypeAlias = Annotated[
     typer.Option(
         envvar="PANTHER_WORKERS",
         help="Number of parallel workers for schema validation. Default 1 (sequential).",
+    ),
+]
+
+
+class OutputFormat(str, Enum):
+    """Output format choices for the test command."""
+
+    text = "text"
+    json = "json"
+
+
+OutputFormatType: TypeAlias = Annotated[
+    OutputFormat,
+    typer.Option(
+        "--output-format",
+        envvar="PANTHER_OUTPUT_FORMAT",
+        help=(
+            "Output format for test results. Only applies to the 'test' command. "
+            "'text' (default) prints human-readable colored output. "
+            "'json' prints a single JSON object to stdout suitable for CI/CD integration."
+        ),
     ),
 ]

--- a/panther_analysis_tool/command/validate.py
+++ b/panther_analysis_tool/command/validate.py
@@ -9,12 +9,11 @@ from panther_analysis_tool import cli_output
 from panther_analysis_tool.backend.client import (
     BulkUploadParams,
     BulkUploadValidateStatusResponse,
-)
-from panther_analysis_tool.backend.client import Client as BackendClient
-from panther_analysis_tool.backend.client import (
     UnsupportedEndpointError,
 )
+from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.core.parse import Filter
+from panther_analysis_tool.output import is_json_mode
 from panther_analysis_tool.zip_chunker import ZipArgs, analysis_chunks
 
 
@@ -45,7 +44,9 @@ def _emit_validate_json(return_code: int, result: Any = None, error: str | None 
     print(json.dumps(envelope, default=str))
 
 
-def run(backend: BackendClient, args: ValidateArgs) -> Tuple[int, str]:
+def run(  # pylint: disable=too-many-return-statements
+    backend: BackendClient, args: ValidateArgs
+) -> Tuple[int, str]:
     """Run bulk upload validation against a Panther deployment.
 
     Args:
@@ -55,7 +56,6 @@ def run(backend: BackendClient, args: ValidateArgs) -> Tuple[int, str]:
     Returns:
         Tuple of (return_code, message_string).
     """
-    from panther_analysis_tool.main import is_json_mode
 
     if backend is None or not backend.supports_bulk_validate():
         if is_json_mode():

--- a/panther_analysis_tool/command/validate.py
+++ b/panther_analysis_tool/command/validate.py
@@ -9,9 +9,11 @@ from panther_analysis_tool import cli_output
 from panther_analysis_tool.backend.client import (
     BulkUploadParams,
     BulkUploadValidateStatusResponse,
-    UnsupportedEndpointError,
 )
 from panther_analysis_tool.backend.client import Client as BackendClient
+from panther_analysis_tool.backend.client import (
+    UnsupportedEndpointError,
+)
 from panther_analysis_tool.core.parse import Filter
 from panther_analysis_tool.output import is_json_mode
 from panther_analysis_tool.zip_chunker import ZipArgs, analysis_chunks

--- a/panther_analysis_tool/command/validate.py
+++ b/panther_analysis_tool/command/validate.py
@@ -1,8 +1,9 @@
 import io
+import json
 import logging
 import zipfile
-from dataclasses import dataclass
-from typing import List, Tuple
+from dataclasses import asdict, dataclass
+from typing import Any, Dict, List, Tuple
 
 from panther_analysis_tool import cli_output
 from panther_analysis_tool.backend.client import (
@@ -26,8 +27,42 @@ class ValidateArgs:
     filters_inverted: List[Filter]
 
 
+def _emit_validate_json(return_code: int, result: Any = None, error: str | None = None) -> None:
+    """Emit structured JSON for the validate command."""
+    envelope: Dict[str, Any] = {
+        "command": "validate",
+        "return_code": return_code,
+        "status": "success" if return_code == 0 else "error",
+    }
+    if result is not None and hasattr(result, "is_valid"):
+        envelope["data"] = {
+            "valid": result.is_valid(),
+            "error": result.get_error() if result.has_error() else None,
+            "issues": [asdict(i) for i in result.get_issues()] if result.has_issues() else [],
+        }
+    elif error:
+        envelope["errors"] = [{"error": error}]
+    print(json.dumps(envelope, default=str))
+
+
 def run(backend: BackendClient, args: ValidateArgs) -> Tuple[int, str]:
+    """Run bulk upload validation against a Panther deployment.
+
+    Args:
+        backend: API backend client.
+        args: Validated command arguments.
+
+    Returns:
+        Tuple of (return_code, message_string).
+    """
+    from panther_analysis_tool.main import is_json_mode
+
     if backend is None or not backend.supports_bulk_validate():
+        if is_json_mode():
+            _emit_validate_json(
+                1, error="Invalid backend. `validate` is only supported via API token"
+            )
+            return 1, ""
         return 1, "Invalid backend. `validate` is only supported via API token"
 
     zip_args = ZipArgs(
@@ -50,14 +85,26 @@ def run(backend: BackendClient, args: ValidateArgs) -> Tuple[int, str]:
     try:
         result = backend.bulk_validate(params)
         if result.is_valid():
+            if is_json_mode():
+                _emit_validate_json(0, result=result)
+                return 0, ""
             return 0, f"{cli_output.success('Validation success')}"
 
+        if is_json_mode():
+            _emit_validate_json(1, result=result)
+            return 1, ""
         return 1, cli_output.multipart_error_msg(result, "Validation failed")
     except UnsupportedEndpointError as err:
         logging.debug(err)
+        if is_json_mode():
+            _emit_validate_json(1, error="Your Panther instance does not support this feature")
+            return 1, ""
         return 1, cli_output.warning("Your Panther instance does not support this feature")
 
     except BaseException as err:  # pylint: disable=broad-except
+        if is_json_mode():
+            _emit_validate_json(1, error=str(err))
+            return 1, ""
         return 1, cli_output.multipart_error_msg(
             BulkUploadValidateStatusResponse.from_json({"error": str(err)}), "Validation failed"
         )

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -107,6 +107,8 @@ from panther_analysis_tool.command.standard_args import (
     IgnoreTableNamesType,
     KMSKeyType,
     MinimumTestsType,
+    OutputFormat,
+    OutputFormatType,
     OutType,
     PathType,
     ShowFailuresOnlyType,
@@ -319,6 +321,7 @@ class TestAnalysisArgs:
     skip_disabled_tests: bool
     test_names: List[str]
     workers: int = 1
+    output_format: OutputFormat = OutputFormat.text
 
 
 @dataclass
@@ -882,6 +885,14 @@ def test_analysis(
     Returns:
         A tuple of the return code, and a list of tuples containing invalid specs and their error.
     """
+    json_mode = args.output_format == OutputFormat.json
+
+    # In JSON mode, redirect logging to stderr so stdout is clean JSON
+    if json_mode:
+        for handler in logging.root.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                handler.setStream(sys.stderr)
+
     logging.info("Testing analysis items in %s", args.path)
 
     # First classify each file, always include globals and data models location
@@ -895,15 +906,23 @@ def test_analysis(
     )
     if specs.empty():
         if invalid_specs:
+            if json_mode:
+                _print_json_error(args.path, invalid_specs)
             return 1, invalid_specs
-        return 1, [f"Nothing to test in {args.path}"]
+        error_msg = f"Nothing to test in {args.path}"
+        if json_mode:
+            _print_json_error(args.path, [(args.path, error_msg)])
+        return 1, [error_msg]
 
     specs = specs.apply(lambda l: filter_analysis(l, args.filters, args.filters_inverted))
 
     if specs.empty():
-        return 1, [
+        error_msg = (
             f"No analysis in {args.path} matched filters {args.filters} - {args.filters_inverted}"
-        ]
+        )
+        if json_mode:
+            _print_json_error(args.path, [(args.path, error_msg)])
+        return 1, [error_msg]
 
     # enrich simple detections with transpiled python as necessary
     if len(specs.simple_detections) > 0:
@@ -933,10 +952,11 @@ def test_analysis(
     log_type_to_data_model, invalid_data_models = setup_data_models(specs.data_models)
     invalid_specs.extend(invalid_data_models)
 
+    # JSON mode always buffers results; text mode only buffers when sorting/filtering
     all_test_results = (
-        None
-        if not bool(args.sort_test_results | args.show_failures_only)
-        else TestResultsContainer(passed={}, errored={})
+        TestResultsContainer(passed={}, errored={})
+        if json_mode or bool(args.sort_test_results | args.show_failures_only)
+        else None
     )
     # then, import rules and policies; run tests
     failed_tests, invalid_detections, skipped_tests = setup_run_tests(
@@ -960,41 +980,184 @@ def test_analysis(
     # cleanup tmp global dir
     cleanup_global_helpers(specs.globals)
 
-    if all_test_results and (all_test_results.passed or all_test_results.errored):
-        for outcome in ["passed", "errored"]:
-            # Skip if test passed and we only want to print failed tests:
-            if args.show_failures_only and outcome != "errored":
-                continue
-            sorted_results = sorted(getattr(all_test_results, outcome).items())
-            for detection_id, test_result_packages in sorted_results:
-                if test_result_packages:
-                    print(detection_id)
-                for test_result_package in test_result_packages:
-                    if len(test_result_package.output) > 0:
-                        print(test_result_package.output)
-                    _print_test_result(
-                        detection=test_result_package.detection,
-                        test_result=test_result_package.result,
-                        failed_tests=test_result_package.failed_tests,
-                    )
-                    print("")
-
-    if debug_args is None:
-        debug_args = {}
-    if not debug_args.get("debug_mode", False):
-        print_summary(
-            args.path,
-            len(specs.detections + specs.simple_detections),
-            failed_tests,
-            invalid_specs,
-            skipped_tests,
+    if json_mode:
+        _print_json_output(
+            test_path=args.path,
+            num_detections=len(specs.detections + specs.simple_detections),
+            failed_tests=failed_tests,
+            invalid_specs=invalid_specs,
+            skipped_tests=skipped_tests,
+            all_test_results=all_test_results or TestResultsContainer(passed={}, errored={}),
         )
+    else:
+        if all_test_results and (all_test_results.passed or all_test_results.errored):
+            for outcome in ["passed", "errored"]:
+                # Skip if test passed and we only want to print failed tests:
+                if args.show_failures_only and outcome != "errored":
+                    continue
+                sorted_results = sorted(getattr(all_test_results, outcome).items())
+                for detection_id, test_result_packages in sorted_results:
+                    if test_result_packages:
+                        print(detection_id)
+                    for test_result_package in test_result_packages:
+                        if len(test_result_package.output) > 0:
+                            print(test_result_package.output)
+                        _print_test_result(
+                            detection=test_result_package.detection,
+                            test_result=test_result_package.result,
+                            failed_tests=test_result_package.failed_tests,
+                        )
+                        print("")
+
+        if debug_args is None:
+            debug_args = {}
+        if not debug_args.get("debug_mode", False):
+            print_summary(
+                args.path,
+                len(specs.detections + specs.simple_detections),
+                failed_tests,
+                invalid_specs,
+                skipped_tests,
+            )
 
     #  if the classic format was invalid, just exit
     if invalid_specs:
         return 1, invalid_specs
 
     return int(bool(failed_tests)), invalid_specs
+
+
+def _serialize_function_result(
+    function_name: str, function_result: Optional[dict]
+) -> Optional[dict]:
+    """Convert a single function test result dict to a JSON-safe representation."""
+    if function_result is None:
+        return None
+    entry: Dict[str, Any] = {"name": function_name.replace("Function", "")}
+    error_val = function_result.get("error")
+    if error_val:
+        entry["status"] = "error"
+        entry["error"] = error_val.get("message") if isinstance(error_val, dict) else str(error_val)
+    elif not function_result.get("matched", True):
+        entry["status"] = "fail"
+        entry["output"] = function_result.get("output")
+    else:
+        entry["status"] = "pass"
+        entry["output"] = function_result.get("output")
+    return entry
+
+
+def _serialize_test_result(container: TestResultContainer) -> Dict[str, Any]:
+    """Convert a TestResultContainer into a JSON-serializable dict."""
+    result = container.result
+    entry: Dict[str, Any] = {
+        "name": result.name,
+        "passed": result.passed,
+        "errored": result.errored,
+    }
+    if result.genericError:
+        entry["genericError"] = result.genericError
+    if result.functions is not None:
+        functions_dict = asdict(result.functions)
+        function_results = []
+        for func_name, func_result in functions_dict.items():
+            serialized = _serialize_function_result(func_name, func_result)
+            if serialized is not None:
+                if container.detection is not None and serialized["name"] == "detection":
+                    serialized["name"] = container.detection.matcher_function_name
+                function_results.append(serialized)
+        if function_results:
+            entry["functions"] = function_results
+    return entry
+
+
+def _print_json_error(test_path: str, invalid_specs: List[Any]) -> None:
+    """Print a JSON error envelope for early-exit error paths.
+
+    Ensures CI/CD consumers always receive valid JSON on stdout, even when
+    test_analysis exits before running any tests.
+    """
+    output: Dict[str, Any] = {
+        "summary": {
+            "path": test_path,
+            "total": 0,
+            "passed": 0,
+            "failed": 0,
+            "invalid": len(invalid_specs),
+            "skipped": 0,
+        },
+        "results": {},
+        "failed": {},
+        "invalid": [{"file": str(fname), "error": str(err)} for fname, err in invalid_specs],
+        "skipped": [],
+    }
+    print(json.dumps(output, default=str))
+
+
+def _print_json_output(
+    test_path: str,
+    num_detections: int,
+    failed_tests: DefaultDict[str, list],
+    invalid_specs: List[Any],
+    skipped_tests: List[Tuple[str, dict]],
+    all_test_results: TestResultsContainer,
+) -> None:
+    """Print structured JSON output for all test results.
+
+    The JSON schema is designed for CI/CD integration and programmatic parsing.
+    Output goes to stdout; all other output (logging) should be on stderr.
+    """
+    num_passed = max(
+        0, num_detections - (len(failed_tests) + len(invalid_specs) + len(skipped_tests))
+    )
+
+    output: Dict[str, Any] = {
+        "summary": {
+            "path": test_path,
+            "total": num_detections,
+            "passed": num_passed,
+            "failed": len(failed_tests),
+            "invalid": len(invalid_specs),
+            "skipped": len(skipped_tests),
+        },
+        "results": {},
+        "failed": {},
+        "invalid": [],
+        "skipped": [],
+    }
+
+    # Build per-detection results from the buffered TestResultsContainer
+    for outcome_key in ("passed", "errored"):
+        for detection_id, containers in getattr(all_test_results, outcome_key).items():
+            if detection_id not in output["results"]:
+                output["results"][detection_id] = []
+            for container in containers:
+                output["results"][detection_id].append(_serialize_test_result(container))
+
+    # Failed tests with their failure reasons
+    for detection_id, failures in failed_tests.items():
+        output["failed"][detection_id] = failures
+
+    # Invalid specs
+    for spec_filename, spec_error in invalid_specs:
+        output["invalid"].append(
+            {
+                "file": str(spec_filename),
+                "error": str(spec_error),
+            }
+        )
+
+    # Skipped tests
+    for spec_filename, spec in skipped_tests:
+        rule_or_policy_id = spec.get("RuleID") or spec.get("PolicyID") or ""
+        output["skipped"].append(
+            {
+                "file": str(spec_filename),
+                "id": rule_or_policy_id,
+            }
+        )
+
+    print(json.dumps(output, default=str))
 
 
 def setup_global_helpers(global_analysis: List[ClassifiedAnalysis]) -> None:
@@ -1085,7 +1248,7 @@ def setup_data_models(
             # check if the LogType already has an enabled data model
             for log_type in analysis_spec["LogTypes"]:
                 if log_type in log_type_to_data_model:
-                    print("\t[ERROR] Conflicting Enabled LogTypes\n")
+                    logging.error("Conflicting Enabled LogTypes")
                     invalid_specs.append(
                         (
                             analysis_spec_filename,
@@ -1138,12 +1301,13 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-m
 
         if test_names:
             if not set(test_names) & {t["Name"] for t in analysis_spec.get("Tests", [])}:
-                print(
-                    analysis_spec.get("RuleID")
-                    or analysis_spec.get("PolicyID")
-                    or analysis_spec_filename
-                )
-                print(f"\tNo tests match the provided test names: {test_names}\n")
+                if not all_test_results:
+                    print(
+                        analysis_spec.get("RuleID")
+                        or analysis_spec.get("PolicyID")
+                        or analysis_spec_filename
+                    )
+                    print(f"\tNo tests match the provided test names: {test_names}\n")
                 skipped_tests.append((analysis_spec_filename, analysis_spec))
                 continue
 
@@ -1187,7 +1351,8 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-m
                 detection_args["body"] = found_base_detection.get("body")
             else:
                 detection_args["path"] = os.path.join(
-                    found_base_path, found_base_detection["Filename"]  # type: ignore
+                    found_base_path,
+                    found_base_detection["Filename"],  # type: ignore
                 )
         elif is_simple_detection(analysis_spec):
             # skip tests when the body is empty
@@ -1218,7 +1383,8 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-m
         # if there is a setup exception, no need to run tests
         if detection is not None and detection.setup_exception:
             invalid_specs.append((analysis_spec_filename, detection.setup_exception))
-            print("\n")
+            if not all_test_results:
+                print("\n")
             continue
 
         failed_tests = run_tests(
@@ -1617,12 +1783,13 @@ def run_tests(  # pylint: disable=too-many-arguments,too-many-positional-argumen
 ) -> DefaultDict[str, list]:
     if len(analysis.get("Tests", [])) < minimum_tests:
         failed_tests[detection_id].append(
-            f'Insufficient test coverage: {minimum_tests} tests required but only {len(analysis.get("Tests", []))} found'
+            f"Insufficient test coverage: {minimum_tests} tests required but only {len(analysis.get('Tests', []))} found"
         )
 
     # First check if any tests exist, so we can print a helpful message if not
     if "Tests" not in analysis:
-        print(f"\tNo tests configured for {detection_id}")
+        if not all_test_results:
+            print(f"\tNo tests configured for {detection_id}")
         return failed_tests
 
     failed_tests = _run_tests(
@@ -1694,6 +1861,41 @@ def _process_correlation_rule_test_results(
     return failed_tests
 
 
+def _buffer_error_result(
+    all_test_results: Optional[TestResultsContainer],
+    detection: Detection,
+    unit_test: Dict[str, Any],
+    failed_tests: DefaultDict[str, list],
+    test_output: str,
+    err: Exception,
+) -> None:
+    """Buffer an errored test result so JSON output includes entries for tests that threw exceptions."""
+    if all_test_results is None:
+        return
+    error_result = TestResult(
+        id=unit_test["Name"],
+        name=unit_test["Name"],
+        detectionId=detection.detection_id,
+        genericError=f"{type(err).__name__}: {err}",
+        error=None,
+        errored=True,
+        passed=False,
+        trigger_alert=None,
+        functions=TestResultsPerFunction(detectionFunction=None),
+    )
+    stored = all_test_results.errored
+    if detection.detection_id not in stored:
+        stored[detection.detection_id] = []
+    stored[detection.detection_id].append(
+        TestResultContainer(
+            detection=detection,
+            result=error_result,
+            failed_tests=failed_tests,
+            output=test_output,
+        )
+    )
+
+
 # pylint: disable=too-many-statements
 def _run_tests(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     analysis_data_models: Dict[str, DataModel],
@@ -1762,7 +1964,7 @@ def _run_tests(  # pylint: disable=too-many-arguments,too-many-positional-argume
                     result = detection.run(test_case, {}, destinations_by_name, batch_mode=False)
             test_output = ""
             if not debug_args or not debug_args.get("debug_mode", False):
-                test_output = cast(io.StringIO, test_output_buf).getvalue()
+                test_output = cast("io.StringIO", test_output_buf).getvalue()
             if debug_args and debug_args.get("debug_mode", False):
                 # Print excceptiosn relative to the rule.py file
                 if err := result.detection_exception:
@@ -1788,12 +1990,17 @@ def _run_tests(  # pylint: disable=too-many-arguments,too-many-positional-argume
             )
             logging.debug(str(err), exc_info=err)
             failed_tests[detection.detection_id].append(unit_test["Name"])
+            _buffer_error_result(
+                all_test_results, detection, unit_test, failed_tests, test_output, err
+            )
             continue
         except Exception as err:  # pylint: disable=broad-except
-            # Catch arbitrary exceptions raised by user code
             logging.warning("Unexpected exception: {%s}", err)
             logging.debug(str(err), exc_info=err)
             failed_tests[detection.detection_id].append(unit_test["Name"])
+            _buffer_error_result(
+                all_test_results, detection, unit_test, failed_tests, test_output, err
+            )
             continue
         finally:
             if len(test_output) > 0 and not all_test_results:
@@ -1876,14 +2083,14 @@ def _print_test_result(
                 # add this as output to the failed test spec as well
                 failed_tests[detection.detection_id].append(f"{test_result.name}:{printable_name}")
                 print(
-                    f'\t\t[{status_fail}] [{printable_name}] {function_result.get("error", {}).get("message")}'
+                    f"\t\t[{status_fail}] [{printable_name}] {function_result.get('error', {}).get('message')}"
                 )
             # if it didn't error, we simply need to check if the output was as expected
             elif not function_result.get("matched", True):
                 failed_tests[detection.detection_id].append(f"{test_result.name}:{printable_name}")
-                print(f'\t\t[{status_fail}] [{printable_name}] {function_result.get("output")}')
+                print(f"\t\t[{status_fail}] [{printable_name}] {function_result.get('output')}")
             else:
-                print(f'\t\t[{status_pass}] [{printable_name}] {function_result.get("output")}')
+                print(f"\t\t[{status_pass}] [{printable_name}] {function_result.get('output')}")
 
 
 def print_and_exit(message: str) -> None:
@@ -2038,6 +2245,7 @@ def test(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         ),
     ] = None,
     workers: WorkersType = 1,
+    output_format: OutputFormatType = OutputFormat.text,
 ) -> Tuple[int, list[Any]]:
     if ignore_files is None:
         ignore_files = []
@@ -2066,6 +2274,7 @@ def test(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         valid_table_names=valid_table_names,
         test_names=test_names,
         workers=workers,
+        output_format=output_format,
     )
 
     return test_analysis(pat_utils.get_optional_backend(api_token, api_host), args)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -144,6 +144,10 @@ from panther_analysis_tool.destination import FakeDestination
 from panther_analysis_tool.directory import setup_temp
 from panther_analysis_tool.enriched_event_generator import EnrichedEventGenerator
 from panther_analysis_tool.log_schemas import user_defined
+from panther_analysis_tool.output import (
+    is_json_mode,
+    set_output_format,
+)
 from panther_analysis_tool.schemas import LOOKUP_TABLE_SCHEMA, SQL_LOOKUP_TABLE_SCHEMA
 from panther_analysis_tool.util import (
     BackendNotFoundException,
@@ -179,17 +183,6 @@ PantherCommand: TypeAlias = Callable[..., Tuple[int, list[Any]]] | Callable[...,
 
 _DISABLE_PANTHER_EXCEPTION_HANDLER = False
 _SKIP_HTTP_VERSION_CHECK = False
-_output_format: OutputFormat = OutputFormat.text
-
-
-def get_output_format() -> OutputFormat:
-    """Return the globally configured output format."""
-    return _output_format
-
-
-def is_json_mode() -> bool:
-    """Return True when the global output format is JSON."""
-    return _output_format == OutputFormat.json
 
 
 def _emit_json_result(command: str, return_code: int, out: Any) -> None:
@@ -983,7 +976,7 @@ def debug_analysis(
     return test_analysis(backend, args, debug_args=debug_args)
 
 
-# pylint: disable=too-many-locals
+# pylint: disable=too-many-locals,too-many-statements,too-many-nested-blocks
 def test_analysis(
     backend: Optional[BackendClient],
     args: TestAnalysisArgs,
@@ -1207,7 +1200,7 @@ def _print_json_error(test_path: str, invalid_specs: List[Any]) -> None:
     print(json.dumps(output, default=str))
 
 
-def _print_json_output(
+def _print_json_output(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     test_path: str,
     num_detections: int,
     failed_tests: DefaultDict[str, list],
@@ -1482,8 +1475,8 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-m
                 detection_args["body"] = found_base_detection.get("body")
             else:
                 detection_args["path"] = os.path.join(
-                    found_base_path,
-                    found_base_detection["Filename"],  # type: ignore
+                    found_base_path,  # type: ignore[arg-type]
+                    found_base_detection["Filename"],
                 )
         elif is_simple_detection(analysis_spec):
             # skip tests when the body is empty
@@ -1538,7 +1531,7 @@ def setup_run_tests(  # pylint: disable=too-many-locals,too-many-arguments,too-m
     return failed_tests, invalid_specs, skipped_tests
 
 
-def print_summary(
+def print_summary(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     test_path: str,
     num_tests: int,
     failed_tests: Dict[str, list],
@@ -1759,7 +1752,7 @@ def _emit_check_packs_json(return_code: int, **data: Any) -> None:
 
 
 # pylint: disable=too-many-statements
-def check_packs(path: str) -> Tuple[int, str]:
+def check_packs(path: str) -> Tuple[int, str]:  # pylint: disable=too-many-return-statements
     """
     Checks each existing pack whether it includes all necessary rules and other items. Also checks
     if any detections, queries, etc. are not included in any packs
@@ -2055,7 +2048,7 @@ def _process_correlation_rule_test_results(
     return failed_tests
 
 
-def _buffer_error_result(
+def _buffer_error_result(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     all_test_results: Optional[TestResultsContainer],
     detection: Detection,
     unit_test: Dict[str, Any],
@@ -2342,8 +2335,7 @@ def global_options(
     """
     Panther Analysis Tool: A command line tool for managing Panther policies and rules.
     """
-    global _output_format  # noqa: PLW0603
-    _output_format = output_format
+    set_output_format(output_format)
 
     if output_format == OutputFormat.json:
         for handler in logging.root.handlers:

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -51,6 +51,7 @@ from panther_core.testing import (
     TestCaseEvaluator,
     TestExpectations,
     TestResult,
+    TestResultsPerFunction,
     TestSpecification,
 )
 from ruamel.yaml import YAML, SafeConstructor, constructor
@@ -108,7 +109,6 @@ from panther_analysis_tool.command.standard_args import (
     KMSKeyType,
     MinimumTestsType,
     OutputFormat,
-    OutputFormatType,
     OutType,
     PathType,
     ShowFailuresOnlyType,
@@ -179,12 +179,67 @@ PantherCommand: TypeAlias = Callable[..., Tuple[int, list[Any]]] | Callable[...,
 
 _DISABLE_PANTHER_EXCEPTION_HANDLER = False
 _SKIP_HTTP_VERSION_CHECK = False
+_output_format: OutputFormat = OutputFormat.text
+
+
+def get_output_format() -> OutputFormat:
+    """Return the globally configured output format."""
+    return _output_format
+
+
+def is_json_mode() -> bool:
+    """Return True when the global output format is JSON."""
+    return _output_format == OutputFormat.json
+
+
+def _emit_json_result(command: str, return_code: int, out: Any) -> None:
+    """Emit a structured JSON envelope to stdout for any command result.
+
+    This is the generic fallback used by call_and_exit for commands that
+    do not produce their own JSON output (e.g. test already handles its own).
+
+    Non-serializable values in ``out`` are coerced to their ``str()``
+    representation via ``json.dumps(default=str)``.  The resulting JSON is
+    always valid, but callers should prefer returning plain strings or
+    lists of ``(filename, error_message)`` tuples for best fidelity.
+    """
+    envelope: Dict[str, Any] = {
+        "command": command,
+        "return_code": return_code,
+    }
+    if return_code == 0:
+        envelope["status"] = "success"
+        if out:
+            envelope["message"] = str(out)
+    else:
+        envelope["status"] = "error"
+        if out and isinstance(out, list):
+            errors = []
+            for errspec in out:
+                if isinstance(errspec, tuple):
+                    fname, error = errspec
+                    errors.append({"file": str(fname), "error": str(error)})
+                else:
+                    errors.append({"error": str(errspec)})
+            envelope["errors"] = errors
+        elif out:
+            envelope["errors"] = [{"error": str(out)}]
+    print(json.dumps(envelope, default=str))
 
 
 def call_and_exit(func: PantherCommand) -> Callable[..., None]:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> None:
         return_code, out = func(*args, **kwargs)
+
+        if is_json_mode():
+            # Commands that produce their own JSON (like test) set out=""
+            # on success to signal that output was already emitted.
+            # For all other commands, emit the generic JSON envelope.
+            command_name = func.__name__.replace("_cmd", "").replace("_command", "")
+            if not _command_emits_own_json(command_name):
+                _emit_json_result(command_name, return_code, out)
+            raise typer.Exit(code=return_code)
 
         if return_code == 1:
             # out is expected to be a list of tuples of (filename, error_message)
@@ -215,6 +270,34 @@ def call_and_exit(func: PantherCommand) -> Callable[..., None]:
     # invalid mypy error https://github.com/python/mypy/issues/12472
     wrapper.__signature__ = signature(func, eval_str=True)  # type: ignore[attr-defined]
     return wrapper
+
+
+_COMMANDS_WITH_OWN_JSON: frozenset[str] = frozenset(
+    {
+        "test",
+        "debug",
+        "upload",
+        "validate",
+        "benchmark",
+        "check_packs",
+        "migrate",
+        "delete",
+        "merge",
+        "update",
+        "enrich_test_data",
+        "update_custom_schemas",
+        "init",
+    }
+)
+
+
+def _command_emits_own_json(command_name: str) -> bool:
+    """Return True if the command already printed its own JSON to stdout.
+
+    Commands in _COMMANDS_WITH_OWN_JSON handle their own structured JSON output
+    and should not receive the generic envelope from call_and_exit.
+    """
+    return command_name in _COMMANDS_WITH_OWN_JSON
 
 
 def app_command_with_config(
@@ -321,7 +404,6 @@ class TestAnalysisArgs:
     skip_disabled_tests: bool
     test_names: List[str]
     workers: int = 1
-    output_format: OutputFormat = OutputFormat.text
 
 
 @dataclass
@@ -509,6 +591,19 @@ def upload_zip(
                     del resp_dict["correlation_rules"]
 
                 logging.debug("API Response:\n%s", json.dumps(resp_dict, indent=4))
+                if is_json_mode():
+                    print(
+                        json.dumps(
+                            {
+                                "command": "upload",
+                                "return_code": 0,
+                                "status": "success",
+                                "data": resp_dict,
+                            },
+                            default=str,
+                        )
+                    )
+                    return 0, ""
                 print_upload_summary(resp_dict)
                 return 0, cli_output.success("Upload succeeded")
 
@@ -611,11 +706,12 @@ def test_lookup_table(path: str) -> Tuple[int, str]:
 
 
 def update_custom_schemas(backend: BackendClient, path: str) -> Tuple[int, str]:
-    """
-    Updates or creates custom schemas.
-    Returns 1 if any file failed to be updated.
+    """Update or create custom schemas on a Panther deployment.
+
     Args:
-        args: The populated Argparse namespace with parsed command-line arguments.
+        backend: API backend client.
+        path: Path containing schema definitions.
+
     Returns:
         A tuple of return code and a placeholder string.
     """
@@ -626,12 +722,28 @@ def update_custom_schemas(backend: BackendClient, path: str) -> Tuple[int, str]:
     uploader = user_defined.Uploader(normalized_path, backend)
     results = uploader.process()
     has_errors = False
+    summaries: list[Dict[str, Any]] = []
     for failed, summary in user_defined.report_summary(normalized_path, results):
         if failed:
             has_errors = True
             logging.error(summary)
         else:
             logging.info(summary)
+        summaries.append({"failed": failed, "summary": summary})
+
+    if is_json_mode():
+        print(
+            json.dumps(
+                {
+                    "command": "update-custom-schemas",
+                    "return_code": int(has_errors),
+                    "status": "error" if has_errors else "success",
+                    "data": {"results": summaries},
+                },
+                default=str,
+            )
+        )
+        return int(has_errors), ""
 
     return int(has_errors), ""
 
@@ -885,13 +997,7 @@ def test_analysis(
     Returns:
         A tuple of the return code, and a list of tuples containing invalid specs and their error.
     """
-    json_mode = args.output_format == OutputFormat.json
-
-    # In JSON mode, redirect logging to stderr so stdout is clean JSON
-    if json_mode:
-        for handler in logging.root.handlers:
-            if isinstance(handler, logging.StreamHandler):
-                handler.setStream(sys.stderr)
+    json_mode = is_json_mode()
 
     logging.info("Testing analysis items in %s", args.path)
 
@@ -980,12 +1086,18 @@ def test_analysis(
     # cleanup tmp global dir
     cleanup_global_helpers(specs.globals)
 
+    # Only detection-related invalids should reduce the passed count.
+    # invalid_specs also contains data model errors, pack errors, etc. that
+    # are not counted in num_detections.
+    num_invalid_detections = len(invalid_detections)
+
     if json_mode:
         _print_json_output(
             test_path=args.path,
             num_detections=len(specs.detections + specs.simple_detections),
             failed_tests=failed_tests,
             invalid_specs=invalid_specs,
+            num_invalid_detections=num_invalid_detections,
             skipped_tests=skipped_tests,
             all_test_results=all_test_results or TestResultsContainer(passed={}, errored={}),
         )
@@ -1017,6 +1129,7 @@ def test_analysis(
                 len(specs.detections + specs.simple_detections),
                 failed_tests,
                 invalid_specs,
+                num_invalid_detections,
                 skipped_tests,
             )
 
@@ -1099,6 +1212,7 @@ def _print_json_output(
     num_detections: int,
     failed_tests: DefaultDict[str, list],
     invalid_specs: List[Any],
+    num_invalid_detections: int,
     skipped_tests: List[Tuple[str, dict]],
     all_test_results: TestResultsContainer,
 ) -> None:
@@ -1106,9 +1220,26 @@ def _print_json_output(
 
     The JSON schema is designed for CI/CD integration and programmatic parsing.
     Output goes to stdout; all other output (logging) should be on stderr.
+
+    Note: The test command uses a flat schema (``summary``, ``results``,
+    ``failed``, ``invalid``, ``skipped``) rather than the ``{command, status,
+    data}`` envelope used by other commands.  This is intentional -- the test
+    output predates the generic envelope and contains richer, domain-specific
+    structure.  A future major version could unify the schemas.
+
+    Args:
+        test_path: Path that was tested.
+        num_detections: Count of detections (rules + simple_detections).
+        failed_tests: Map of detection_id -> list of failed test names.
+        invalid_specs: All invalid specs (detections, data models, packs, etc.).
+        num_invalid_detections: Count of invalid specs that are actually detections.
+            Only these reduce the passed count since num_detections only counts
+            detections, not data models or packs.
+        skipped_tests: List of (filename, spec) tuples for skipped tests.
+        all_test_results: Buffered test results for per-detection breakdown.
     """
     num_passed = max(
-        0, num_detections - (len(failed_tests) + len(invalid_specs) + len(skipped_tests))
+        0, num_detections - (len(failed_tests) + num_invalid_detections + len(skipped_tests))
     )
 
     output: Dict[str, Any] = {
@@ -1412,9 +1543,20 @@ def print_summary(
     num_tests: int,
     failed_tests: Dict[str, list],
     invalid_specs: List[Any],
+    num_invalid_detections: int,
     skipped_tests: List[Tuple[str, dict]],
 ) -> None:
-    """Print a summary of passed, failed, and invalid specs"""
+    """Print a summary of passed, failed, and invalid specs.
+
+    Args:
+        test_path: Path that was tested.
+        num_tests: Count of detections (rules + simple_detections).
+        failed_tests: Map of detection_id -> list of failed test names.
+        invalid_specs: All invalid specs (detections, data models, packs, etc.).
+        num_invalid_detections: Count of invalid specs that are detections.
+            Only these reduce the passed count.
+        skipped_tests: List of (filename, spec) tuples for skipped tests.
+    """
     err_message = "\t{}\n\t\t{}\n"
 
     if skipped_tests:
@@ -1438,7 +1580,9 @@ def print_summary(
     print("--------------------------")
     print("Test Summary")
     print(f"\tPath: {test_path}")
-    print(f"\tPassed: {num_tests - (len(failed_tests) + len(invalid_specs) + len(skipped_tests))}")
+    print(
+        f"\tPassed: {num_tests - (len(failed_tests) + num_invalid_detections + len(skipped_tests))}"
+    )
     print(f"\tSkipped: {len(skipped_tests)}")
     print(f"\tFailed: {len(failed_tests)}")
     print(f"\tInvalid: {len(invalid_specs)}\n")
@@ -1554,8 +1698,20 @@ def enrich_test_data(backend: BackendClient, args: EnrichTestDataArgs) -> Tuple[
     enricher = EnrichedEventGenerator(backend)
     result = enricher.enrich_test_data(list(filtered_raw_analysis_items_by_id.values()))
 
-    # just report the detection IDs that were enriched
     enriched_analysis_ids = [analysis_spec.analysis_id() for analysis_spec in result]
+    if is_json_mode():
+        print(
+            json.dumps(
+                {
+                    "command": "enrich-test-data",
+                    "return_code": 0,
+                    "status": "success",
+                    "data": {"enriched_ids": enriched_analysis_ids},
+                },
+                default=str,
+            )
+        )
+        return 0, ""
     result_str = "No analysis specs enriched"
     if any(enriched_analysis_ids):
         result_str = "Analysis specs enriched:\n\t" + "\n\t".join(enriched_analysis_ids)
@@ -1581,6 +1737,25 @@ def get_shallow_dependencies(spec_: ClassifiedAnalysis) -> set[str]:
         return set(subrule["RuleID"] for subrule in subrules)
     # Otherwise, return empty set
     return set()
+
+
+def _check_packs_json_default(obj: Any) -> Any:
+    """JSON serializer fallback that sorts sets for deterministic output."""
+    if isinstance(obj, set):
+        return sorted(obj)
+    return str(obj)
+
+
+def _emit_check_packs_json(return_code: int, **data: Any) -> None:
+    """Emit structured JSON for the check-packs command."""
+    envelope: Dict[str, Any] = {
+        "command": "check-packs",
+        "return_code": return_code,
+        "status": "success" if return_code == 0 else "error",
+    }
+    if data:
+        envelope["data"] = data
+    print(json.dumps(envelope, default=_check_packs_json_default))
 
 
 # pylint: disable=too-many-statements
@@ -1667,6 +1842,9 @@ def check_packs(path: str) -> Tuple[int, str]:
             )
 
     if missing_pack_items:
+        if is_json_mode():
+            _emit_check_packs_json(1, missing_items=missing_pack_items)
+            return 1, ""
         err_str = ["The following packs have missing items:\n"]
         for missing_entries in missing_pack_items:
             err_str += [str(missing_entries.pop("path"))]
@@ -1716,6 +1894,9 @@ def check_packs(path: str) -> Tuple[int, str]:
             all_items_not_in_packs.add(id_)
 
     if all_items_not_in_packs:
+        if is_json_mode():
+            _emit_check_packs_json(1, items_not_in_packs=sorted(all_items_not_in_packs))
+            return 1, ""
         err_str = ["The following items are not included in any packs:"]
         err_str += sorted(list(all_items_not_in_packs))
         return 1, "\n".join(err_str)
@@ -1749,21 +1930,34 @@ def check_packs(path: str) -> Tuple[int, str]:
                 )
 
     if experimental_items_in_packs:
+        if is_json_mode():
+            _emit_check_packs_json(1, experimental_in_packs=sorted(experimental_items_in_packs))
+            return 1, ""
         err_str = ["The following experimental items are not allowed in packs:"]
         err_str += sorted(experimental_items_in_packs)
         return 1, "\n".join(err_str)
 
     if deprecated_items_in_packs:
+        if is_json_mode():
+            _emit_check_packs_json(1, deprecated_in_packs=sorted(deprecated_items_in_packs))
+            return 1, ""
         err_str = ["The following deprecated items are not allowed in packs:"]
         err_str += sorted(deprecated_items_in_packs)
         return 1, "\n".join(err_str)
 
     if excluded_tag_items_in_packs:
+        if is_json_mode():
+            excluded = [{"id": i, "tags": t} for i, t in sorted(excluded_tag_items_in_packs)]
+            _emit_check_packs_json(1, excluded_tag_in_packs=excluded)
+            return 1, ""
         err_str = ["The following items with excluded tags are not allowed in packs:"]
         for item_id, tag_list in sorted(excluded_tag_items_in_packs):
             err_str.append(f"\t{item_id} (tags: {tag_list})")
         return 1, "\n".join(err_str)
 
+    if is_json_mode():
+        _emit_check_packs_json(0)
+        return 0, ""
     return 0, "Looks like packs are up to date"
 
 
@@ -2134,10 +2328,28 @@ def global_options(
     skip_version_check: bool = typer.Option(
         False, "--skip-version-check", help="Skip Panther version check"
     ),
+    output_format: OutputFormat = typer.Option(
+        OutputFormat.text,
+        "--output-format",
+        envvar="PANTHER_OUTPUT_FORMAT",
+        help=(
+            "Output format for command results. "
+            "'text' (default) prints human-readable colored output. "
+            "'json' prints a single JSON object to stdout suitable for CI/CD integration."
+        ),
+    ),
 ) -> None:
     """
     Panther Analysis Tool: A command line tool for managing Panther policies and rules.
     """
+    global _output_format  # noqa: PLW0603
+    _output_format = output_format
+
+    if output_format == OutputFormat.json:
+        for handler in logging.root.handlers:
+            if isinstance(handler, logging.StreamHandler):
+                handler.setStream(sys.stderr)
+
     # These options run before any subcommand.
     if debug:
         logging.getLogger().setLevel(logging.DEBUG)
@@ -2245,7 +2457,6 @@ def test(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         ),
     ] = None,
     workers: WorkersType = 1,
-    output_format: OutputFormatType = OutputFormat.text,
 ) -> Tuple[int, list[Any]]:
     if ignore_files is None:
         ignore_files = []
@@ -2274,7 +2485,6 @@ def test(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         valid_table_names=valid_table_names,
         test_names=test_names,
         workers=workers,
-        output_format=output_format,
     )
 
     return test_analysis(pat_utils.get_optional_backend(api_token, api_host), args)

--- a/panther_analysis_tool/output.py
+++ b/panther_analysis_tool/output.py
@@ -1,0 +1,27 @@
+"""Global output format state shared between main and command modules.
+
+This module exists to break the circular import between ``main`` and
+the ``command.*`` modules.  Command modules import ``is_json_mode``
+from here instead of from ``main``, and ``main.global_options`` calls
+``set_output_format`` to update the shared state.
+"""
+
+from panther_analysis_tool.command.standard_args import OutputFormat
+
+_output_format: OutputFormat = OutputFormat.text
+
+
+def set_output_format(fmt: OutputFormat) -> None:
+    """Set the globally configured output format (called by main)."""
+    global _output_format  # noqa: PLW0603  # pylint: disable=global-statement
+    _output_format = fmt
+
+
+def get_output_format() -> OutputFormat:
+    """Return the globally configured output format."""
+    return _output_format
+
+
+def is_json_mode() -> bool:
+    """Return True when the global output format is JSON."""
+    return _output_format == OutputFormat.json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "panther_analysis_tool"
-version = "1.5.2"
+version = "1.6.0"
 description = "Panther command line interface for writing, testing, and packaging policies/rules."
 authors = [{ name = "Panther Labs Inc", email = "pypi@runpanther.io" }]
 readme = "README.md"

--- a/tests/unit/panther_analysis_tool/test_json_output.py
+++ b/tests/unit/panther_analysis_tool/test_json_output.py
@@ -1,4 +1,4 @@
-"""Tests for --output-format json feature: serialization helpers and JSON output functions."""
+"""Tests for --output-format json feature: serialization helpers, JSON output functions, and global infrastructure."""
 
 import json
 from collections import defaultdict
@@ -14,10 +14,16 @@ from panther_analysis_tool.core.definitions import (
     TestResultsContainer,
 )
 from panther_analysis_tool.main import (
+    _check_packs_json_default,
+    _command_emits_own_json,
+    _emit_check_packs_json,
+    _emit_json_result,
     _print_json_error,
     _print_json_output,
     _serialize_function_result,
     _serialize_test_result,
+    get_output_format,
+    is_json_mode,
 )
 
 
@@ -126,6 +132,7 @@ class TestPrintJsonOutput(TestCase):
         num_detections: int = 5,
         failed_tests: Optional[DefaultDict[str, list]] = None,
         invalid_specs: Optional[List[Any]] = None,
+        num_invalid_detections: Optional[int] = None,
         skipped_tests: Optional[List[Tuple[str, dict]]] = None,
         all_test_results: Optional[TestResultsContainer] = None,
     ) -> Dict[str, Any]:
@@ -138,6 +145,8 @@ class TestPrintJsonOutput(TestCase):
             skipped_tests = []
         if all_test_results is None:
             all_test_results = TestResultsContainer(passed={}, errored={})
+        if num_invalid_detections is None:
+            num_invalid_detections = len(invalid_specs)
 
         buf = StringIO()
         with mock.patch("panther_analysis_tool.main.print", side_effect=lambda x: buf.write(x)):
@@ -146,6 +155,7 @@ class TestPrintJsonOutput(TestCase):
                 num_detections=num_detections,
                 failed_tests=failed_tests,
                 invalid_specs=invalid_specs,
+                num_invalid_detections=num_invalid_detections,
                 skipped_tests=skipped_tests,
                 all_test_results=all_test_results,
             )
@@ -188,9 +198,34 @@ class TestPrintJsonOutput(TestCase):
         failed["R2"] = ["t2"]
         invalid = [("f1.yml", "err1"), ("f2.yml", "err2"), ("f3.yml", "err3")]
         output = self._capture_json_output(
-            num_detections=1, failed_tests=failed, invalid_specs=invalid
+            num_detections=1,
+            failed_tests=failed,
+            invalid_specs=invalid,
+            num_invalid_detections=3,
         )
         self.assertEqual(output["summary"]["passed"], 0)
+
+    def test_non_detection_invalids_do_not_reduce_passed(self) -> None:
+        """Data model and pack errors in invalid_specs should not lower the passed count.
+
+        num_detections only counts rules/simple_detections. Data model load
+        failures and pack validation errors are appended to invalid_specs but
+        were never counted in num_detections, so subtracting them would
+        artificially deflate the passed count.
+        """
+        invalid = [
+            ("data_model.yml", "Conflicting Enabled LogType"),
+            ("pack.yml", "pack definition includes items that do not exist"),
+            ("bad_rule.yml", "Schema validation failed"),
+        ]
+        output = self._capture_json_output(
+            num_detections=5,
+            invalid_specs=invalid,
+            num_invalid_detections=1,
+        )
+        self.assertEqual(output["summary"]["total"], 5)
+        self.assertEqual(output["summary"]["passed"], 4)
+        self.assertEqual(output["summary"]["invalid"], 3)
 
     def test_results_include_buffered_test_results(self) -> None:
         test_result = _make_test_result(name="pass - good", passed=True, detection_id="Rule.OK")
@@ -246,3 +281,266 @@ class TestOutputFormatEnum(TestCase):
 
     def test_enum_is_string_subclass(self) -> None:
         self.assertIsInstance(OutputFormat.text, str)
+
+
+class TestGlobalJsonMode(TestCase):
+    """Tests for the global is_json_mode / get_output_format infrastructure."""
+
+    def setUp(self) -> None:
+        import panther_analysis_tool.main as main_mod
+
+        self._orig = main_mod._output_format
+        main_mod._output_format = OutputFormat.text
+
+    def tearDown(self) -> None:
+        import panther_analysis_tool.main as main_mod
+
+        main_mod._output_format = self._orig
+
+    def test_is_json_mode_default_is_text(self) -> None:
+        self.assertFalse(is_json_mode())
+
+    def test_is_json_mode_when_json(self) -> None:
+        import panther_analysis_tool.main as main_mod
+
+        main_mod._output_format = OutputFormat.json
+        self.assertTrue(is_json_mode())
+
+    def test_get_output_format_returns_current(self) -> None:
+        self.assertEqual(get_output_format(), OutputFormat.text)
+        import panther_analysis_tool.main as main_mod
+
+        main_mod._output_format = OutputFormat.json
+        self.assertEqual(get_output_format(), OutputFormat.json)
+
+
+class TestEmitJsonResult(TestCase):
+    """Tests for the generic _emit_json_result envelope."""
+
+    def _capture(self, command: str, return_code: int, out: Any) -> Dict[str, Any]:
+        buf = StringIO()
+        with mock.patch("panther_analysis_tool.main.print", side_effect=lambda x: buf.write(x)):
+            _emit_json_result(command, return_code, out)
+        return json.loads(buf.getvalue())
+
+    def test_success_with_message(self) -> None:
+        result = self._capture("zip", 0, "archive.zip")
+        self.assertEqual(result["command"], "zip")
+        self.assertEqual(result["return_code"], 0)
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["message"], "archive.zip")
+
+    def test_success_empty_output(self) -> None:
+        result = self._capture("fmt", 0, "")
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("message", result)
+
+    def test_error_with_string(self) -> None:
+        result = self._capture("check_connection", 1, "Connection refused")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["errors"][0]["error"], "Connection refused")
+
+    def test_error_with_tuple_list(self) -> None:
+        out = [("rule.yml", "validation failed")]
+        result = self._capture("test", 1, out)
+        self.assertEqual(result["errors"][0]["file"], "rule.yml")
+        self.assertEqual(result["errors"][0]["error"], "validation failed")
+
+    def test_error_with_plain_list(self) -> None:
+        out = ["some error string"]
+        result = self._capture("upload", 1, out)
+        self.assertEqual(result["errors"][0]["error"], "some error string")
+
+
+class TestCommandEmitsOwnJson(TestCase):
+    """Tests for _command_emits_own_json routing logic."""
+
+    def test_test_command_emits_own(self) -> None:
+        self.assertTrue(_command_emits_own_json("test"))
+
+    def test_upload_command_emits_own(self) -> None:
+        self.assertTrue(_command_emits_own_json("upload"))
+
+    def test_validate_command_emits_own(self) -> None:
+        self.assertTrue(_command_emits_own_json("validate"))
+
+    def test_debug_command_emits_own(self) -> None:
+        self.assertTrue(_command_emits_own_json("debug"))
+
+    def test_unknown_command_does_not(self) -> None:
+        self.assertFalse(_command_emits_own_json("zip"))
+
+    def test_all_known_commands_registered(self) -> None:
+        known = [
+            "test",
+            "debug",
+            "upload",
+            "validate",
+            "benchmark",
+            "check_packs",
+            "migrate",
+            "delete",
+            "merge",
+            "update",
+            "enrich_test_data",
+            "update_custom_schemas",
+            "init",
+        ]
+        for cmd in known:
+            self.assertTrue(
+                _command_emits_own_json(cmd),
+                f"{cmd} should emit its own JSON",
+            )
+
+
+class TestEmitCheckPacksJson(TestCase):
+    """Tests for _emit_check_packs_json helper."""
+
+    def _capture(self, return_code: int, **data: Any) -> Dict[str, Any]:
+        buf = StringIO()
+        with mock.patch("panther_analysis_tool.main.print", side_effect=lambda x: buf.write(x)):
+            _emit_check_packs_json(return_code, **data)
+        return json.loads(buf.getvalue())
+
+    def test_success_no_data(self) -> None:
+        result = self._capture(0)
+        self.assertEqual(result["command"], "check-packs")
+        self.assertEqual(result["return_code"], 0)
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("data", result)
+
+    def test_error_with_missing_items(self) -> None:
+        items = [{"path": "pack.yml", "missing": {"Rule.A", "Rule.B"}}]
+        result = self._capture(1, missing_items=items)
+        self.assertEqual(result["status"], "error")
+        self.assertIn("data", result)
+        missing = result["data"]["missing_items"][0]["missing"]
+        self.assertEqual(sorted(missing), ["Rule.A", "Rule.B"])
+
+    def test_error_with_sorted_list(self) -> None:
+        result = self._capture(1, items_not_in_packs=["Z.Rule", "A.Rule"])
+        self.assertEqual(result["data"]["items_not_in_packs"], ["Z.Rule", "A.Rule"])
+
+    def test_sets_are_sorted_in_output(self) -> None:
+        """Verify _check_packs_json_default converts sets to sorted lists."""
+        self.assertEqual(_check_packs_json_default({"c", "a", "b"}), ["a", "b", "c"])
+
+    def test_non_set_falls_back_to_str(self) -> None:
+        """Non-set, non-serializable objects fall back to str()."""
+        self.assertIsInstance(_check_packs_json_default(object()), str)
+
+
+class TestEmitValidateJson(TestCase):
+    """Tests for _emit_validate_json helper."""
+
+    def _capture(self, return_code: int, **kwargs: Any) -> Dict[str, Any]:
+        from panther_analysis_tool.command.validate import _emit_validate_json
+
+        buf = StringIO()
+        with mock.patch(
+            "panther_analysis_tool.command.validate.print",
+            side_effect=lambda x: buf.write(x),
+        ):
+            _emit_validate_json(return_code, **kwargs)
+        return json.loads(buf.getvalue())
+
+    def test_error_with_string(self) -> None:
+        result = self._capture(1, error="Invalid backend")
+        self.assertEqual(result["command"], "validate")
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["errors"][0]["error"], "Invalid backend")
+
+    def test_success_no_result(self) -> None:
+        result = self._capture(0)
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("data", result)
+        self.assertNotIn("errors", result)
+
+    def test_error_with_mock_result(self) -> None:
+        """Verify the result object branch when has_error/has_issues are present."""
+
+        class _MockResult:
+            def is_valid(self) -> bool:
+                return False
+
+            def has_error(self) -> bool:
+                return True
+
+            def get_error(self) -> str:
+                return "some error"
+
+            def has_issues(self) -> bool:
+                return False
+
+            def get_issues(self) -> list:
+                return []
+
+        result = self._capture(1, result=_MockResult())
+        self.assertEqual(result["status"], "error")
+        self.assertFalse(result["data"]["valid"])
+        self.assertEqual(result["data"]["error"], "some error")
+        self.assertEqual(result["data"]["issues"], [])
+
+
+class TestEmitDeleteJson(TestCase):
+    """Tests for _emit_delete_json helper."""
+
+    def _capture(self, return_code: int, **data: Any) -> Dict[str, Any]:
+        from panther_analysis_tool.command.bulk_delete import _emit_delete_json
+
+        buf = StringIO()
+        with mock.patch(
+            "panther_analysis_tool.command.bulk_delete.print",
+            side_effect=lambda x: buf.write(x),
+        ):
+            _emit_delete_json(return_code, **data)
+        return json.loads(buf.getvalue())
+
+    def test_success_with_deletions(self) -> None:
+        result = self._capture(0, detections=["Rule.A"], queries=["Q1"])
+        self.assertEqual(result["command"], "delete")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"]["detections"], ["Rule.A"])
+        self.assertEqual(result["data"]["queries"], ["Q1"])
+
+    def test_success_empty(self) -> None:
+        result = self._capture(0)
+        self.assertEqual(result["status"], "success")
+        self.assertNotIn("data", result)
+
+
+class TestEmitMergeJson(TestCase):
+    """Tests for _emit_merge_json helper."""
+
+    def _capture(
+        self,
+        updated: list[str],
+        conflicts: list[str],
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        from panther_analysis_tool.command.merge import _emit_merge_json
+
+        buf = StringIO()
+        with mock.patch(
+            "panther_analysis_tool.command.merge.print",
+            side_effect=lambda x: buf.write(x),
+        ):
+            _emit_merge_json(updated, conflicts, **kwargs)
+        return json.loads(buf.getvalue())
+
+    def test_empty_merge(self) -> None:
+        result = self._capture([], [])
+        self.assertEqual(result["command"], "merge")
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["data"]["updated_items"], [])
+        self.assertEqual(result["data"]["merge_conflicts"], [])
+
+    def test_with_updates_and_conflicts(self) -> None:
+        result = self._capture(["Rule.A"], ["Rule.B"], preview=True)
+        self.assertTrue(result["data"]["preview"])
+        self.assertEqual(result["data"]["updated_items"], ["Rule.A"])
+        self.assertEqual(result["data"]["merge_conflicts"], ["Rule.B"])
+
+    def test_with_message(self) -> None:
+        result = self._capture([], [], message="Not found")
+        self.assertEqual(result["data"]["message"], "Not found")

--- a/tests/unit/panther_analysis_tool/test_json_output.py
+++ b/tests/unit/panther_analysis_tool/test_json_output.py
@@ -6,6 +6,8 @@ from io import StringIO
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 from unittest import TestCase, mock
 
+from panther_core.testing import TestResult, TestResultsPerFunction
+
 from panther_analysis_tool.command.standard_args import OutputFormat
 from panther_analysis_tool.core.definitions import (
     TestResultContainer,
@@ -22,7 +24,6 @@ from panther_analysis_tool.main import (
     _serialize_test_result,
 )
 from panther_analysis_tool.output import get_output_format, is_json_mode
-from panther_core.testing import TestResult, TestResultsPerFunction
 
 
 def _make_test_result(

--- a/tests/unit/panther_analysis_tool/test_json_output.py
+++ b/tests/unit/panther_analysis_tool/test_json_output.py
@@ -6,8 +6,6 @@ from io import StringIO
 from typing import Any, DefaultDict, Dict, List, Optional, Tuple
 from unittest import TestCase, mock
 
-from panther_core.testing import TestResult, TestResultsPerFunction
-
 from panther_analysis_tool.command.standard_args import OutputFormat
 from panther_analysis_tool.core.definitions import (
     TestResultContainer,
@@ -22,9 +20,9 @@ from panther_analysis_tool.main import (
     _print_json_output,
     _serialize_function_result,
     _serialize_test_result,
-    get_output_format,
-    is_json_mode,
 )
+from panther_analysis_tool.output import get_output_format, is_json_mode
+from panther_core.testing import TestResult, TestResultsPerFunction
 
 
 def _make_test_result(
@@ -287,30 +285,30 @@ class TestGlobalJsonMode(TestCase):
     """Tests for the global is_json_mode / get_output_format infrastructure."""
 
     def setUp(self) -> None:
-        import panther_analysis_tool.main as main_mod
+        import panther_analysis_tool.output as output_mod
 
-        self._orig = main_mod._output_format
-        main_mod._output_format = OutputFormat.text
+        self._orig = output_mod._output_format
+        output_mod._output_format = OutputFormat.text
 
     def tearDown(self) -> None:
-        import panther_analysis_tool.main as main_mod
+        import panther_analysis_tool.output as output_mod
 
-        main_mod._output_format = self._orig
+        output_mod._output_format = self._orig
 
     def test_is_json_mode_default_is_text(self) -> None:
         self.assertFalse(is_json_mode())
 
     def test_is_json_mode_when_json(self) -> None:
-        import panther_analysis_tool.main as main_mod
+        import panther_analysis_tool.output as output_mod
 
-        main_mod._output_format = OutputFormat.json
+        output_mod._output_format = OutputFormat.json
         self.assertTrue(is_json_mode())
 
     def test_get_output_format_returns_current(self) -> None:
         self.assertEqual(get_output_format(), OutputFormat.text)
-        import panther_analysis_tool.main as main_mod
+        import panther_analysis_tool.output as output_mod
 
-        main_mod._output_format = OutputFormat.json
+        output_mod._output_format = OutputFormat.json
         self.assertEqual(get_output_format(), OutputFormat.json)
 
 

--- a/tests/unit/panther_analysis_tool/test_json_output.py
+++ b/tests/unit/panther_analysis_tool/test_json_output.py
@@ -1,0 +1,248 @@
+"""Tests for --output-format json feature: serialization helpers and JSON output functions."""
+
+import json
+from collections import defaultdict
+from io import StringIO
+from typing import Any, DefaultDict, Dict, List, Optional, Tuple
+from unittest import TestCase, mock
+
+from panther_core.testing import TestResult, TestResultsPerFunction
+
+from panther_analysis_tool.command.standard_args import OutputFormat
+from panther_analysis_tool.core.definitions import (
+    TestResultContainer,
+    TestResultsContainer,
+)
+from panther_analysis_tool.main import (
+    _print_json_error,
+    _print_json_output,
+    _serialize_function_result,
+    _serialize_test_result,
+)
+
+
+def _make_test_result(
+    name: str = "test-1",
+    passed: bool = True,
+    errored: bool = False,
+    generic_error: Optional[str] = None,
+    detection_id: str = "Rule.Example",
+    functions: Optional[TestResultsPerFunction] = None,
+) -> TestResult:
+    """Build a minimal TestResult for testing."""
+    return TestResult(
+        id=name,
+        name=name,
+        detectionId=detection_id,
+        genericError=generic_error,
+        error=None,
+        errored=errored,
+        passed=passed,
+        trigger_alert=None,
+        functions=functions or TestResultsPerFunction(detectionFunction=None),
+    )
+
+
+class TestSerializeFunctionResult(TestCase):
+    """Tests for _serialize_function_result."""
+
+    def test_none_input_returns_none(self) -> None:
+        result = _serialize_function_result("titleFunction", None)
+        self.assertIsNone(result)
+
+    def test_passing_result(self) -> None:
+        func_result = {"output": '"Example Title"', "error": None, "matched": True}
+        result = _serialize_function_result("titleFunction", func_result)
+        assert result is not None
+        self.assertEqual(result["name"], "title")
+        self.assertEqual(result["status"], "pass")
+        self.assertEqual(result["output"], '"Example Title"')
+
+    def test_failing_result(self) -> None:
+        func_result = {"output": '"wrong"', "error": None, "matched": False}
+        result = _serialize_function_result("detectionFunction", func_result)
+        assert result is not None
+        self.assertEqual(result["name"], "detection")
+        self.assertEqual(result["status"], "fail")
+
+    def test_error_result_with_dict(self) -> None:
+        func_result = {"output": None, "error": {"message": "boom"}, "matched": None}
+        result = _serialize_function_result("severityFunction", func_result)
+        assert result is not None
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "boom")
+
+    def test_error_result_with_string_error(self) -> None:
+        func_result = {"output": None, "error": "something broke", "matched": None}
+        result = _serialize_function_result("titleFunction", func_result)
+        assert result is not None
+        self.assertEqual(result["status"], "error")
+        self.assertEqual(result["error"], "something broke")
+
+    def test_function_name_strips_function_suffix(self) -> None:
+        func_result = {"output": "ok", "matched": True}
+        result = _serialize_function_result("alertContextFunction", func_result)
+        assert result is not None
+        self.assertEqual(result["name"], "alertContext")
+
+
+class TestSerializeTestResult(TestCase):
+    """Tests for _serialize_test_result."""
+
+    def test_passing_test_result(self) -> None:
+        test_result = _make_test_result(name="pass - example", passed=True)
+        container = TestResultContainer(
+            detection=None,
+            result=test_result,
+            failed_tests=defaultdict(list),
+            output="",
+        )
+        serialized = _serialize_test_result(container)
+        self.assertEqual(serialized["name"], "pass - example")
+        self.assertTrue(serialized["passed"])
+        self.assertFalse(serialized["errored"])
+
+    def test_errored_test_result(self) -> None:
+        test_result = _make_test_result(
+            name="fail - bad", passed=False, errored=True, generic_error="KeyError: foo"
+        )
+        container = TestResultContainer(
+            detection=None,
+            result=test_result,
+            failed_tests=defaultdict(list),
+            output="",
+        )
+        serialized = _serialize_test_result(container)
+        self.assertFalse(serialized["passed"])
+        self.assertTrue(serialized["errored"])
+        self.assertEqual(serialized["genericError"], "KeyError: foo")
+
+
+class TestPrintJsonOutput(TestCase):
+    """Tests for _print_json_output."""
+
+    def _capture_json_output(
+        self,
+        num_detections: int = 5,
+        failed_tests: Optional[DefaultDict[str, list]] = None,
+        invalid_specs: Optional[List[Any]] = None,
+        skipped_tests: Optional[List[Tuple[str, dict]]] = None,
+        all_test_results: Optional[TestResultsContainer] = None,
+    ) -> Dict[str, Any]:
+        """Call _print_json_output and parse the captured stdout as JSON."""
+        if failed_tests is None:
+            failed_tests = defaultdict(list)
+        if invalid_specs is None:
+            invalid_specs = []
+        if skipped_tests is None:
+            skipped_tests = []
+        if all_test_results is None:
+            all_test_results = TestResultsContainer(passed={}, errored={})
+
+        buf = StringIO()
+        with mock.patch("panther_analysis_tool.main.print", side_effect=lambda x: buf.write(x)):
+            _print_json_output(
+                test_path="./rules",
+                num_detections=num_detections,
+                failed_tests=failed_tests,
+                invalid_specs=invalid_specs,
+                skipped_tests=skipped_tests,
+                all_test_results=all_test_results,
+            )
+        return json.loads(buf.getvalue())
+
+    def test_all_passing_produces_valid_json(self) -> None:
+        output = self._capture_json_output(num_detections=3)
+        self.assertEqual(output["summary"]["total"], 3)
+        self.assertEqual(output["summary"]["passed"], 3)
+        self.assertEqual(output["summary"]["failed"], 0)
+        self.assertEqual(output["results"], {})
+        self.assertEqual(output["failed"], {})
+        self.assertEqual(output["invalid"], [])
+        self.assertEqual(output["skipped"], [])
+
+    def test_failed_tests_in_output(self) -> None:
+        failed: DefaultDict[str, list] = defaultdict(list)
+        failed["Rule.Bad"] = ["test-1", "test-2"]
+        output = self._capture_json_output(num_detections=5, failed_tests=failed)
+        self.assertEqual(output["summary"]["failed"], 1)
+        self.assertIn("Rule.Bad", output["failed"])
+        self.assertEqual(output["failed"]["Rule.Bad"], ["test-1", "test-2"])
+
+    def test_invalid_specs_in_output(self) -> None:
+        invalid = [("bad_rule.yml", "Schema validation failed")]
+        output = self._capture_json_output(num_detections=5, invalid_specs=invalid)
+        self.assertEqual(output["summary"]["invalid"], 1)
+        self.assertEqual(output["invalid"][0]["file"], "bad_rule.yml")
+        self.assertEqual(output["invalid"][0]["error"], "Schema validation failed")
+
+    def test_skipped_tests_in_output(self) -> None:
+        skipped = [("skipped.yml", {"RuleID": "Rule.Skipped"})]
+        output = self._capture_json_output(num_detections=5, skipped_tests=skipped)
+        self.assertEqual(output["summary"]["skipped"], 1)
+        self.assertEqual(output["skipped"][0]["id"], "Rule.Skipped")
+
+    def test_num_passed_never_negative(self) -> None:
+        failed: DefaultDict[str, list] = defaultdict(list)
+        failed["R1"] = ["t1"]
+        failed["R2"] = ["t2"]
+        invalid = [("f1.yml", "err1"), ("f2.yml", "err2"), ("f3.yml", "err3")]
+        output = self._capture_json_output(
+            num_detections=1, failed_tests=failed, invalid_specs=invalid
+        )
+        self.assertEqual(output["summary"]["passed"], 0)
+
+    def test_results_include_buffered_test_results(self) -> None:
+        test_result = _make_test_result(name="pass - good", passed=True, detection_id="Rule.OK")
+        container = TestResultContainer(
+            detection=None,
+            result=test_result,
+            failed_tests=defaultdict(list),
+            output="",
+        )
+        results = TestResultsContainer(
+            passed={"Rule.OK": [container]},
+            errored={},
+        )
+        output = self._capture_json_output(num_detections=1, all_test_results=results)
+        self.assertIn("Rule.OK", output["results"])
+        self.assertEqual(len(output["results"]["Rule.OK"]), 1)
+        self.assertTrue(output["results"]["Rule.OK"][0]["passed"])
+
+
+class TestPrintJsonError(TestCase):
+    """Tests for _print_json_error."""
+
+    def test_produces_valid_json_with_errors(self) -> None:
+        buf = StringIO()
+        with mock.patch("panther_analysis_tool.main.print", side_effect=lambda x: buf.write(x)):
+            _print_json_error("./rules", [("bad.yml", "parse error")])
+        output = json.loads(buf.getvalue())
+        self.assertEqual(output["summary"]["total"], 0)
+        self.assertEqual(output["summary"]["passed"], 0)
+        self.assertEqual(output["summary"]["invalid"], 1)
+        self.assertEqual(output["invalid"][0]["file"], "bad.yml")
+        self.assertEqual(output["invalid"][0]["error"], "parse error")
+
+    def test_empty_path_no_specs(self) -> None:
+        buf = StringIO()
+        with mock.patch("panther_analysis_tool.main.print", side_effect=lambda x: buf.write(x)):
+            _print_json_error("./empty", [("./empty", "Nothing to test")])
+        output = json.loads(buf.getvalue())
+        self.assertEqual(output["summary"]["path"], "./empty")
+        self.assertEqual(output["summary"]["total"], 0)
+
+
+class TestOutputFormatEnum(TestCase):
+    """Tests for the OutputFormat enum."""
+
+    def test_enum_values(self) -> None:
+        self.assertEqual(OutputFormat.text.value, "text")
+        self.assertEqual(OutputFormat.json.value, "json")
+
+    def test_enum_string_comparison(self) -> None:
+        self.assertEqual(OutputFormat.text, "text")
+        self.assertEqual(OutputFormat.json, "json")
+
+    def test_enum_is_string_subclass(self) -> None:
+        self.assertIsInstance(OutputFormat.text, str)


### PR DESCRIPTION
## Summary

Adds a global `--output-format {text,json}` option to **all** CLI commands, enabling structured JSON output for CI/CD integration and programmatic consumption. When enabled, all logging redirects to stderr and each command emits a single JSON object to stdout.

This is a more complete implementation of the feature requested in #634, extending JSON output beyond just the `test` command to cover the entire CLI surface. Supersedes #772.

### Architecture

- **Global option**: `--output-format json` (or `PANTHER_OUTPUT_FORMAT=json` envvar) is registered in the Typer app callback and applies to every command
- **Automatic coverage**: Commands that don't produce custom JSON automatically receive a generic `{command, status, return_code}` envelope via the `call_and_exit` wrapper
- **Custom JSON**: Commands with rich domain data produce structured, command-specific output
- **Clean stdout**: All logging is redirected to stderr in JSON mode; helper functions that print informational text are suppressed
- **Interactive prompts**: Skipped in JSON mode (e.g., bulk delete confirmation) with a log message to stderr

### Commands with custom JSON output

| Command | JSON data includes |
|---|---|
| `test` | Summary counts, per-detection results with function-level pass/fail/error, failures, invalid specs, skipped tests |
| `validate` | Validation result, issues list, error details |
| `upload` | Full API response with upload results |
| `benchmark` | Timing statistics (mean/median/max/min), performance rating, per-iteration data |
| `check-packs` | Missing items, items not in packs, experimental/deprecated violations |
| `delete` | Deleted detection IDs and query names |
| `merge` | Updated item IDs, merge conflict IDs, preview mode |
| `migrate` | Migration status, conflicts, warnings |
| `enrich-test-data` | Enriched analysis IDs |
| `update-custom-schemas` | Per-schema results |
| `init` | Project initialization status |

All other commands (`zip`, `release`, `fmt`, `check-connection`, `test-lookup-table`, `publish`, `explore`, `install`, `update`) receive the generic envelope automatically.

### Changes

**New/modified files:**

- `panther_analysis_tool/main.py` — Global `--output-format` in app callback, `_emit_json_result()` generic envelope, `_COMMANDS_WITH_OWN_JSON` routing, test command JSON output, `_emit_check_packs_json()`, upload/enrich/update-schemas JSON paths
- `panther_analysis_tool/command/standard_args.py` — `OutputFormat(str, Enum)` definition
- `panther_analysis_tool/command/validate.py` — `_emit_validate_json()` with validation result/issues
- `panther_analysis_tool/command/benchmark.py` — `_emit_benchmark_json()` with timing stats and performance rating
- `panther_analysis_tool/command/bulk_delete.py` — `_emit_delete_json()` with deletion results
- `panther_analysis_tool/command/merge.py` — `_emit_merge_json()` with update/conflict tracking
- `panther_analysis_tool/command/migrate.py` — `_emit_migrate_json()` leveraging existing `MigrationStatus.to_dict()`
- `panther_analysis_tool/command/init_project.py` — JSON output with stdout suppression for helper functions
- `tests/unit/panther_analysis_tool/test_json_output.py` — 47 unit tests

**Version bump:** 1.5.2 → 1.6.0

## Usage Examples

<details>
<summary><strong><code>test</code></strong> — Run tests with full JSON output</summary>

```bash
panther_analysis_tool --output-format json test \
  --path rules/ \
  --filter RuleID=Crowdstrike.Detection.Passthrough 2>/dev/null
```

```json
{
  "summary": {
    "path": "rules/",
    "total": 1,
    "passed": 1,
    "failed": 0,
    "invalid": 0,
    "skipped": 0
  },
  "results": {
    "Crowdstrike.Detection.Passthrough": [
      {
        "name": "Low Severity Finding",
        "passed": true,
        "errored": false,
        "functions": [
          {"name": "rule", "status": "pass", "output": "true"},
          {"name": "title", "status": "pass", "output": "Crowdstrike Alert: NGAV on macbook"},
          {"name": "severity", "status": "pass", "output": "LOW"}
        ]
      }
    ]
  },
  "failed": {},
  "invalid": [],
  "skipped": []
}
```

Extract just the summary:

```bash
panther_analysis_tool --output-format json test --path rules/ 2>/dev/null | jq '.summary'
```

Extract a specific test result:

```bash
panther_analysis_tool --output-format json test \
  --path rules/ \
  --filter RuleID=Crowdstrike.Detection.Passthrough 2>/dev/null \
  | jq '.results["Crowdstrike.Detection.Passthrough"][0] | {name, passed}'
```

</details>

<details>
<summary><strong><code>validate</code></strong> — Validate detections against a Panther deployment</summary>

```bash
panther_analysis_tool --output-format json validate --path rules/ 2>/dev/null
```

```json
{
  "command": "validate",
  "return_code": 0,
  "status": "success",
  "data": {
    "valid": true,
    "error": null,
    "issues": []
  }
}
```

On failure:

```json
{
  "command": "validate",
  "return_code": 1,
  "status": "error",
  "data": {
    "valid": false,
    "error": "Validation failed",
    "issues": [{"severity": "error", "message": "Invalid field reference"}]
  }
}
```

</details>

<details>
<summary><strong><code>upload</code></strong> — Upload detections to Panther</summary>

```bash
panther_analysis_tool --output-format json upload --path rules/ 2>/dev/null
```

```json
{
  "command": "upload",
  "return_code": 0,
  "status": "success",
  "data": {
    "rules": {"new": 0, "modified": 2, "total": 15},
    "policies": {"new": 0, "modified": 0, "total": 3}
  }
}
```

</details>

<details>
<summary><strong><code>benchmark</code></strong> — Performance test a detection rule</summary>

```bash
panther_analysis_tool --output-format json benchmark \
  --path rules/my_rule.py --iterations 10 2>/dev/null
```

```json
{
  "command": "benchmark",
  "return_code": 0,
  "status": "success",
  "data": {
    "rule": "my_rule.yml",
    "hour": "2026-03-10T12:00:00",
    "iterations_completed": 10,
    "had_error": false,
    "read_time_seconds": {"mean": 0.45, "median": 0.42, "max": 0.78, "min": 0.31},
    "processing_time_seconds": {"mean": 1.23, "median": 1.15, "max": 2.01, "min": 0.89},
    "performance_rating": "highly_performant",
    "iterations": [{"read_time_nanos": 420000000, "processing_time_nanos": 1150000000}]
  }
}
```

</details>

<details>
<summary><strong><code>check-packs</code></strong> — Validate pack completeness</summary>

```bash
panther_analysis_tool --output-format json check-packs --path . 2>/dev/null
```

Success:

```json
{
  "command": "check-packs",
  "return_code": 0,
  "status": "success"
}
```

Missing items:

```json
{
  "command": "check-packs",
  "return_code": 1,
  "status": "error",
  "data": {
    "missing_items": [{"path": "packs/core.yml", "missing": ["Rule.Missing"]}]
  }
}
```

</details>

<details>
<summary><strong><code>delete</code></strong> — Bulk delete detections or saved queries</summary>

```bash
panther_analysis_tool --output-format json delete \
  --analysis-id Rule.Old Rule.Deprecated 2>/dev/null
```

```json
{
  "command": "delete",
  "return_code": 0,
  "status": "success",
  "data": {
    "detections": ["Rule.Old", "Rule.Deprecated"]
  }
}
```

Note: Interactive confirmation is skipped in JSON mode. A log message is emitted to stderr.

</details>

<details>
<summary><strong><code>merge</code></strong> — Merge analysis items with latest Panther content</summary>

```bash
panther_analysis_tool --output-format json merge 2>/dev/null
```

```json
{
  "command": "merge",
  "return_code": 0,
  "status": "success",
  "data": {
    "preview": false,
    "updated_items": ["AWS.CloudTrail.Root.Activity", "AWS.S3.BucketPolicy"],
    "merge_conflicts": ["Custom.SSO.Login"]
  }
}
```

</details>

<details>
<summary><strong><code>migrate</code></strong> — Migrate detections to latest format</summary>

```bash
panther_analysis_tool --output-format json migrate 2>/dev/null
```

```json
{
  "command": "migrate",
  "return_code": 0,
  "status": "success",
  "data": {
    "single_item": false,
    "has_conflicts": false,
    "has_warnings": true,
    "empty": false,
    "migrated": ["Rule.A", "Rule.B"],
    "warnings": ["Rule.C: deprecated field 'Threshold'"]
  }
}
```

</details>

<details>
<summary><strong><code>enrich-test-data</code></strong> — Enrich test data with live Panther data</summary>

```bash
panther_analysis_tool --output-format json enrich-test-data --path rules/ 2>/dev/null
```

```json
{
  "command": "enrich-test-data",
  "return_code": 0,
  "status": "success",
  "data": {
    "enriched_ids": ["AWS.CloudTrail.Root.Activity", "AWS.S3.ServerAccess.Logging"]
  }
}
```

</details>

<details>
<summary><strong><code>update-custom-schemas</code></strong> — Update custom log schemas</summary>

```bash
panther_analysis_tool --output-format json update-custom-schemas --path schemas/ 2>/dev/null
```

```json
{
  "command": "update-custom-schemas",
  "return_code": 0,
  "status": "success",
  "data": {
    "results": [
      {"failed": false, "summary": "Custom.MyLog: updated successfully"},
      {"failed": false, "summary": "Custom.AuditLog: created"}
    ]
  }
}
```

</details>

<details>
<summary><strong><code>init</code></strong> — Initialize a new Panther project</summary>

```bash
panther_analysis_tool --output-format json init 2>/dev/null
```

```json
{
  "command": "init",
  "return_code": 0,
  "status": "success",
  "data": {
    "pat_root_created": false
  }
}
```

</details>

<details>
<summary><strong>Generic envelope</strong> — Commands without custom JSON (e.g., <code>zip</code>, <code>fmt</code>)</summary>

```bash
panther_analysis_tool --output-format json zip --path rules/ --out ./dist 2>/dev/null
```

```json
{
  "command": "zip",
  "return_code": 0,
  "status": "success",
  "message": "Created archive at ./dist/panther-analysis-all.zip"
}
```

On error:

```json
{
  "command": "check_connection",
  "return_code": 1,
  "status": "error",
  "errors": [{"error": "Connection refused"}]
}
```

</details>

## Testing

47 unit tests covering:

- **Core serialization**: `_serialize_function_result`, `_serialize_test_result` — pass/fail/error states, function name stripping
- **Test command output**: `_print_json_output`, `_print_json_error` — all-passing, failures, invalid specs, skipped, negative-passed clamping, non-detection invalids
- **Global infrastructure**: `is_json_mode`, `get_output_format`, `_emit_json_result`, `_command_emits_own_json` — mode switching, generic envelope, routing
- **Command helpers**: `_emit_check_packs_json`, `_emit_validate_json`, `_emit_delete_json`, `_emit_merge_json` — valid JSON output, edge cases
- **Enum**: `OutputFormat` values, string comparison, str subclass

All 630 existing tests pass with zero regressions.

Closes #634