### PR TITLE
feat: add scheduled prompt support (AnalysisType: scheduled_prompt) for validation, packaging, and upload

### DIFF
--- a/panther_analysis_tool/analysis_utils.py
+++ b/panther_analysis_tool/analysis_utils.py
@@ -39,6 +39,7 @@ from panther_analysis_tool.constants import (
     POLICIES_PATH_PATTERN,
     QUERIES_PATH_PATTERN,
     RULES_PATH_PATTERN,
+    SCHEDULED_PROMPTS_PATH_PATTERN,
     SCHEMAS,
     VERSION_STRING,
     AnalysisTypes,
@@ -423,6 +424,7 @@ def load_analysis_specs_ex(
                             PACKS_PATH_PATTERN,
                             POLICIES_PATH_PATTERN,
                             QUERIES_PATH_PATTERN,
+                            SCHEDULED_PROMPTS_PATH_PATTERN,
                         )
                     )
                 ):
@@ -1031,6 +1033,8 @@ def pretty_analysis_type(analysis_type: str, plural: bool = False) -> str:
             return "Derived Detection" if not plural else "Derived Detections"
         case AnalysisTypes.SIMPLE_DETECTION:
             return "Simple Detection" if not plural else "Simple Detections"
+        case AnalysisTypes.SCHEDULED_PROMPT:
+            return "Scheduled Prompt" if not plural else "Scheduled Prompts"
         case _:
             raise ValueError(f"Unsupported analysis type: {analysis_type}")
 

--- a/panther_analysis_tool/backend/client.py
+++ b/panther_analysis_tool/backend/client.py
@@ -210,7 +210,7 @@ class BulkUploadValidateStatusResponse(BackendMultipartError):
 
 
 @dataclass(frozen=True)
-class BulkUploadResponse:
+class BulkUploadResponse:  # pylint: disable=too-many-instance-attributes
     rules: BulkUploadStatistics
     queries: BulkUploadStatistics
     policies: BulkUploadStatistics
@@ -218,6 +218,7 @@ class BulkUploadResponse:
     lookup_tables: BulkUploadStatistics
     global_helpers: BulkUploadStatistics
     correlation_rules: BulkUploadStatistics
+    scheduled_prompts: BulkUploadStatistics
 
 
 @dataclass(frozen=True)
@@ -594,6 +595,11 @@ def to_bulk_upload_response(data: Any) -> BackendResponse[BulkUploadResponse]:
                 total=data.get("correlationRules", default_stats).get("total"),
                 new=data.get("correlationRules", default_stats).get("new"),
                 modified=data.get("correlationRules", default_stats).get("modified"),
+            ),
+            scheduled_prompts=BulkUploadStatistics(
+                total=data.get("scheduledPrompts", default_stats).get("total"),
+                new=data.get("scheduledPrompts", default_stats).get("new"),
+                modified=data.get("scheduledPrompts", default_stats).get("modified"),
             ),
         ),
     )

--- a/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
+++ b/panther_analysis_tool/backend/graphql/async_bulk_upload_status.graphql
@@ -24,6 +24,9 @@ query status($input: ID!) {
             correlationRules {
                 ...UploadStatisticDetails
             }
+            scheduledPrompts {
+                ...UploadStatisticDetails
+            }
         }
     }
 }

--- a/panther_analysis_tool/backend/graphql/bulk_upload.graphql
+++ b/panther_analysis_tool/backend/graphql/bulk_upload.graphql
@@ -21,6 +21,9 @@ mutation UploadDetections($input: UploadDetectionEntitiesInput!) {
         correlationRules {
             ...UploadStatisticDetails
         }
+        scheduledPrompts {
+            ...UploadStatisticDetails
+        }
     }
 }
 

--- a/panther_analysis_tool/constants.py
+++ b/panther_analysis_tool/constants.py
@@ -15,6 +15,7 @@ from panther_analysis_tool.schemas import (
     POLICY_SCHEMA,
     RULE_SCHEMA,
     SAVED_QUERY_SCHEMA,
+    SCHEDULED_PROMPT_SCHEMA,
     SCHEDULED_QUERY_SCHEMA,
 )
 
@@ -32,6 +33,7 @@ PACKS_PATH_PATTERN = "*/packs"
 POLICIES_PATH_PATTERN = "*policies*"
 QUERIES_PATH_PATTERN = "*queries*"
 RULES_PATH_PATTERN = "*rules*"
+SCHEDULED_PROMPTS_PATH_PATTERN = "*scheduled_prompts*"
 
 
 class AnalysisTypes:
@@ -47,6 +49,7 @@ class AnalysisTypes:
     SCHEDULED_RULE = "scheduled_rule"
     SIMPLE_DETECTION = "simple_detection"
     CORRELATION_RULE = "correlation_rule"
+    SCHEDULED_PROMPT = "scheduled_prompt"
 
 
 # The UserID is required by Panther for some API calls, but we have no way of
