### PR TITLE
chore: add business-platform team to CODEOWNERS [EPD-6090]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 
 # These owners will be the default owners for everything in the repo.
 
-*       @panther-labs/detection-threat-hunting-experience
+*       @panther-labs/detection-threat-hunting-experience @panther-labs/business-platform


### PR DESCRIPTION
Jira: [EPD-6090](https://panther.atlassian.net/browse/EPD-6090)

- Adds `@panther-labs/business-platform` as an additional default code owner (alongside `@panther-labs/detection-threat-hunting-experience`)
- Lets the Business Platform team's approvals satisfy the code-owner gate on Dependabot PRs, which our automated triage/babysit routine ([windmill#1466](https://github.com/panther-labs/windmill/pull/1466)) surfaces weekly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[EPD-6090]: https://panther-labs.atlassian.net/browse/EPD-6090?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