### PR TITLE
Scope business-platform ownership to .github folder

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,7 @@
 
 # These owners will be the default owners for everything in the repo.
 
-*       @panther-labs/detection-threat-hunting-experience @panther-labs/business-platform
+*       @panther-labs/detection-threat-hunting-experience
+
+# business-platform co-owns the .github repo to approve dependabot PRs for the auto triaging job
+/.github/       @panther-labs/detection-threat-hunting-experience @panther-labs/business-platform


### PR DESCRIPTION
`@panther-labs/business-platform` currently co-owns the entire repo via the default `*` rule. This scopes it to co-owning `/.github/` only, leaving `@panther-labs/detection-threat-hunting-experience` as the sole default owner elsewhere. Business Platform only needs to own the `/.github/` for the dependabot PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)