@@ -66,6 +69,7 @@ SCHEMAS: Dict[str, Schema] = {
     AnalysisTypes.DERIVED: DERIVED_SCHEMA,
     AnalysisTypes.SCHEDULED_RULE: RULE_SCHEMA,
     AnalysisTypes.CORRELATION_RULE: CORRELATION_RULE_SCHEMA,
+    AnalysisTypes.SCHEDULED_PROMPT: SCHEDULED_PROMPT_SCHEMA,
 }
 
 SET_FIELDS = [

--- a/panther_analysis_tool/core/definitions.py
+++ b/panther_analysis_tool/core/definitions.py
@@ -32,6 +32,8 @@ def analysis_id_field_name(analysis_type: str) -> str:
             return "PackID"
         case AnalysisTypes.LOOKUP_TABLE:
             return "LookupName"
+        case AnalysisTypes.SCHEDULED_PROMPT:
+            return "PromptName"
         case _:
             raise ValueError(f"Unsupported analysis type: {analysis_type}")
 
@@ -74,6 +76,7 @@ class ClassifiedAnalysisContainer:
     queries: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
     lookup_tables: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
     packs: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
+    scheduled_prompts: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
 
     def _self_as_list(self) -> List[List[ClassifiedAnalysis]]:
         return [
@@ -84,6 +87,7 @@ class ClassifiedAnalysisContainer:
             self.queries,
             self.lookup_tables,
             self.packs,
+            self.scheduled_prompts,
         ]
 
     def empty(self) -> bool:
@@ -101,6 +105,7 @@ class ClassifiedAnalysisContainer:
         container.queries = func(self.queries)
         container.lookup_tables = func(self.lookup_tables)
         container.packs = func(self.packs)
+        container.scheduled_prompts = func(self.scheduled_prompts)
         return container
 
     def items(self) -> Generator[ClassifiedAnalysis, None, None]:
@@ -132,6 +137,8 @@ class ClassifiedAnalysisContainer:
             self.queries.append(classified_analysis)
         elif analysis_type == AnalysisTypes.SCHEDULED_QUERY:
             self.queries.append(classified_analysis)
+        elif analysis_type == AnalysisTypes.SCHEDULED_PROMPT:
+            self.scheduled_prompts.append(classified_analysis)
 
 
 @dataclasses.dataclass

--- a/panther_analysis_tool/core/definitions.py
+++ b/panther_analysis_tool/core/definitions.py
@@ -76,7 +76,9 @@ class ClassifiedAnalysisContainer:
     queries: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
     lookup_tables: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
     packs: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
-    scheduled_prompts: List[ClassifiedAnalysis] = dataclasses.field(init=False, default_factory=list)
+    scheduled_prompts: List[ClassifiedAnalysis] = dataclasses.field(
+        init=False, default_factory=list
+    )
 
     def _self_as_list(self) -> List[List[ClassifiedAnalysis]]:
         return [

--- a/panther_analysis_tool/detection_schemas/analysis_config_schema.json
+++ b/panther_analysis_tool/detection_schemas/analysis_config_schema.json
@@ -1466,7 +1466,8 @@
             "scheduled_query",
             "lookup_table",
             "saved_query",
-            "correlation_rule"
+            "correlation_rule",
+            "scheduled_prompt"
           ]
         },
         "Description": {

--- a/panther_analysis_tool/main.py
+++ b/panther_analysis_tool/main.py
@@ -283,6 +283,7 @@ def zip_analysis_chunks(
         ZipChunk(patterns=[], types=AnalysisTypes.SCHEDULED_RULE, max_size=200),  # type: ignore
         ZipChunk(patterns=[], types=AnalysisTypes.LOOKUP_TABLE, max_size=100),  # type: ignore
         ZipChunk(patterns=[], types=AnalysisTypes.CORRELATION_RULE, max_size=200),  # type: ignore
+        ZipChunk(patterns=[], types=AnalysisTypes.SCHEDULED_PROMPT, max_size=100),  # type: ignore
     ]
 
     filenames = []
@@ -469,6 +470,7 @@ def print_upload_summary(response: dict) -> None:
         "Global Helpers": response.get("global_helpers", {}),
         "Lookup Tables": response.get("lookup_tables", {}),
         "Correlation Rules": response.get("correlation_rules", {}),
+        "Scheduled Prompts": response.get("scheduled_prompts", {}),
     }
 
     for category, stats in categories.items():

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -52,6 +52,7 @@ TYPE_SCHEMA = Schema(
             "scheduled_rule",
             "scheduled_query",
             "lookup_table",
+            "scheduled_prompt",
         ),
     },
     ignore_extra_keys=True,
@@ -297,6 +298,31 @@ SCHEDULED_QUERY_SCHEMA = Schema(
     },
     ignore_extra_keys=False,
     # Prevent user typos on optional fields
