### PR TITLE
no enabled field on saved queries only scheduled ones

### DIFF
--- a/panther_analysis_tool/core/install_item.py
+++ b/panther_analysis_tool/core/install_item.py
@@ -245,7 +245,6 @@ def set_enabled_field(spec: dict[str, Any]) -> None:
         AnalysisTypes.POLICY,
         AnalysisTypes.DATA_MODEL,
         AnalysisTypes.LOOKUP_TABLE,
-        AnalysisTypes.SAVED_QUERY,
         AnalysisTypes.SCHEDULED_QUERY,
         AnalysisTypes.DERIVED,
         AnalysisTypes.SIMPLE_DETECTION,

--- a/tests/unit/panther_analysis_tool/core/test_install_item.py
+++ b/tests/unit/panther_analysis_tool/core/test_install_item.py
@@ -148,7 +148,6 @@ _FAKE_SAVED_QUERY_1_V1 = yaml.dump(
     {
         "AnalysisType": "saved_query",
         "QueryName": "fake.saved_query.1",
-        "Enabled": False,
         "Description": "Fake saved query 1 v1",
     }
 )
@@ -606,7 +605,6 @@ def test_set_enabled_field() -> None:
         AnalysisTypes.POLICY,
         AnalysisTypes.DATA_MODEL,
         AnalysisTypes.LOOKUP_TABLE,
-        AnalysisTypes.SAVED_QUERY,
         AnalysisTypes.SCHEDULED_QUERY,
     ]:
         spec = {
@@ -621,6 +619,7 @@ def test_set_enabled_field_for_other_types() -> None:
     for analysis_type in [
         AnalysisTypes.PACK,
         AnalysisTypes.GLOBAL,
+        AnalysisTypes.SAVED_QUERY,
     ]:
         spec = {
             "AnalysisType": analysis_type,


### PR DESCRIPTION
### Background

<High level overview here>

### Changes

* Removed saved_query analysis type from enabled field addition logic because it does not exist. 

### Testing

* Updated unit test
