### PR TITLE
Don't retry unknown errors + add isaac to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,5 +70,6 @@ coverage.xml
 .panther_settings.yml
 panther-analysis/
 .claude/settings.local.json
+.isaac/config.json
 
 .cache/

--- a/panther_analysis_tool/backend/errors.py
+++ b/panther_analysis_tool/backend/errors.py
@@ -19,7 +19,6 @@ def is_retryable_error_str(err: str) -> bool:
     return (
         UPLOAD_IN_PROGRESS_SUBSTR in err
         or err == "upload failed"
-        or "unknown error occurred" in err
         or "ddb lock" in err
         or "pload does not exist" in err
     )

--- a/tests/unit/panther_analysis_tool/backend/test_errors.py
+++ b/tests/unit/panther_analysis_tool/backend/test_errors.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+from panther_analysis_tool.backend.errors import (
+    is_retryable_error,
+    is_retryable_error_str,
+)
+
+
+class TestIsRetryableErrorStr(TestCase):
+    def test_empty_is_not_retryable(self) -> None:
+        self.assertFalse(is_retryable_error_str(""))
+
+    def test_transient_conditions_are_retryable(self) -> None:
+        # Genuinely transient bulk-upload conditions must stay retryable.
+        for err in (
+            "another upload is in process",
+            "upload failed",
+            "ddb lock could not be acquired",
+            "upload does not exist",
+        ):
+            with self.subTest(err=err):
+                self.assertTrue(is_retryable_error_str(err))
+
+    def test_generic_bulk_upload_timeout_is_not_retryable(self) -> None:
+        # Volume-driven server-side timeout catch-all: deterministic, retrying cannot help.
+        # See EPD-6524.
+        self.assertFalse(
+            is_retryable_error_str("unknown error occurred during bulk upload process")
+        )
+        self.assertFalse(is_retryable_error_str("unknown error occurred"))
+
+
+class TestIsRetryableError(TestCase):
+    def test_none_is_not_retryable(self) -> None:
+        self.assertFalse(is_retryable_error(None))
+
+    def test_matches_message_and_body(self) -> None:
+        self.assertTrue(is_retryable_error({"message": "another upload is in process"}))
+        self.assertTrue(is_retryable_error({"body": "ddb lock could not be acquired"}))
+
+    def test_generic_bulk_upload_timeout_is_not_retryable(self) -> None:
+        self.assertFalse(
+            is_retryable_error(
+                {"message": "unknown error occurred during bulk upload process"}
+            )
+        )

--- a/tests/unit/panther_analysis_tool/backend/test_errors.py
+++ b/tests/unit/panther_analysis_tool/backend/test_errors.py
@@ -40,7 +40,5 @@ class TestIsRetryableError(TestCase):
 
     def test_generic_bulk_upload_timeout_is_not_retryable(self) -> None:
         self.assertFalse(
-            is_retryable_error(
-                {"message": "unknown error occurred during bulk upload process"}
-            )
+            is_retryable_error({"message": "unknown error occurred during bulk upload process"})
         )


### PR DESCRIPTION
### Background
Many customers fleetwide are running into occasional issues with bulk upload. Investigation showed that some shouldn't be retried and that the retries are just putting strain on the system and delaying the failure message reaching customers.

NOTE: I'm not sure why this error message was originally considered retryable, so this change may cause some retryable errors to stop being retried. We'll be relying on the scream test to detect that.

### Changes

* Remove `"unknown error occurred"` from the list of retryable errors for upload
* Add .isaac/config.json to .gitignore

### Testing

* Added unit tests