+)
+
+SCHEDULED_PROMPT_SCHEMA = Schema(
+    {
+        "AnalysisType": Or("scheduled_prompt"),
+        "PromptName": And(str, Regex(r"^[a-z][a-z0-9_]*$")),
+        "DisplayName": str,
+        "PromptText": str,
+        # RunAsUser is required: every scheduled prompt declares the user it executes as, so a bulk
+        # import never falls back to the importer (e.g. a PAT/API token) as the execution identity.
+        # Client-side format check only; the server resolves the email to an active user at upload.
+        "RunAsUser": And(str, Regex(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")),
+        "Schedule": QueryScheduleSchema(
+            {
+                Or("CronExpression", "RateMinutes", only_one=True): Or(str, int),
+                "TimeoutMinutes": int,
+            }
+        ),
+        Optional("Description"): str,
+        Optional("OutputLength"): Or("small", "medium", "largest"),
+        Optional("Enabled"): bool,
+        # `Private` is intentionally not a field: prompts managed as code are org-shared (public).
+        # ignore_extra_keys=False rejects a stray `Private` (and any other typo).
+    },
+    ignore_extra_keys=False,
 )
 
 LOOKUP_TABLE_SCHEMA = Schema(

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -306,10 +306,11 @@ SCHEDULED_PROMPT_SCHEMA = Schema(
         "PromptName": And(str, Regex(r"^[a-z][a-z0-9_]*$")),
         "DisplayName": str,
         "PromptText": str,
-        # RunAsUser is required: every scheduled prompt declares the user it executes as, so a bulk
-        # import never falls back to the importer (e.g. a PAT/API token) as the execution identity.
-        # Client-side format check only; the server resolves the email to an active user at upload.
-        "RunAsUser": And(str, Regex(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")),
+        # Required, and polymorphic — a user email OR an API-token id (po_...), matching the
+        # backend, which resolves it server-side. Format/existence is validated at validate/upload,
+        # so locally we only require a non-empty string (a strict email regex would wrongly reject
+        # a valid token id).
+        "RunAsUser": And(str, len),
         "Schedule": QueryScheduleSchema(
             {
                 Or("CronExpression", "RateMinutes", only_one=True): Or(str, int),
@@ -319,8 +320,10 @@ SCHEDULED_PROMPT_SCHEMA = Schema(
         Optional("Description"): str,
         Optional("OutputLength"): Or("small", "medium", "largest"),
         Optional("Enabled"): bool,
-        # `Private` is intentionally not a field: prompts managed as code are org-shared (public).
-        # ignore_extra_keys=False rejects a stray `Private` (and any other typo).
+        # Bulk upload is shared-only: `Private: false`/omitted is accepted; `Private: true` is
+        # rejected — mirrors the backend, which keeps the field but parse-rejects `true` so a
+        # downloaded private prompt fails loudly instead of silently flipping to shared.
+        Optional("Private"): False,
     },
     ignore_extra_keys=False,
 )

--- a/panther_analysis_tool/schemas.py
+++ b/panther_analysis_tool/schemas.py
@@ -303,7 +303,7 @@ SCHEDULED_QUERY_SCHEMA = Schema(
 SCHEDULED_PROMPT_SCHEMA = Schema(
     {
         "AnalysisType": Or("scheduled_prompt"),
-        "PromptName": And(str, Regex(r"^[a-z][a-z0-9_]*$")),
+        "PromptName": And(str, Regex(r"^[a-z][a-z0-9_]*\Z")),
         "DisplayName": str,
         "PromptText": str,
         # Required, and polymorphic — a user email OR an API-token id (po_...), matching the

--- a/panther_analysis_tool/util.py
+++ b/panther_analysis_tool/util.py
@@ -178,6 +178,7 @@ def get_spec_id(spec: dict) -> str:
             "scheduled_query": "QueryName",
             "scheduled_rule": "RuleID",
             "rule": "RuleID",
+            "scheduled_prompt": "PromptName",
         }
         return spec[id_keys[analysis_type]]
     if schema_name := spec.get("schema", ""):

--- a/panther_analysis_tool/validation.py
+++ b/panther_analysis_tool/validation.py
@@ -133,7 +133,8 @@ def validate_packs(analysis_specs: ClassifiedAnalysisContainer) -> List[Any]:
             or analysis_spec.get("GlobalID")
             or analysis_spec.get("PackID")
             or analysis_spec.get("QueryName")
-            or analysis_spec["LookupName"]
+            or analysis_spec.get("LookupName")
+            or analysis_spec.get("PromptName")
         )
         id_to_detection[analysis_id] = analysis_spec
     for item in analysis_specs.packs:

--- a/panther_analysis_tool/validation.py
+++ b/panther_analysis_tool/validation.py
@@ -125,18 +125,9 @@ def validate_packs(analysis_specs: ClassifiedAnalysisContainer) -> List[Any]:
     # first, setup dictionary of id to detection item
     id_to_detection = {}
     for item in analysis_specs.items():
-        analysis_spec = item.analysis_spec
-        analysis_id = (
-            analysis_spec.get("PolicyID")
-            or analysis_spec.get("RuleID")
-            or analysis_spec.get("DataModelID")
-            or analysis_spec.get("GlobalID")
-            or analysis_spec.get("PackID")
-            or analysis_spec.get("QueryName")
-            or analysis_spec.get("LookupName")
-            or analysis_spec.get("PromptName")
-        )
-        id_to_detection[analysis_id] = analysis_spec
+        # analysis_id() resolves the per-type ID field (PolicyID/RuleID/PromptName/...)
+        # via the central analysis_id_field_name map, instead of re-listing every field here.
+        id_to_detection[item.analysis_id()] = item.analysis_spec
     for item in analysis_specs.packs:
         analysis_spec = item.analysis_spec
         analysis_spec_filename = item.file_name

--- a/tests/fixtures/detections/valid_analysis/scheduled_prompts/example_prompt.yml
+++ b/tests/fixtures/detections/valid_analysis/scheduled_prompts/example_prompt.yml
@@ -1,0 +1,12 @@
+AnalysisType: scheduled_prompt
+PromptName: valid_analysis_example_prompt
+DisplayName: Valid Analysis Example Prompt
+Description: A test scheduled prompt for unit testing zip chunking under valid_analysis
+PromptText: |
+  Summarize notable IAM changes from the last week and flag any new admin users.
+OutputLength: medium
+Enabled: true
+RunAsUser: security-bot@example.com
+Schedule:
+  CronExpression: "0 9 * * 1"
+  TimeoutMinutes: 10

--- a/tests/fixtures/scheduled_prompts/example_prompt.yml
+++ b/tests/fixtures/scheduled_prompts/example_prompt.yml
@@ -1,0 +1,12 @@
+AnalysisType: scheduled_prompt
+PromptName: example_test_prompt
+DisplayName: Example Test Prompt
+Description: A test scheduled prompt for unit testing
+PromptText: |
+  Summarize notable IAM changes from the last week and flag any new admin users.
+OutputLength: medium
+Enabled: true
+RunAsUser: security-bot@example.com
+Schedule:
+  CronExpression: "0 9 * * 1"
+  TimeoutMinutes: 10

--- a/tests/unit/panther_analysis_tool/backend/test_graphql_queries.py
+++ b/tests/unit/panther_analysis_tool/backend/test_graphql_queries.py
@@ -1,0 +1,50 @@
+"""Tests asserting that the GraphQL query files request the fields we expect.
+
+A regression where a field is dropped from a `.graphql` file is otherwise silent —
+GraphQL responses simply omit unrequested fields, and the response parsers default
+the missing values to zero. These tests guard against that class of bug for the
+bulk-upload mutation and async-upload status query selection sets.
+"""
+
+import unittest
+
+from panther_analysis_tool.backend.public_api_client import (
+    _get_graphql_content_filepath,
+)
+
+# Every per-entity-type stat field the upload response parsers read. Adding a new
+# category to to_bulk_upload_response without selecting it here would silently zero
+# its counts in the upload summary.
+_KNOWN_CATEGORIES = (
+    "dataModels",
+    "globalHelpers",
+    "lookupTables",
+    "policies",
+    "rules",
+    "queries",
+    "correlationRules",
+    "scheduledPrompts",
+)
+
+
+def _read_graphql(name: str) -> str:
+    with open(_get_graphql_content_filepath(name), encoding="utf-8") as f:
+        return f.read()
+
+
+class TestBulkUploadGraphQLQueries(unittest.TestCase):
+    def test_bulk_upload_requests_scheduled_prompts_field(self) -> None:
+        self.assertIn("scheduledPrompts {", _read_graphql("bulk_upload"))
+
+    def test_async_bulk_upload_status_requests_scheduled_prompts_field(self) -> None:
+        self.assertIn("scheduledPrompts {", _read_graphql("async_bulk_upload_status"))
+
+    def test_bulk_upload_requests_all_known_categories(self) -> None:
+        contents = _read_graphql("bulk_upload")
+        for field in _KNOWN_CATEGORIES:
+            self.assertIn(f"{field} {{", contents, msg=f"missing {field} selection")
+
+    def test_async_bulk_upload_status_requests_all_known_categories(self) -> None:
+        contents = _read_graphql("async_bulk_upload_status")
+        for field in _KNOWN_CATEGORIES:
+            self.assertIn(f"{field} {{", contents, msg=f"missing {field} selection")

--- a/tests/unit/panther_analysis_tool/backend/test_lambda_client.py
+++ b/tests/unit/panther_analysis_tool/backend/test_lambda_client.py
@@ -61,6 +61,7 @@ class TestLambdaClient(TestCase):
                 "lookup_tables": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
                 "global_helpers": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
                 "correlation_rules": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
+                "scheduled_prompts": {"total": 0, "new": 0, "modified": 0, "deleted": 0},
             },
         )
 

--- a/tests/unit/panther_analysis_tool/core/test_definitions.py
+++ b/tests/unit/panther_analysis_tool/core/test_definitions.py
@@ -21,6 +21,7 @@ from panther_analysis_tool.core.definitions import analysis_id_field_name
         (AnalysisTypes.SAVED_QUERY, "QueryName"),
         (AnalysisTypes.PACK, "PackID"),
         (AnalysisTypes.LOOKUP_TABLE, "LookupName"),
+        (AnalysisTypes.SCHEDULED_PROMPT, "PromptName"),
     ],
 )
 def test_analysis_id_field_name(analysis_type: str, expected_field: str) -> None:

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -4,6 +4,7 @@ import logging
 import os
 import shutil
 import zipfile
+from contextlib import redirect_stdout
 from datetime import datetime, timedelta
 from typing import Any
 from unittest import mock
@@ -719,17 +720,13 @@ class TestPantherAnalysisTool(TestCase):
         self.assertEqual(len(invalid_specs), 0)
 
     def test_print_upload_summary_includes_scheduled_prompts(self) -> None:
-        from contextlib import redirect_stdout
-
-        from panther_analysis_tool.main import print_upload_summary
-
         response = {
             "rules": {"total": 0, "new": 0, "modified": 0},
             "scheduled_prompts": {"total": 5, "new": 3, "modified": 2},
         }
         buf = io.StringIO()
         with redirect_stdout(buf):
-            print_upload_summary(response)
+            pat.print_upload_summary(response)
 
         output = buf.getvalue()
         self.assertIn("Scheduled Prompts", output)
@@ -738,16 +735,12 @@ class TestPantherAnalysisTool(TestCase):
         self.assertIn("Modified: 2", output)
 
     def test_print_upload_summary_omits_scheduled_prompts_when_zero(self) -> None:
-        from contextlib import redirect_stdout
-
-        from panther_analysis_tool.main import print_upload_summary
-
         # All zeros — the Scheduled Prompts section should be suppressed (matches
         # behavior for other categories), but the summary header should still print.
         response = {"scheduled_prompts": {"total": 0, "new": 0, "modified": 0}}
         buf = io.StringIO()
         with redirect_stdout(buf):
-            print_upload_summary(response)
+            pat.print_upload_summary(response)
 
         output = buf.getvalue()
         self.assertIn("Upload Summary", output)

--- a/tests/unit/panther_analysis_tool/test_main.py
+++ b/tests/unit/panther_analysis_tool/test_main.py
@@ -44,6 +44,7 @@ from panther_analysis_tool.main import app, upload_analysis
 FIXTURES_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../", "fixtures"))
 DETECTIONS_FIXTURES_PATH = os.path.join(FIXTURES_PATH, "detections")
 STATUS_FIXTURES_PATH = os.path.join(FIXTURES_PATH, "status")
+SCHEDULED_PROMPTS_FIXTURES_PATH = os.path.join(FIXTURES_PATH, "scheduled_prompts")
 
 print("Using fixtures path:", FIXTURES_PATH)
 
@@ -693,7 +694,64 @@ class TestPantherAnalysisTool(TestCase):
             self.assertTrue(statinfo.st_size > 0)
             self.assertTrue(out_filename.endswith(".zip"))
 
-        self.assertEqual(7, len(results))
+        self.assertEqual(8, len(results))
+
+        # Verify the SCHEDULED_PROMPT chunk actually contains the prompt YAML —
+        # guards against scheduled prompts being silently dropped from the upload.
+        all_zipped_files: list[str] = []
+        for out_filename in results:
+            with zipfile.ZipFile(out_filename, "r") as zf:
+                all_zipped_files.extend(zf.namelist())
+        prompt_files = [name for name in all_zipped_files if "scheduled_prompts/" in name]
+        self.assertEqual(
+            1, len(prompt_files), msg=f"expected 1 scheduled prompt in zips, got {prompt_files}"
+        )
+        self.assertTrue(prompt_files[0].endswith("example_prompt.yml"))
+
+    def test_pat_test_with_scheduled_prompts_only(self) -> None:
+        # Scheduled prompts aren't testable detections, but `pat test` against a
+        # directory of only prompts should succeed cleanly — not error or report
+        # invalid specs (same behavior as scheduled_query / lookup_table).
+        return_code, invalid_specs = mock_test_analysis(
+            self, ["test", "--path", SCHEDULED_PROMPTS_FIXTURES_PATH]
+        )
+        self.assertEqual(return_code, 0)
+        self.assertEqual(len(invalid_specs), 0)
+
+    def test_print_upload_summary_includes_scheduled_prompts(self) -> None:
+        from contextlib import redirect_stdout
+
+        from panther_analysis_tool.main import print_upload_summary
+
+        response = {
+            "rules": {"total": 0, "new": 0, "modified": 0},
+            "scheduled_prompts": {"total": 5, "new": 3, "modified": 2},
+        }
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_upload_summary(response)
+
+        output = buf.getvalue()
+        self.assertIn("Scheduled Prompts", output)
+        self.assertIn("Total: 5", output)
+        self.assertIn("New: 3", output)
+        self.assertIn("Modified: 2", output)
+
+    def test_print_upload_summary_omits_scheduled_prompts_when_zero(self) -> None:
+        from contextlib import redirect_stdout
+
+        from panther_analysis_tool.main import print_upload_summary
+
+        # All zeros — the Scheduled Prompts section should be suppressed (matches
+        # behavior for other categories), but the summary header should still print.
+        response = {"scheduled_prompts": {"total": 0, "new": 0, "modified": 0}}
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            print_upload_summary(response)
+
+        output = buf.getvalue()
+        self.assertIn("Upload Summary", output)
+        self.assertNotIn("Scheduled Prompts", output)
 
     def test_generate_release_assets(self) -> None:
         # Note: This is a workaround for CI
@@ -770,6 +828,7 @@ class TestPantherAnalysisTool(TestCase):
                     lookup_tables=stats,
                     global_helpers=stats,
                     correlation_rules=stats,
+                    scheduled_prompts=stats,
                 ),
                 status_code=200,
             )
@@ -803,6 +862,7 @@ class TestPantherAnalysisTool(TestCase):
                     lookup_tables=stats,
                     global_helpers=stats,
                     correlation_rules=stats,
+                    scheduled_prompts=stats,
                 ),
                 status_code=200,
             )

