### PR TITLE
Update requests dependency pin from ~=2.32.4 to ~=2.33.1

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -2480,25 +2480,25 @@ files = [
 
 [[package]]
 name = "requests"
-version = "2.32.4"
+version = "2.33.1"
 description = "Python HTTP for Humans."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.10"
 groups = ["main", "dev"]
 files = [
-    {file = "requests-2.32.4-py3-none-any.whl", hash = "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c"},
-    {file = "requests-2.32.4.tar.gz", hash = "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"},
+    {file = "requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a"},
+    {file = "requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517"},
 ]
 
 [package.dependencies]
-certifi = ">=2017.4.17"
+certifi = ">=2023.5.7"
 charset_normalizer = ">=2,<4"
 idna = ">=2.5,<4"
-urllib3 = ">=1.21.1,<3"
+urllib3 = ">=1.26,<3"
 
 [package.extras]
 socks = ["PySocks (>=1.5.6,!=1.5.7)"]
-use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
+use-chardet-on-py3 = ["chardet (>=3.0.2,<8)"]
 
 [[package]]
 name = "responses"
@@ -3519,14 +3519,14 @@ files = [
 
 [[package]]
 name = "types-requests"
-version = "2.32.4.20250913"
+version = "2.33.0.20260408"
 description = "Typing stubs for requests"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["dev"]
 files = [
-    {file = "types_requests-2.32.4.20250913-py3-none-any.whl", hash = "sha256:78c9c1fffebbe0fa487a418e0fa5252017e9c60d1a2da394077f1780f655d7e1"},
-    {file = "types_requests-2.32.4.20250913.tar.gz", hash = "sha256:abd6d4f9ce3a9383f269775a9835a4c24e5cd6b9f647d64f88aa4613c33def5d"},
+    {file = "types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f"},
+    {file = "types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b"},
 ]
 
 [package.dependencies]
@@ -3860,4 +3860,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <4.0"
-content-hash = "c2a737381bf083359fefda396db461d861e39527dc2d5a1290924b1ba9045e92"
+content-hash = "a4d336bcb8bdc0923c7de1bf1e65634700f0f1eb16284bb497c39ff2e0e7ea69"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3860,4 +3860,4 @@ propcache = ">=0.2.1"
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11, <4.0"
-content-hash = "a4d336bcb8bdc0923c7de1bf1e65634700f0f1eb16284bb497c39ff2e0e7ea69"
+content-hash = "bb68a93bb029a7a0487680782840da5bebb3b15eb97ed030a44657e5072a91c1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "pyyaml~=6.0.3",
     "referencing~=0.37.0",
     "regex~=2025.11.3",
-    "requests>=2.33.1",
+    "requests~=2.33.1",
     "rpds-py~=0.30.0",
     "ruamel-yaml~=0.18.16",
     "ruamel-yaml-clib~=0.2.15",
@@ -122,7 +122,7 @@ responses = "~=0.25.8"
 textual-dev = "^1.8.0"
 types-pyyaml = "^6.0.12.20250915"
 types-python-dateutil = "~=2.9.0.20251115"
-types-requests = ">=2.33.0"
+types-requests = "~=2.33.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
     "pyyaml~=6.0.3",
     "referencing~=0.37.0",
     "regex~=2025.11.3",
-    "requests~=2.32.4",
+    "requests>=2.33.1",
     "rpds-py~=0.30.0",
     "ruamel-yaml~=0.18.16",
     "ruamel-yaml-clib~=0.2.15",
@@ -122,7 +122,7 @@ responses = "~=0.25.8"
 textual-dev = "^1.8.0"
 types-pyyaml = "^6.0.12.20250915"
 types-python-dateutil = "~=2.9.0.20251115"
-types-requests = "~=2.32.4.20250913"
+types-requests = ">=2.33.0"
 
 [tool.poetry.requires-plugins]
 poetry-plugin-export = ">=1.8"

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,7 +54,7 @@ python-dateutil==2.9.0.post0 ; python_version >= "3.11" and python_version < "4.
 pyyaml==6.0.3 ; python_version >= "3.11" and python_version < "4.0"
 referencing==0.37.0 ; python_version >= "3.11" and python_version < "4.0"
 regex==2025.11.3 ; python_version >= "3.11" and python_version < "4.0"
-requests==2.32.4 ; python_version >= "3.11" and python_version < "4.0"
+requests==2.33.1 ; python_version >= "3.11" and python_version < "4.0"
 rich==14.3.3 ; python_version >= "3.11" and python_version < "4.0"
 rpds-py==0.30.0 ; python_version >= "3.11" and python_version < "4.0"
 ruamel-yaml-clib==0.2.15 ; python_version >= "3.11" and python_version < "4.0"


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

Update requests dependency pins                                              
  
  - Updated requests from ~=2.32.4 to ~=2.33.1 to allow future minor/patch releases without being blocked on     
  upgrades.                                                                                                    
  - Updated types-requests (dev dependency) from ~=2.32.4.20250913 to ~=2.33.0 for the same reason       
  - Regenerated poetry.lock to reflect the updated constraints.

### Testing

* <Testing steps>
