### PR TITLE
fix: suppress sqlfluff plugin loading INFO messages

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -1936,10 +1936,7 @@ def global_options(
         logging.getLogger().setLevel(logging.DEBUG)
     else:
         aiohttp_logger.setLevel(logging.WARNING)
-        logging.getLogger("sqlfluff.parser").setLevel(logging.WARNING)
-        logging.getLogger("sqlfluff.linter").setLevel(logging.WARNING)
-        logging.getLogger("sqlfluff.lexer").setLevel(logging.WARNING)
-        logging.getLogger("sqlfluff.templater").setLevel(logging.WARNING)
+        logging.getLogger("sqlfluff").setLevel(logging.WARNING)
 
     if not skip_version_check and not _SKIP_HTTP_VERSION_CHECK:
         latest = pat_utils.get_latest_version()


### PR DESCRIPTION
## Summary

- Replaces four individual sqlfluff child logger overrides (`sqlfluff.parser`, `.linter`, `.lexer`, `.templater`) with a single parent `sqlfluff` logger set to WARNING
- This suppresses the noisy "Loading plugin sqlfluff_rules_* version X.Y.Z" INFO messages that are emitted on every `panther_analysis_tool test` invocation

## Problem

Every test run currently prints 10+ lines of sqlfluff plugin loading messages to stderr:

```
INFO: Loading plugin sqlfluff version 3.5.0.
INFO: Loading plugin sqlfluff_rules_aliasing version 3.5.0.
INFO: Loading plugin sqlfluff_rules_ambiguous version 3.5.0.
INFO: Loading plugin sqlfluff_rules_capitalisation version 3.5.0.
INFO: Loading plugin sqlfluff_rules_convention version 3.5.0.
INFO: Loading plugin sqlfluff_rules_jinja version 3.5.0.
INFO: Loading plugin sqlfluff_rules_layout version 3.5.0.
INFO: Loading plugin sqlfluff_rules_references version 3.5.0.
INFO: Loading plugin sqlfluff_rules_structure version 3.5.0.
INFO: Loading plugin sqlfluff_rules_tsql version 3.5.0.
```

These messages originate from `sqlfluff.core.plugin`, which was not covered by the existing child logger overrides. Setting the parent `sqlfluff` logger to WARNING covers all current and future sqlfluff submodules, while still allowing warnings and errors to surface.

## Changes Made

- `panther_analysis_tool/main.py`: In `global_options()`, replaced four `logging.getLogger("sqlfluff.<child>").setLevel(logging.WARNING)` calls with a single `logging.getLogger("sqlfluff").setLevel(logging.WARNING)`. Python's logging hierarchy propagates the level to all child loggers, so the four specific overrides were redundant once the parent is set.

## Test Plan

- Ran `panther_analysis_tool test --filter RuleID=Custom.AWS.GuardDuty.Finding.IAM` and confirmed sqlfluff "Loading plugin" INFO lines no longer appear
- `--debug` mode still enables full debug output as expected
- sqlfluff WARNING/ERROR messages still surface normally

---
> Made with Cursor (claude-4.6-opus-max)