--- a/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
+++ b/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
@@ -1,0 +1,119 @@
+"""Unit tests for the scheduled_prompt analysis type: schema validation + display label.
+
+Schema coverage focuses on the as-code contract divergences from other types:
+- RunAsUser is REQUIRED (execution identity; never the importer/token).
+- DisplayName is REQUIRED (no fallback, unlike skills).
+- `Private` is NOT a valid field (prompts managed as code are org-shared/public);
+  ignore_extra_keys=False rejects it.
+"""
+
+import unittest
+from typing import Any, Dict
+
+from schema import SchemaError
+
+from panther_analysis_tool.analysis_utils import pretty_analysis_type
+from panther_analysis_tool.schemas import SCHEDULED_PROMPT_SCHEMA
+
+
+def _valid_prompt() -> Dict[str, Any]:
+    return {
+        "AnalysisType": "scheduled_prompt",
+        "PromptName": "weekly_iam_review",
+        "DisplayName": "Weekly IAM Review",
+        "PromptText": "Summarize new IAM users created this week.",
+        "RunAsUser": "alice@example.com",
+        "Schedule": {"CronExpression": "0 9 * * 1", "TimeoutMinutes": 10},
+    }
+
+
+class TestScheduledPromptSchema(unittest.TestCase):
+    def test_valid_minimal(self) -> None:
+        SCHEDULED_PROMPT_SCHEMA.validate(_valid_prompt())
+
+    def test_valid_all_optional_fields(self) -> None:
+        prompt = _valid_prompt()
+        prompt.update(
+            {
+                "Description": "A scheduled prompt for unit testing",
+                "OutputLength": "largest",
+                "Enabled": True,
+            }
+        )
+        SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_valid_rate_schedule(self) -> None:
+        prompt = _valid_prompt()
+        prompt["Schedule"] = {"RateMinutes": 60, "TimeoutMinutes": 10}
+        SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    # --- contract: RunAsUser is required and email-shaped ---
+    def test_missing_run_as_user_rejected(self) -> None:
+        prompt = _valid_prompt()
+        del prompt["RunAsUser"]
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_run_as_user_must_be_email(self) -> None:
+        prompt = _valid_prompt()
+        prompt["RunAsUser"] = "not-an-email"
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    # --- contract: as-code is public; `Private` is not a valid field ---
+    def test_private_field_rejected(self) -> None:
+        prompt = _valid_prompt()
+        prompt["Private"] = True
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    # --- contract: DisplayName required (no fallback, unlike skills) ---
+    def test_missing_display_name_rejected(self) -> None:
+        prompt = _valid_prompt()
+        del prompt["DisplayName"]
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_missing_prompt_text_rejected(self) -> None:
+        prompt = _valid_prompt()
+        del prompt["PromptText"]
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_invalid_prompt_name_uppercase_rejected(self) -> None:
+        prompt = _valid_prompt()
+        prompt["PromptName"] = "BadName"
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_invalid_output_length_rejected(self) -> None:
+        prompt = _valid_prompt()
+        prompt["OutputLength"] = "huge"
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_schedule_requires_exactly_one_of_cron_or_rate(self) -> None:
+        prompt = _valid_prompt()
+        prompt["Schedule"] = {
+            "CronExpression": "0 9 * * 1",
+            "RateMinutes": 60,
+            "TimeoutMinutes": 10,
+        }
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_unknown_field_rejected(self) -> None:
+        prompt = _valid_prompt()
+        prompt["Bogus"] = "x"
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+
+class TestPrettyAnalysisTypeScheduledPrompt(unittest.TestCase):
+    def test_singular(self) -> None:
+        self.assertEqual(pretty_analysis_type("scheduled_prompt"), "Scheduled Prompt")
+
+    def test_plural(self) -> None:
+        self.assertEqual(
+            pretty_analysis_type("scheduled_prompt", plural=True), "Scheduled Prompts"
+        )

