### PR TITLE
feat: add validate-sql command to compile query SQL against the data lake

### DIFF
--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -457,7 +457,36 @@ class FeatureFlagsResponse:
     flags: List[FeatureFlagTreatment]
 
 
-class Client(ABC):
+class DataLakeQueryStatus:
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+@dataclass(frozen=True)
+class ExecuteDataLakeQueryParams:
+    sql: str
+    database_name: Optional[str] = None
+
+
+@dataclass(frozen=True)
+class ExecuteDataLakeQueryResponse:
+    id: str  # pylint: disable=invalid-name
+
+
+@dataclass(frozen=True)
+class GetDataLakeQueryParams:
+    id: str  # pylint: disable=invalid-name
+
+
+@dataclass(frozen=True)
+class GetDataLakeQueryResponse:
+    status: str
+    message: str
+
+
+class Client(ABC):  # pylint: disable=too-many-public-methods
     @abstractmethod
     def check(self) -> BackendCheckResponse:
         pass
@@ -548,6 +577,22 @@ class Client(ABC):
 
     @abstractmethod
     def feature_flags(self, params: FeatureFlagsParams) -> BackendResponse[FeatureFlagsResponse]:
+        pass
+
+    @abstractmethod
+    def supports_data_lake_queries(self) -> bool:
+        pass
+
+    @abstractmethod
+    def execute_data_lake_query(
+        self, params: ExecuteDataLakeQueryParams
+    ) -> BackendResponse[ExecuteDataLakeQueryResponse]:
+        pass
+
+    @abstractmethod
+    def get_data_lake_query(
+        self, params: GetDataLakeQueryParams
+    ) -> BackendResponse[GetDataLakeQueryResponse]:
         pass
 
 

--- a/panther_analysis_tool/backend/graphql/execute_data_lake_query.graphql
+++ b/panther_analysis_tool/backend/graphql/execute_data_lake_query.graphql
@@ -1,0 +1,5 @@
+mutation ExecuteDataLakeQuery($input: ExecuteDataLakeQueryInput!) {
+    executeDataLakeQuery(input: $input) {
+        id
+    }
+}

--- a/panther_analysis_tool/backend/graphql/get_data_lake_query.graphql
+++ b/panther_analysis_tool/backend/graphql/get_data_lake_query.graphql
@@ -1,0 +1,7 @@
+query GetDataLakeQuery($id: ID!) {
+    dataLakeQuery(id: $id) {
+        id
+        status
+        message
+    }
+}

