### PR TITLE
fix: allow experimental/deprecated detections to be tested

### DIFF
--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -2060,7 +2060,9 @@ def test(  # pylint: disable=too-many-arguments,too-many-positional-arguments
     if test_names is None:
         test_names = []
 
-    filters, filters_inverted = get_filters_with_status_filters(_filter)
+    # test should parse filter as is, and not filter out Status: deprecated, Status: experimental
+    # so that experimental/deprecated detections still get tested (just not uploaded)
+    filters, filters_inverted = parse_filter_args(_filter)
 
     args = TestAnalysisArgs(
         filters=filters,

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -2110,7 +2110,9 @@ def debug_command(  # pylint: disable=too-many-arguments,too-many-positional-arg
     if available_destination is None:
         available_destination = []
 
-    filters, filters_inverted = get_filters_with_status_filters(_filter)
+    # debug should parse filter as is, and not filter out Status: deprecated, Status: experimental
+    # so that experimental/deprecated detections still get tested (just not uploaded)
+    filters, filters_inverted = parse_filter_args(_filter)
 
     args = TestAnalysisArgs(
         filters=filters,

--- a/tests/unit/panther_analysis_tool/core/test_parse.py
+++ b/tests/unit/panther_analysis_tool/core/test_parse.py
@@ -52,13 +52,13 @@ class TestParser(TestCase):
             self.assertIn(
                 Filter(key="RuleID", values=["abc"], inverted=True), parsed_filters_inverted
             )
-            # by default: experimental and deprecated should always be filtered out
-            self.assertIn(
-                Filter(key="Status", values=["experimental", "deprecated"], inverted=True),
-                parsed_filters_inverted,
-            )
+            # test command should NOT filter out experimental/deprecated
+            # (they should still be tested, just not uploaded)
+            status_filters = [f for f in parsed_filters_inverted if f.key == "Status"]
+            self.assertEqual(len(status_filters), 0)
 
-    def test_parse_filters_status_cannot_be_overridden(self) -> None:
+    def test_parse_filters_status_passed_through_for_test(self) -> None:
+        """Test that Status filters are passed through as-is for the test command."""
         with patch(
             "panther_analysis_tool.main.test_analysis", return_value=(0, [])
         ) as mock_test_analysis:
@@ -71,12 +71,6 @@ class TestParser(TestCase):
                     "--filter",
                     "AnalysisType=policy,global",
                     "--filter",
-                    "Severity=Critical",
-                    "--filter",
-                    "Enabled=true",
-                    "--filter",
-                    "RuleID!=abc",
-                    "--filter",
                     "Status=experimental",
                 ],
             )
@@ -86,20 +80,12 @@ class TestParser(TestCase):
 
             self.assertEqual(result.exit_code, 0)
 
-            mock_test_analysis.return_value = (0, [])
-
             args = mock_test_analysis.call_args[0][1]
 
             parsed_filters, parsed_filters_inverted = args.filters, args.filters_inverted
             self.assertIn(Filter(key="AnalysisType", values=["policy", "global"]), parsed_filters)
-            self.assertIn(Filter(key="Severity", values=["Critical"]), parsed_filters)
-            self.assertIn(Filter(key="Enabled", values=[True]), parsed_filters)
-            self.assertIn(
-                Filter(key="RuleID", values=["abc"], inverted=True), parsed_filters_inverted
-            )
-            # experimental/deprecated should always be excluded, even when user explicitly requests them
-            # experimental should be stripped from the positive filter
-            self.assertIn(Filter(key="Status", values=[]), parsed_filters)
+            # Status=experimental should be passed through without modification for test
+            self.assertIn(Filter(key="Status", values=["experimental"]), parsed_filters)
 
     def test_add_status_filters_no_status_filter(self):
         """Test that defaults are added when no Status filter is provided"""

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -351,29 +351,23 @@ class TestPantherAnalysisTool(TestCase):
         self.assertEqual(return_code, 0)
         self.assertEqual(len(invalid_specs), 0)
 
-    def test_status_deprecated_filtered_out(self) -> None:
+    def test_status_deprecated_not_filtered_out_for_test(self) -> None:
         return_code, invalid_specs = mock_test_analysis(
             self,
             f"test --path {STATUS_FIXTURES_PATH}/status_deprecated".split(),
         )
-        # by default deprecated status should have been filtered out
-        # so this should error since there was nothing to test
-        self.assertEqual(return_code, 1)
-        self.assertEqual(len(invalid_specs), 1)
-        self.assertIn("No", invalid_specs[0])
-        self.assertIn("matched filters", invalid_specs[0])
+        # deprecated detections should still be tested (just not uploaded)
+        self.assertEqual(return_code, 0)
+        self.assertEqual(len(invalid_specs), 0)
 
-    def test_status_experimental_filtered_out(self) -> None:
+    def test_status_experimental_not_filtered_out_for_test(self) -> None:
         return_code, invalid_specs = mock_test_analysis(
             self,
             f"test --path {STATUS_FIXTURES_PATH}/status_experimental".split(),
         )
-        # by default experimental status should have been filtered out
-        # so this should error since there was nothing to test
-        self.assertEqual(return_code, 1)
-        self.assertEqual(len(invalid_specs), 1)
-        self.assertIn("No", invalid_specs[0])
-        self.assertIn("matched filters", invalid_specs[0])
+        # experimental detections should still be tested (just not uploaded)
+        self.assertEqual(return_code, 0)
+        self.assertEqual(len(invalid_specs), 0)
 
     def test_status_stable_not_filtered_out(self) -> None:
         return_code, invalid_specs = mock_test_analysis(
@@ -896,7 +890,7 @@ class TestPantherAnalysisTool(TestCase):
     def test_test_analysis_command_no_args(self) -> None:
         return_code, invalid_specs = mock_test_analysis(self, ["test"])
         self.assertEqual(return_code, 1)
-        self.assertEqual(len(invalid_specs), 26)
+        self.assertEqual(len(invalid_specs), 23)
 
     def test_available_destination_names_invalid_name_returned(self) -> None:
         """When an available destination is given but does not match the returned names"""


### PR DESCRIPTION
## Summary
- The previous fix (5f675d4) correctly prevented experimental/deprecated detections from being uploaded, but also excluded them from `pat test`
- Changes the `test` command to use `parse_filter_args` instead of `get_filters_with_status_filters` so these detections are still tested
- Upload, zip, publish, and other deployment commands continue to exclude experimental/deprecated detections

## Verification
- `pat test --path ../panther-analysis --filter Status=experimental` → **132 passed** (was -2 before)
- `pat test --path ../panther-analysis` → **942 passed** (was 805, +137 experimental/deprecated now tested)
- `pat zip --path ../panther-analysis` → **0 experimental, 0 deprecated** in output zip

## Test plan
- [x] Unit tests updated and passing (119/119)
- [x] Verified experimental rules are tested against panther-analysis
- [x] Verified experimental rules are excluded from zip output
- [x] Verified upload test still asserts experimental exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)