--- a/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
+++ b/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
@@ -13,7 +13,12 @@ from typing import Any, Dict
 from schema import SchemaError
 
 from panther_analysis_tool.analysis_utils import pretty_analysis_type
+from panther_analysis_tool.core.definitions import (
+    ClassifiedAnalysis,
+    ClassifiedAnalysisContainer,
+)
 from panther_analysis_tool.schemas import SCHEDULED_PROMPT_SCHEMA
+from panther_analysis_tool.validation import validate_packs
 
 
 def _valid_prompt() -> Dict[str, Any]:
@@ -129,3 +134,56 @@ class TestPrettyAnalysisTypeScheduledPrompt(unittest.TestCase):
         self.assertEqual(
             pretty_analysis_type("scheduled_prompt", plural=True), "Scheduled Prompts"
         )
+
+
+class TestValidatePacksWithScheduledPrompt(unittest.TestCase):
+    """validate_packs iterates ALL classified specs, including scheduled prompts, which
+    carry only a PromptName (none of the other ID fields). The ID-lookup chain must use
+    PromptName and never fall back to a bare subscript — otherwise a prompt alongside a
+    pack raises KeyError and crashes every test/validate run that includes one."""
+
+    @staticmethod
+    def _prompt(name: str) -> ClassifiedAnalysis:
+        return ClassifiedAnalysis(
+            f"{name}.yml", ".", {"AnalysisType": "scheduled_prompt", "PromptName": name}
+        )
+
+    def test_prompt_only_container_does_not_crash(self) -> None:
+        container = ClassifiedAnalysisContainer()
+        container.scheduled_prompts.append(self._prompt("weekly_iam_review"))
+        self.assertEqual(validate_packs(container), [])  # no KeyError, no invalid packs
+
+    def test_prompt_is_indexed_by_prompt_name_for_pack_membership(self) -> None:
+        container = ClassifiedAnalysisContainer()
+        container.scheduled_prompts.append(self._prompt("weekly_iam_review"))
+        container.packs.append(
+            ClassifiedAnalysis(
+                "pack.yml",
+                ".",
+                {
+                    "AnalysisType": "pack",
+                    "PackID": "iam_pack",
+                    "PackDefinition": {"IDs": ["weekly_iam_review"]},
+                },
+            )
+        )
+        # The prompt resolves by PromptName, so the pack reference is valid.
+        self.assertEqual(validate_packs(container), [])
+
+    def test_pack_referencing_missing_prompt_is_reported(self) -> None:
+        container = ClassifiedAnalysisContainer()
+        container.scheduled_prompts.append(self._prompt("weekly_iam_review"))
+        container.packs.append(
+            ClassifiedAnalysis(
+                "pack.yml",
+                ".",
+                {
+                    "AnalysisType": "pack",
+                    "PackID": "iam_pack",
+                    "PackDefinition": {"IDs": ["nonexistent_prompt"]},
+                },
+            )
+        )
+        invalid = validate_packs(container)
+        self.assertEqual(len(invalid), 1)
+        self.assertIn("nonexistent_prompt", invalid[0][1])