--- a/panther_analysis_tool/backend/lambda_client.py
+++ b/panther_analysis_tool/backend/lambda_client.py
@@ -19,10 +19,14 @@ from .client import (
     DeleteDetectionsResponse,
     DeleteSavedQueriesParams,
     DeleteSavedQueriesResponse,
+    ExecuteDataLakeQueryParams,
+    ExecuteDataLakeQueryResponse,
     FeatureFlagsParams,
     FeatureFlagsResponse,
     GenerateEnrichedEventParams,
     GenerateEnrichedEventResponse,
+    GetDataLakeQueryParams,
+    GetDataLakeQueryResponse,
     GetRuleBodyParams,
     GetRuleBodyResponse,
     ListSchemasParams,
@@ -65,7 +69,7 @@ class LambdaClientOpts:
     datalake_lambda: str
 
 
-class LambdaClient(Client):
+class LambdaClient(Client):  # pylint: disable=too-many-public-methods
     _user_id: str
     _lambda_client: boto3.client
 
@@ -337,3 +341,18 @@ class LambdaClient(Client):
     def feature_flags(self, params: FeatureFlagsParams) -> BackendResponse[FeatureFlagsResponse]:
         # pylint: disable=broad-exception-raised
         raise BaseException("feature-flags is not supported with lambda client")
+
+    def supports_data_lake_queries(self) -> bool:
+        return False
+
+    def execute_data_lake_query(
+        self, params: ExecuteDataLakeQueryParams
+    ) -> BackendResponse[ExecuteDataLakeQueryResponse]:
+        # pylint: disable=broad-exception-raised
+        raise BaseException("data lake queries are not supported with lambda client")
+
+    def get_data_lake_query(
+        self, params: GetDataLakeQueryParams
+    ) -> BackendResponse[GetDataLakeQueryResponse]:
+        # pylint: disable=broad-exception-raised
+        raise BaseException("data lake queries are not supported with lambda client")

--- a/panther_analysis_tool/backend/mocks.py
+++ b/panther_analysis_tool/backend/mocks.py
@@ -11,10 +11,14 @@ from panther_analysis_tool.backend.client import Client as BackendClient
 from panther_analysis_tool.backend.client import (
     DeleteDetectionsParams,
     DeleteSavedQueriesParams,
+    ExecuteDataLakeQueryParams,
+    ExecuteDataLakeQueryResponse,
     FeatureFlagsParams,
     FeatureFlagsResponse,
     GenerateEnrichedEventParams,
     GenerateEnrichedEventResponse,
+    GetDataLakeQueryParams,
+    GetDataLakeQueryResponse,
     GetRuleBodyParams,
     GetRuleBodyResponse,
     ListSchemasParams,
@@ -31,7 +35,7 @@ from panther_analysis_tool.backend.client import (
 )
 
 
-class MockBackend(BackendClient):
+class MockBackend(BackendClient):  # pylint: disable=too-many-public-methods
     def async_bulk_upload(self, params: BulkUploadParams) -> BackendResponse[BulkUploadResponse]:  # type: ignore
         pass
 
@@ -98,4 +102,17 @@ class MockBackend(BackendClient):
         pass
 
     def feature_flags(self, params: FeatureFlagsParams) -> BackendResponse[FeatureFlagsResponse]:  # type: ignore
+        pass
+
+    def supports_data_lake_queries(self) -> bool:  # type: ignore
+        pass
+
+    def execute_data_lake_query(  # type: ignore
+        self, params: ExecuteDataLakeQueryParams
+    ) -> BackendResponse[ExecuteDataLakeQueryResponse]:
+        pass
+
+    def get_data_lake_query(  # type: ignore
+        self, params: GetDataLakeQueryParams
+    ) -> BackendResponse[GetDataLakeQueryResponse]:
         pass

--- a/panther_analysis_tool/backend/public_api_client.py
+++ b/panther_analysis_tool/backend/public_api_client.py
@@ -27,11 +27,15 @@ from .client import (
     DeleteDetectionsResponse,
     DeleteSavedQueriesParams,
     DeleteSavedQueriesResponse,
+    ExecuteDataLakeQueryParams,
+    ExecuteDataLakeQueryResponse,
     FeatureFlagsParams,
     FeatureFlagsResponse,
     FeatureFlagTreatment,
     GenerateEnrichedEventParams,
     GenerateEnrichedEventResponse,
+    GetDataLakeQueryParams,
+    GetDataLakeQueryResponse,
     GetRuleBodyParams,
     GetRuleBodyResponse,
     ListSchemasParams,
@@ -132,6 +136,12 @@ class PublicAPIRequests:  # pylint: disable=too-many-public-methods
 
     def feature_flags_query(self) -> GraphQLRequest:
         return self._load("feature_flags")
+
+    def execute_data_lake_query_mutation(self) -> GraphQLRequest:
+        return self._load("execute_data_lake_query")
+
+    def get_data_lake_query_query(self) -> GraphQLRequest:
+        return self._load("get_data_lake_query")
 
     def _load(self, name: str) -> GraphQLRequest:
         if name not in self._cache:
@@ -596,6 +606,40 @@ class PublicAPIClient(Client):  # pylint: disable=too-many-public-methods
                     FeatureFlagTreatment(flag=flag.get("flag"), treatment=flag.get("treatment"))
                     for flag in data.get("flags") or []
                 ]
+            ),
+        )
+
+    def supports_data_lake_queries(self) -> bool:
+        return True
+
+    def execute_data_lake_query(
+        self, params: ExecuteDataLakeQueryParams
+    ) -> BackendResponse[ExecuteDataLakeQueryResponse]:
+        query = self._requests.execute_data_lake_query_mutation()
+        query_input: Dict[str, Any] = {"input": {"sql": params.sql}}
+        if params.database_name:
+            query_input["input"]["databaseName"] = params.database_name
+
+        res = self._potentially_supported_execute(query, variable_values=query_input)
+        data = res.data.get("executeDataLakeQuery", {})  # type: ignore
+
+        return BackendResponse(
+            status_code=200,
+            data=ExecuteDataLakeQueryResponse(id=data.get("id", "")),
+        )
+
+    def get_data_lake_query(
+        self, params: GetDataLakeQueryParams
+    ) -> BackendResponse[GetDataLakeQueryResponse]:
+        query = self._requests.get_data_lake_query_query()
+        res = self._safe_execute(query, variable_values={"id": params.id})
+        data = res.data.get("dataLakeQuery", {})  # type: ignore
+
+        return BackendResponse(
+            status_code=200,
+            data=GetDataLakeQueryResponse(
+                status=data.get("status", ""),
+                message=data.get("message", ""),
             ),
         )
 