--- a/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
+++ b/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
@@ -1,10 +1,10 @@
 """Unit tests for the scheduled_prompt analysis type: schema validation + display label.
 
 Schema coverage focuses on the as-code contract divergences from other types:
-- RunAsUser is REQUIRED (execution identity; never the importer/token).
+- RunAsUser is REQUIRED and polymorphic (a user email OR an API-token id); format is
+  resolved server-side, so locally only non-empty is enforced.
 - DisplayName is REQUIRED (no fallback, unlike skills).
-- `Private` is NOT a valid field (prompts managed as code are org-shared/public);
-  ignore_extra_keys=False rejects it.
+- Bulk upload is shared-only: `Private: false`/omitted is accepted; `Private: true` rejected.
 """
 
 import unittest
@@ -47,25 +47,37 @@ class TestScheduledPromptSchema(unittest.TestCase):
         prompt["Schedule"] = {"RateMinutes": 60, "TimeoutMinutes": 10}
         SCHEDULED_PROMPT_SCHEMA.validate(prompt)
 
-    # --- contract: RunAsUser is required and email-shaped ---
+    # --- contract: RunAsUser is required; polymorphic (a user email OR a po_ token id) ---
     def test_missing_run_as_user_rejected(self) -> None:
         prompt = _valid_prompt()
         del prompt["RunAsUser"]
         with self.assertRaises(SchemaError):
             SCHEDULED_PROMPT_SCHEMA.validate(prompt)
 
-    def test_run_as_user_must_be_email(self) -> None:
+    def test_empty_run_as_user_rejected(self) -> None:
         prompt = _valid_prompt()
-        prompt["RunAsUser"] = "not-an-email"
+        prompt["RunAsUser"] = ""
         with self.assertRaises(SchemaError):
             SCHEDULED_PROMPT_SCHEMA.validate(prompt)
 
-    # --- contract: as-code is public; `Private` is not a valid field ---
-    def test_private_field_rejected(self) -> None:
+    def test_run_as_user_accepts_api_token_id(self) -> None:
+        # The backend accepts a po_ API-token id as the run-as identity; a strict email
+        # regex would wrongly reject it. Format/existence is validated server-side.
+        prompt = _valid_prompt()
+        prompt["RunAsUser"] = "po_abc123def456"
+        SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    # --- contract: shared-only — Private:false/omitted accepted, Private:true rejected ---
+    def test_private_true_rejected(self) -> None:
         prompt = _valid_prompt()
         prompt["Private"] = True
         with self.assertRaises(SchemaError):
             SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
+    def test_private_false_accepted(self) -> None:
+        prompt = _valid_prompt()
+        prompt["Private"] = False
+        SCHEDULED_PROMPT_SCHEMA.validate(prompt)
 
     # --- contract: DisplayName required (no fallback, unlike skills) ---
     def test_missing_display_name_rejected(self) -> None:

--- a/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
+++ b/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
@@ -103,6 +103,13 @@ class TestScheduledPromptSchema(unittest.TestCase):
         with self.assertRaises(SchemaError):
             SCHEDULED_PROMPT_SCHEMA.validate(prompt)
 
+    def test_prompt_name_trailing_newline_rejected(self) -> None:
+        # Guards the \Z anchor: $ would match before a trailing newline and let this through.
+        prompt = _valid_prompt()
+        prompt["PromptName"] = "weekly_iam_review\n"
+        with self.assertRaises(SchemaError):
+            SCHEDULED_PROMPT_SCHEMA.validate(prompt)
+
     def test_invalid_output_length_rejected(self) -> None:
         prompt = _valid_prompt()
         prompt["OutputLength"] = "huge"

--- a/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
+++ b/tests/unit/panther_analysis_tool/test_scheduled_prompts.py
@@ -131,9 +131,7 @@ class TestPrettyAnalysisTypeScheduledPrompt(unittest.TestCase):
         self.assertEqual(pretty_analysis_type("scheduled_prompt"), "Scheduled Prompt")
 
     def test_plural(self) -> None:
-        self.assertEqual(
-            pretty_analysis_type("scheduled_prompt", plural=True), "Scheduled Prompts"
-        )
+        self.assertEqual(pretty_analysis_type("scheduled_prompt", plural=True), "Scheduled Prompts")
 
 
 class TestValidatePacksWithScheduledPrompt(unittest.TestCase):


### PR DESCRIPTION
## What this adds