--- a/panther_analysis_tool/command/validate_sql.py
+++ b/panther_analysis_tool/command/validate_sql.py
@@ -27,6 +27,10 @@ _MISSING_TABLE_ERROR = "does not exist or not authorized"
 # template queries, which are meant to be filled in by a human before running.
 _PLACEHOLDER_PATTERN = re.compile(r"<[A-Z][A-Z0-9_]*>")
 
+# The backend routes queries with this pragma to the PantherFlow engine, which
+# ignores the EXPLAIN prefix and executes the query for real.
+_PANTHERFLOW_PRAGMA = re.compile(r"--\s*pragma:\s*pantherflow", re.IGNORECASE)
+
 
 @dataclass
 class ValidateSqlArgs:
@@ -122,6 +126,13 @@ def _collect_targets(args: ValidateSqlArgs) -> List[SqlValidationTarget]:
         # nothing on their own and only compile when included from another query.
         if "{% macro" in sql:
             logging.info("Skipping %s: query only defines jinja macros", analysis_id)
+            continue
+
+        if _PANTHERFLOW_PRAGMA.search(sql):
+            logging.info(
+                "Skipping %s: PantherFlow queries cannot be compile-checked with EXPLAIN",
+                analysis_id,
+            )
             continue
 
         placeholder = _PLACEHOLDER_PATTERN.search(sql)

--- a/panther_analysis_tool/command/validate_sql.py
+++ b/panther_analysis_tool/command/validate_sql.py
@@ -1,0 +1,187 @@
+import logging
+import re
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional, Tuple
+
+from panther_analysis_tool import cli_output
+from panther_analysis_tool.analysis_utils import filter_analysis, load_analysis_specs
+from panther_analysis_tool.backend.client import Client as BackendClient
+from panther_analysis_tool.backend.client import (
+    DataLakeQueryStatus,
+    ExecuteDataLakeQueryParams,
+    GetDataLakeQueryParams,
+    UnsupportedEndpointError,
+)
+from panther_analysis_tool.constants import AnalysisTypes
+from panther_analysis_tool.core.definitions import ClassifiedAnalysis
+from panther_analysis_tool.core.parse import Filter
+
+POLL_INTERVAL_SECONDS = 1
+PER_QUERY_TIMEOUT_SECONDS = 60
+
+_SQL_KEYS = ("Query", "SnowflakeQuery")
+_MISSING_TABLE_ERROR = "does not exist or not authorized"
+
+# Matches substitution markers like <ACTOR_ID> or <WINDOW> used by investigation
+# template queries, which are meant to be filled in by a human before running.
+_PLACEHOLDER_PATTERN = re.compile(r"<[A-Z][A-Z0-9_]*>")
+
+
+@dataclass
+class ValidateSqlArgs:
+    path: str
+    ignore_files: List[str]
+    filters: List[Filter]
+    filters_inverted: List[Filter]
+    skip_missing_tables: bool = False
+
+
+@dataclass(frozen=True)
+class SqlValidationTarget:
+    analysis_id: str
+    file_name: str
+    sql: str
+    enabled: bool = True
+
+
+def run(backend: BackendClient, args: ValidateSqlArgs) -> Tuple[int, str]:
+    if backend is None or not backend.supports_data_lake_queries():
+        return 1, "Invalid backend. `validate-sql` is only supported via API token"
+
+    targets = _collect_targets(args)
+    if not targets:
+        return 0, "No SQL queries found to validate"
+
+    failures: List[Tuple[SqlValidationTarget, str]] = []
+    skipped = 0
+    for target in targets:
+        try:
+            error = _validate_target(backend, target)
+        except UnsupportedEndpointError as err:
+            logging.debug(err)
+            return 1, cli_output.warning("Your Panther instance does not support this feature")
+
+        if error is None:
+            print(f"  {cli_output.success('PASS')} {target.analysis_id}")
+        elif _MISSING_TABLE_ERROR in error and (args.skip_missing_tables or not target.enabled):
+            # Disabled queries don't need their log source onboarded; enabled queries
+            # do, unless --skip-missing-tables loosens that requirement.
+            skipped += 1
+            print(
+                f"  {cli_output.warning('SKIP')} {target.analysis_id}"
+                " (table does not exist in this instance)"
+            )
+        else:
+            failures.append((target, error))
+            print(f"  {cli_output.failed('FAIL')} {target.analysis_id} ({target.file_name})")
+            for line in error.splitlines():
+                print(f"         {line}")
+
+    skip_suffix = f" ({skipped} skipped due to missing tables)" if skipped else ""
+    if failures:
+        return 1, cli_output.failed(
+            f"SQL validation failed for {len(failures)} of {len(targets)} queries{skip_suffix}"
+        )
+
+    return 0, cli_output.success(
+        f"SQL validation succeeded for all {len(targets) - skipped} queries{skip_suffix}"
+    )
+
+
+def _collect_targets(args: ValidateSqlArgs) -> List[SqlValidationTarget]:
+    analysis = []
+    for file_name, dir_name, analysis_spec, error in load_analysis_specs(
+        [args.path], args.ignore_files
+    ):
+        if error is not None:
+            logging.warning("Skipping %s: %s", file_name, error)
+            continue
+        analysis.append(ClassifiedAnalysis(file_name, dir_name, analysis_spec))
+
+    analysis = filter_analysis(analysis, args.filters, args.filters_inverted)
+
+    targets = []
+    for item in analysis:
+        spec = item.analysis_spec
+        analysis_type = spec.get("AnalysisType")
+        if analysis_type in (AnalysisTypes.SCHEDULED_QUERY, AnalysisTypes.SAVED_QUERY):
+            analysis_id = spec.get("QueryName", "")
+        elif analysis_type == AnalysisTypes.LOOKUP_TABLE:
+            analysis_id = spec.get("LookupName", "")
+        else:
+            continue
+
+        sql = _lookup_sql(spec)
+        if sql is None:
+            if analysis_type != AnalysisTypes.LOOKUP_TABLE:
+                logging.warning("Skipping %s: no Query or SnowflakeQuery field found", analysis_id)
+            continue
+
+        # Jinja macro library files (e.g. panther-analysis queries/macros) expand to
+        # nothing on their own and only compile when included from another query.
+        if "{% macro" in sql:
+            logging.info("Skipping %s: query only defines jinja macros", analysis_id)
+            continue
+
+        placeholder = _PLACEHOLDER_PATTERN.search(sql)
+        if placeholder:
+            logging.info(
+                "Skipping %s: query contains placeholder %s",
+                analysis_id,
+                placeholder.group(0),
+            )
+            continue
+
+        targets.append(
+            SqlValidationTarget(
+                analysis_id=analysis_id,
+                file_name=item.file_name,
+                sql=sql,
+                enabled=bool(spec.get("Enabled", True)),
+            )
+        )
+
+    return targets
+
+
+def _lookup_sql(analysis_spec: Dict[str, Any]) -> Optional[str]:
+    for key in _SQL_KEYS:
+        if isinstance(analysis_spec.get(key), str):
+            return analysis_spec[key]
+    return None
+
+
+def _validate_target(backend: BackendClient, target: SqlValidationTarget) -> Optional[str]:
+    """Compiles the target's SQL against the data lake via EXPLAIN.
+
+    Returns None if the SQL is valid, otherwise the compilation error message.
+    """
+    # EXPLAIN compiles the query in the data lake without scanning any data,
+    # which surfaces syntax errors and invalid table/column references.
+    sql = re.sub(r"[;\s]+$", "", target.sql)
+    explain_sql = f"EXPLAIN {sql}"
+
+    try:
+        execute_res = backend.execute_data_lake_query(ExecuteDataLakeQueryParams(sql=explain_sql))
+    except UnsupportedEndpointError:
+        raise
+    except BaseException as err:  # pylint: disable=broad-except
+        return str(err)
+
+    deadline = time.time() + PER_QUERY_TIMEOUT_SECONDS
+    while True:
+        try:
+            status_res = backend.get_data_lake_query(GetDataLakeQueryParams(id=execute_res.data.id))
+        except BaseException as err:  # pylint: disable=broad-except
+            return str(err)
+
+        status = (status_res.data.status or "").lower()
+        if status == DataLakeQueryStatus.SUCCEEDED:
+            return None
+        if status in (DataLakeQueryStatus.FAILED, DataLakeQueryStatus.CANCELLED):
+            return status_res.data.message or f"validation query {status}"
+        if time.time() >= deadline:
+            return "timed out waiting for SQL validation to complete"
+
+        time.sleep(POLL_INTERVAL_SECONDS)

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -94,6 +94,7 @@ from panther_analysis_tool.command import (
     migrate,
     update,
     validate,
+    validate_sql,
 )
 from panther_analysis_tool.command.standard_args import (
     APIHostType,
@@ -2351,6 +2352,44 @@ def validate_cmd(
     )
 
     return validate.run(pat_utils.get_api_backend(api_token, api_host), args)
+
+
+@app_command_with_config(
+    name="validate-sql",
+    help="Validate the SQL of scheduled queries, saved queries, and SQL-based lookup tables "
+    "by compiling them (via EXPLAIN) against your Panther data lake.",
+)
+def validate_sql_cmd(
+    api_token: APITokenType = None,
+    api_host: APIHostType = "",
+    _filter: FilterType = None,
+    ignore_files: IgnoreFilesType = None,
+    path: PathType = ".",
+    skip_missing_tables: Annotated[
+        bool,
+        typer.Option(
+            "--skip-missing-tables",
+            envvar="PANTHER_SKIP_MISSING_TABLES",
+            help="Skip enabled queries that reference tables that do not exist in the Panther "
+            "instance (e.g. log sources that are not onboarded) instead of failing them. "
+            "Disabled queries with missing tables are always skipped.",
+        ),
+    ] = False,
+) -> Tuple[int, str]:
+    if ignore_files is None:
+        ignore_files = []
+
+    filters, filters_inverted = get_filters_with_status_filters(_filter)
+
+    args = validate_sql.ValidateSqlArgs(
+        filters=filters,
+        filters_inverted=filters_inverted,
+        ignore_files=ignore_files,
+        path=path,
+        skip_missing_tables=skip_missing_tables,
+    )
+
+    return validate_sql.run(pat_utils.get_api_backend(api_token, api_host), args)
 
 
 @app_command_with_config(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,12 +128,12 @@ types-requests = "~=2.33.0"
 poetry-plugin-export = ">=1.8"
 
 [tool.black]
-exclude = '\.poetry'
+exclude = '\.poetry|venv'
 line-length = 100
 
 [tool.isort]
 profile = "black"
-skip = ['\.poetry']
+skip = ['\.poetry', 'venv']
 
 [tool.mypy]
 disallow_untyped_defs = true

--- a/tests/unit/panther_analysis_tool/command/test_validate_sql.py
+++ b/tests/unit/panther_analysis_tool/command/test_validate_sql.py
@@ -87,6 +87,16 @@ Query: |
   WHERE p_occurs_since('<WINDOW>') AND actor:id = '<ACTOR_ID>'
 """
 
+PANTHERFLOW_QUERY_YAML = """
+AnalysisType: saved_query
+QueryName: My PantherFlow Query
+Query: |
+  --pragma: pantherflow
+  panther_logs.public.panther_audit
+  | where p_event_time > time.ago(7d)
+  | limit 100
+"""
+
 MISSING_TABLE_ERROR = (
     "SQL compilation error:\n"
     "Object 'PANTHER_LOGS.PUBLIC.SOME_TABLE' does not exist or not authorized."
@@ -125,6 +135,7 @@ class TestValidateSql(unittest.TestCase):
             ("rule.yml", RULE_YAML),
             ("macros.yml", MACRO_LIBRARY_YAML),
             ("placeholder_template.yml", PLACEHOLDER_TEMPLATE_YAML),
+            ("pantherflow_query.yml", PANTHERFLOW_QUERY_YAML),
         ]:
             with open(os.path.join(self.tmp_dir.name, name), "w", encoding="utf-8") as out:
                 out.write(content)

--- a/tests/unit/panther_analysis_tool/command/test_validate_sql.py
+++ b/tests/unit/panther_analysis_tool/command/test_validate_sql.py
@@ -1,0 +1,260 @@
+import os
+import tempfile
+import unittest
+from unittest import mock
+
+from panther_analysis_tool.backend.client import (
+    BackendResponse,
+    ExecuteDataLakeQueryResponse,
+    GetDataLakeQueryResponse,
+)
+from panther_analysis_tool.backend.mocks import MockBackend
+from panther_analysis_tool.command import validate_sql
+
+SCHEDULED_QUERY_YAML = """
+AnalysisType: scheduled_query
+QueryName: My Scheduled Query
+Enabled: true
+Query: |
+  SELECT * FROM panther_logs.public.aws_cloudtrail WHERE p_occurs_since('1 day')
+Schedule:
+  RateMinutes: 60
+  TimeoutMinutes: 5
+"""
+
+SAVED_QUERY_YAML = """
+AnalysisType: saved_query
+QueryName: My Saved Query
+SnowflakeQuery: SELECT 1;
+"""
+
+DISABLED_QUERY_YAML = """
+AnalysisType: scheduled_query
+QueryName: My Disabled Query
+Enabled: false
+Query: SELECT * FROM panther_logs.public.some_table
+Schedule:
+  RateMinutes: 60
+  TimeoutMinutes: 5
+"""
+
+SQL_LOOKUP_TABLE_YAML = """
+AnalysisType: lookup_table
+LookupName: My SQL Lookup
+Enabled: true
+Query: SELECT actor FROM panther_logs.public.aws_cloudtrail
+LogTypeMap:
+  PrimaryKey: actor
+Refresh:
+  PeriodMinutes: 60
+"""
+
+FILE_LOOKUP_TABLE_YAML = """
+AnalysisType: lookup_table
+LookupName: My File Lookup
+Enabled: true
+Filename: lookup.csv
+Schema: My.Schema
+LogTypeMap:
+  PrimaryKey: actor
+"""
+
+RULE_YAML = """
+AnalysisType: rule
+RuleID: My.Rule
+Enabled: true
+Filename: my_rule.py
+LogTypes:
+  - AWS.CloudTrail
+Severity: Info
+"""
+
+MACRO_LIBRARY_YAML = """
+AnalysisType: saved_query
+QueryName: My Macros
+Query: |
+  -- pragma: template
+  {% macro my_macro(subquery) export %}
+  select * from {{ subquery }}
+  {% endmacro %}
+"""
+
+PLACEHOLDER_TEMPLATE_YAML = """
+AnalysisType: saved_query
+QueryName: My Investigation Template
+Query: |
+  SELECT * FROM panther_logs.public.okta_systemlog
+  WHERE p_occurs_since('<WINDOW>') AND actor:id = '<ACTOR_ID>'
+"""
+
+MISSING_TABLE_ERROR = (
+    "SQL compilation error:\n"
+    "Object 'PANTHER_LOGS.PUBLIC.SOME_TABLE' does not exist or not authorized."
+)
+
+
+def _make_backend(statuses=None) -> MockBackend:
+    backend = MockBackend()
+    backend.supports_data_lake_queries = mock.MagicMock(return_value=True)
+    backend.execute_data_lake_query = mock.MagicMock(
+        return_value=BackendResponse(
+            data=ExecuteDataLakeQueryResponse(id="query-id"), status_code=200
+        )
+    )
+    backend.get_data_lake_query = mock.MagicMock(
+        side_effect=[
+            BackendResponse(
+                data=GetDataLakeQueryResponse(status=status, message=message), status_code=200
+            )
+            for status, message in (statuses or [("succeeded", "done")] * 10)
+        ]
+    )
+    return backend
+
+
+class TestValidateSql(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp_dir.cleanup)
+        for name, content in [
+            ("scheduled_query.yml", SCHEDULED_QUERY_YAML),
+            ("saved_query.yml", SAVED_QUERY_YAML),
+            ("disabled_query.yml", DISABLED_QUERY_YAML),
+            ("sql_lookup.yml", SQL_LOOKUP_TABLE_YAML),
+            ("file_lookup.yml", FILE_LOOKUP_TABLE_YAML),
+            ("rule.yml", RULE_YAML),
+            ("macros.yml", MACRO_LIBRARY_YAML),
+            ("placeholder_template.yml", PLACEHOLDER_TEMPLATE_YAML),
+        ]:
+            with open(os.path.join(self.tmp_dir.name, name), "w", encoding="utf-8") as out:
+                out.write(content)
+
+        self.args = validate_sql.ValidateSqlArgs(
+            path=self.tmp_dir.name, ignore_files=[], filters=[], filters_inverted=[]
+        )
+
+    def test_unsupported_backend(self) -> None:
+        backend = MockBackend()
+        backend.supports_data_lake_queries = mock.MagicMock(return_value=False)
+
+        code, msg = validate_sql.run(backend, self.args)
+        self.assertEqual(code, 1)
+        self.assertIn("API token", msg)
+
+    def test_collect_targets(self) -> None:
+        targets = validate_sql._collect_targets(self.args)
+
+        self.assertEqual(
+            {t.analysis_id: t.enabled for t in targets},
+            {
+                "My Scheduled Query": True,
+                "My Saved Query": True,
+                "My Disabled Query": False,
+                "My SQL Lookup": True,
+            },
+        )
+
+    def test_all_queries_valid(self) -> None:
+        backend = _make_backend()
+
+        code, msg = validate_sql.run(backend, self.args)
+        self.assertEqual(code, 0)
+        self.assertIn("all 4 queries", msg)
+        self.assertEqual(backend.execute_data_lake_query.call_count, 4)
+
+        for call in backend.execute_data_lake_query.call_args_list:
+            sql = call.args[0].sql
+            self.assertTrue(sql.startswith("EXPLAIN "))
+            self.assertFalse(sql.rstrip().endswith(";"))
+
+    def _statuses_for(self, status_by_id):
+        """Builds a get_data_lake_query status list matching target collection order."""
+        targets = validate_sql._collect_targets(self.args)
+        return [status_by_id.get(t.analysis_id, ("succeeded", "done")) for t in targets]
+
+    def test_invalid_query_fails(self) -> None:
+        backend = _make_backend(
+            statuses=self._statuses_for(
+                {"My Saved Query": ("failed", "SQL compilation error:\ninvalid identifier 'FOO'")}
+            )
+        )
+
+        code, msg = validate_sql.run(backend, self.args)
+        self.assertEqual(code, 1)
+        self.assertIn("1 of 4", msg)
+
+    def test_disabled_query_with_missing_table_is_skipped_by_default(self) -> None:
+        backend = _make_backend(
+            statuses=self._statuses_for({"My Disabled Query": ("failed", MISSING_TABLE_ERROR)})
+        )
+
+        code, msg = validate_sql.run(backend, self.args)
+        self.assertEqual(code, 0)
+        self.assertIn("1 skipped due to missing tables", msg)
+
+    def test_disabled_query_with_syntax_error_still_fails(self) -> None:
+        backend = _make_backend(
+            statuses=self._statuses_for(
+                {"My Disabled Query": ("failed", "SQL compilation error:\nsyntax error")}
+            )
+        )
+
+        code, msg = validate_sql.run(backend, self.args)
+        self.assertEqual(code, 1)
+        self.assertIn("1 of 4", msg)
+
+    def test_enabled_query_with_missing_table_fails_by_default(self) -> None:
+        backend = _make_backend(
+            statuses=self._statuses_for({"My Scheduled Query": ("failed", MISSING_TABLE_ERROR)})
+        )
+
+        code, msg = validate_sql.run(backend, self.args)
+        self.assertEqual(code, 1)
+        self.assertIn("1 of 4", msg)
+
+    def test_polls_until_terminal_status(self) -> None:
+        backend = _make_backend(
+            statuses=[
+                ("running", "still going"),
+                ("succeeded", "done"),
+            ]
+        )
+
+        with mock.patch.object(validate_sql.time, "sleep"):
+            error = validate_sql._validate_target(
+                backend,
+                validate_sql.SqlValidationTarget(
+                    analysis_id="My Query", file_name="a.yml", sql="SELECT 1"
+                ),
+            )
+
+        self.assertIsNone(error)
+        self.assertEqual(backend.get_data_lake_query.call_count, 2)
+
+    def test_skip_missing_tables_flag_covers_enabled_queries(self) -> None:
+        backend = _make_backend(
+            statuses=self._statuses_for({"My Scheduled Query": ("failed", MISSING_TABLE_ERROR)})
+        )
+
+        args = validate_sql.ValidateSqlArgs(
+            path=self.tmp_dir.name,
+            ignore_files=[],
+            filters=[],
+            filters_inverted=[],
+            skip_missing_tables=True,
+        )
+        code, msg = validate_sql.run(backend, args)
+        self.assertEqual(code, 0)
+        self.assertIn("1 skipped due to missing tables", msg)
+
+    def test_cancelled_query_is_an_error(self) -> None:
+        backend = _make_backend(statuses=[("cancelled", "")])
+
+        error = validate_sql._validate_target(
+            backend,
+            validate_sql.SqlValidationTarget(
+                analysis_id="My Query", file_name="a.yml", sql="SELECT 1"
+            ),
+        )
+
+        self.assertEqual(error, "validation query cancelled")


### PR DESCRIPTION
## Summary

Adds a `validate-sql` command that validates the SQL of scheduled queries, saved queries, and SQL-based lookup tables by compiling them against the Panther data lake. Each query is executed with an `EXPLAIN` prefix via the `executeDataLakeQuery` / `dataLakeQuery` public API operations — Snowflake compiles the query without scanning any data (0 bytes scanned), surfacing syntax errors and invalid table/column references that static analysis (sqlfluff) misses.

Closes #639

```
panther_analysis_tool validate-sql --path . --api-token ... --api-host ...
```

## Behavior

- **Validated**: `scheduled_query` / `saved_query` specs (`Query` or `SnowflakeQuery`) and `lookup_table` specs with a `Query` field. Supports the standard `--filter` / `--ignore-files` options.
- **Missing tables** (log source not onboarded in the instance):
  - Enabled queries **fail** — a scheduled query that can't resolve its table is broken in that instance.
  - Disabled queries are **skipped** (syntax errors still fail).
  - `--skip-missing-tables` extends the skip to enabled queries, for repos that ship content for log sources the validating instance doesn't have.
- **Skipped**: Jinja macro library files (`{% macro %}`-only SQL, which expands to nothing standalone; queries that *use* macros validate fine since the backend expands templates server-side) and investigation templates with `<PLACEHOLDER>` markers.

## Live testing

Ran against panther-analysis (106 queries) on the threat-research instance (~3.5 min):

- Found a **real bug**: `kubernetes_ioc_activity_query.yml` has its `INNER JOIN` after the `WHERE` clause — invalid SQL never caught by static analysis (filed as panther-labs/panther-analysis#2101).
- Confirmed `p_occurs_since` and Jinja macros expand server-side under `EXPLAIN`.
- All skip/fail categories verified against real instance responses.

## Implementation notes

- New GraphQL operations follow the existing pattern: `.graphql` files + `PublicAPIRequests` loaders + typed params/response dataclasses + `Client` abstract methods. `LambdaClient` raises (unsupported), consistent with other public-API-only features.
- Validation polls `dataLakeQuery` until a terminal status with a 60s per-query timeout.
- Also excludes `venv` from black/isort so `make fmt` doesn't reformat an in-project venv (separate commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)