Panther AI **scheduled prompts** run on a schedule as a chosen user or API token — today they can only be authored in the Console. This PR teaches the analysis tool to treat a `scheduled_prompt` YAML like any other analysis item, so prompts can be **validated, packaged, and bulk-uploaded through CI/CD** the same way rules and queries already are.

The server side ships in three PRs (links are informational — `panther-enterprise` is private; this PR is self-contained and reviewable from the diff alone):

- **1/3** — https://github.com/panther-labs/panther-enterprise/pull/29629: the `ViewScheduledPrompts` / `ManageScheduledPrompts` permissions.
- **2/3** — https://github.com/panther-labs/panther-enterprise/pull/29634: the YAML model, store, and upsert client.
- **3/3** — https://github.com/panther-labs/panther-enterprise/pull/29754: the bulk upload/download pipeline and Console UI — the endpoints this PR calls.

## YAML shape

```yaml
AnalysisType: scheduled_prompt
PromptName: weekly_iam_review          # unique id; must start with a lowercase letter, then lowercase letters / digits / underscores
DisplayName: Weekly IAM Review
PromptText: Summarize new IAM users created this week.
RunAsUser: alice@example.com           # required; a user email OR a Panther API-token id (begins with po_)
Schedule:                              # exactly one of CronExpression / RateMinutes
  CronExpression: "0 9 * * 1"
  TimeoutMinutes: 10
# optional: Description, OutputLength (small|medium|largest), Enabled, Private (false only — true is rejected)
```

## Changes

- **`schemas.py`** — `SCHEDULED_PROMPT_SCHEMA`, with strict key checking (typos are rejected, not silently ignored).
- **Core wiring** (`constants.py`, `core/definitions.py`, `analysis_utils.py`, `util.py`) — the new analysis type, a `*scheduled_prompts*` path glob for discovery, `PromptName` as the identifier, and classification + display-name support.
- **`validation.py`** — `validate_packs` now derives each item's id via `item.analysis_id()` instead of a hardcoded field chain that ended in a bare `LookupName` subscript — which would `KeyError` on any type without that field (including `scheduled_prompt`).
- **`main.py`** — prompts get their own upload chunk and a `Scheduled Prompts` row in the upload summary.
- **`backend/client.py` + the two bulk-upload `.graphql` files** — the `.graphql` files add `scheduledPrompts` to the upload mutation and status query; `client.py` parses the counts. Without the field the server omits it and the counts silently read as zero, so a dedicated test (`test_graphql_queries.py`) guards its presence.
- **`analysis_config_schema.json`** — adds `scheduled_prompt` to the `AnalysisType` enum, so it's recognized in config-file validation (used by `pat test` and pack validation).
- Fixtures and unit tests.

## Validation contract

- **`RunAsUser` is required and polymorphic** — a user email or a `po_` token id. The client only checks it is non-empty; existence, liveness, and the `RunPantherAI` permission are validated server-side and surfaced by `pat validate`.
- **`Private` is shared-only** — `true` is rejected (not silently ignored); prompts are made private only via the Console.
- Numeric bounds are server-authoritative — the `RateMinutes ≥ 5` floor, the `TimeoutMinutes` 1–15 range, and text-length limits are enforced server-side and surfaced by `pat validate`. (The client applies only the generic schedule checks it shares with saved queries — `RateMinutes > 1`, `RateMinutes ≥ TimeoutMinutes` — so e.g. `RateMinutes: 3` passes locally but is rejected on upload.)

## Not in scope: deletion

There is no `pat delete` for scheduled prompts — matching **AI Skills** (#785), which also ships upload/validate-only. Both lack a public delete mutation today; a delete path can be added for prompts and skills together once one exists. To take a prompt out of rotation as-code, set `Enabled: false` and re-upload; hard-delete is via the Console.

## Auth: token only

Uploading scheduled prompts requires **API-token auth** (`--api-token` + `--api-host`). **Legacy AWS-profile auth** (no token; direct `panther-analysis-api` Lambda invoke via `--aws-profile` / the boto3 default chain) is rejected per file with `system user cannot import scheduled prompts` — that path carries no user/token actor, and a prompt must have a real owner. Detections still upload under legacy auth; prompts are the exception. (`pat validate` is token-only regardless.)

## Testing

Unit tests cover the schema contract (required/optional fields, `RunAsUser` polymorphism, `Private` rejection), packaging, classification, the upload summary, the GraphQL-field guard, and a `validate_packs` regression (a prompt next to a pack must not crash ID resolution). Verified live against a dev tenant: `pat validate` + `pat upload` + idempotent re-import, with run-as accepted for a permitted user/token and rejected for one lacking `RunPantherAI` or no longer active.

```bash
make install && make test
# local, no instance (schema-validates the fixture; prompts aren't executable, so the test runner doesn't run them):
pat test     --path tests/fixtures/scheduled_prompts
# validate — no writes; token needs BulkUploadValidate (or BulkUpload) + ManageScheduledPrompts:
pat validate --path tests/fixtures/scheduled_prompts --api-host "$HOST" --api-token "$TOK"
# upload — token needs BulkUpload + ManageScheduledPrompts (+ AIRunAsModify only when RunAsUser is a different identity than the token):
pat upload   --path tests/fixtures/scheduled_prompts --api-host "$HOST" --api-token "$TOK"
```
